### PR TITLE
Redirect to dashboard is the user is logged in

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
   def home
+    redirect_to dashboard_path if logged_in?
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -6,9 +6,15 @@ class PagesControllerTest < ActionController::TestCase
   end
 
   describe '#home' do
-    test 'returns success' do
+    it 'returns success' do
       get :home
       assert_response :success
+    end
+
+    it 'redirects to the dashboard_path if a user is logged in' do
+      session[:user_id] = users(:tobias).id
+      get :home
+      assert_redirected_to dashboard_path
     end
   end
 end


### PR DESCRIPTION
It's just been bugging me, if the user is authenticated go ahead and take them to their dashboard.

I'm leaving the static page for now because I'm assuming we'll want a splash page of some kind later down the road.