### PR TITLE
Add `test` to the script folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ before_script:
   - psql -c 'create database classroom_test;' -U postgres
 
 script:
-  - bundle exec rubocop
-  - bundle exec scss-lint
   - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec rspec
+  - ./script/test
 
 bundler_args: --without development production --deployment --jobs=3 --retry=3

--- a/script/test
+++ b/script/test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+echo "===> Running rubocop..."
+bundle exec rubocop
+
+echo "===> Running scss-lint..."
+bundle exec scss-lint
+
+echo "===> Running specs..."
+bundle exec rspec


### PR DESCRIPTION
To run all of the tests and the linters, you can now run `script/test`. This is also set for the Travis CI configuration in the `.travis.yml` file.

I kept forgetting to run these tests, so I thought it would be nice to have them in one script. And then if I ever update how the tests are run, it will automatically updates on Travis