### PR TITLE
Add Google analytics to production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ end
 
 group :production do
   gem 'dalli'
+  gem 'rack-tracker'
   gem 'rails_12factor'
   gem 'puma'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-tracker (1.0.0)
+      activesupport (>= 3.0)
+      rack (>= 1.4)
+      tilt (>= 1.4)
     rails (4.2.3)
       actionmailer (= 4.2.3)
       actionpack (= 4.2.3)
@@ -307,6 +311,7 @@ DEPENDENCIES
   pry-rails
   puma
   quiet_assets
+  rack-tracker
   rails (= 4.2.3)
   rails_12factor
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,8 @@ Rails.application.configure do
   }
 
   ActionMailer::Base.delivery_method = :smtp
+
+  config.middleware.use(Rack::Tracker) do
+    handler :google_analytics, { tracker: ENV['GOOGLE_ANALYTICS_TRACKING_ID'] }
+  end
 end


### PR DESCRIPTION
This uses the [rack-analytics](https://github.com/railslove/rack-tracker) gem to track what's going in Classroom. Just fill in the tracking code as the `GOOGLE_ANALYTICS_TRACKING_ID` on Heroku and you're all set!