### PR TITLE
Fix failure route for Heroku deployment

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   get '/login',  to: 'sessions#new',     as: 'login'
   get '/logout', to: 'sessions#destroy', as: 'logout'
 
+  get   '/auth/failure',            to: 'sessions#failure'
   match '/auth/:provider/callback', to: 'sessions#create',  via: [:get, :post]
-  match '/auth/failure',            to: 'sessions#failure', via: [:get, :post]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   get '/login',  to: 'sessions#new',     as: 'login'
   get '/logout', to: 'sessions#destroy', as: 'logout'
 
-  match '/auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
-  post  '/auth/failure',            to: 'sessions#failure'
+  match '/auth/:provider/callback', to: 'sessions#create',  via: [:get, :post]
+  match '/auth/failure',            to: 'sessions#failure', via: [:get, :post]
 end


### PR DESCRIPTION
I usually test my apps incrementally to make sure everything works on a production environment, this fixes the return of a failure during GitHub authentication.

@johndbritton for the GitHub authentication failures, do I actually need a POST route? Or can I get away with just GET?