### PR TITLE
Caching Octokit Responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'autoprefixer-rails'
 
 gem 'coffee-rails', '~> 4.1.0'
 
+gem 'faraday-http-cache'
+
 gem 'jbuilder'
 
 gem 'octokit'
@@ -40,6 +42,7 @@ group :development, :test do
 end
 
 group :production do
+  gem 'dalli'
   gem 'rails_12factor'
   gem 'puma'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    dalli (2.7.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
@@ -84,6 +85,8 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.1.1)
+      faraday (~> 0.8)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     hashie (3.4.2)
@@ -252,10 +255,12 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   coffee-rails (~> 4.1.0)
+  dalli
   database_cleaner
   dotenv-rails
   factory_girl_rails
   faker
+  faraday-http-cache
   jbuilder
   octokit
   omniauth

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,13 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(','), { username: ENV["MEMCACHEDCLOUD_USERNAME"],
+                                                                                     password: ENV["MEMCACHEDCLOUD_PASSWORD"],
+                                                                                     namespace: 'CLASSROOM',
+                                                                                     expires_in: (ENV["REQUEST_CACHE_TIMEOUT"] || 30).to_i.minutes,
+                                                                                     compress: true,
+                                                                                     pool_size: 5 }
+
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,6 @@
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, store: Rails.cache, logger: Rails.logger
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack


### PR DESCRIPTION
From the Octokit README

> Once configured, the middleware will store responses in cache based on ETag fingerprint and serve those back up for future 304 responses for the same resource. See the [project README](https://github.com/plataformatec/faraday-http-cache) for advanced usage.