### PR TITLE
Soft Delete Models

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,4 +1,6 @@
 class Assignment < ActiveRecord::Base
+  default_scope { where(deleted_at: nil) }
+
   has_one :assignment_invitation, dependent: :destroy
 
   has_many :assignment_repos, dependent: :destroy

--- a/app/models/assignment_invitation.rb
+++ b/app/models/assignment_invitation.rb
@@ -1,4 +1,6 @@
 class AssignmentInvitation < ActiveRecord::Base
+  default_scope { where(deleted_at: nil) }
+
   has_one :organization, through: :assignment
 
   belongs_to :assignment

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -1,4 +1,6 @@
 class GroupAssignment < ActiveRecord::Base
+  default_scope { where(deleted_at: nil) }
+
   has_one :group_assignment_invitation, dependent: :destroy
 
   has_many :group_assignment_repos, dependent: :destroy

--- a/app/models/group_assignment_invitation.rb
+++ b/app/models/group_assignment_invitation.rb
@@ -1,4 +1,6 @@
 class GroupAssignmentInvitation < ActiveRecord::Base
+  default_scope { where(deleted_at: nil) }
+
   has_one :grouping,     through: :group_assignment
   has_one :organization, through: :group_assignment
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,6 @@
 class Organization < ActiveRecord::Base
+  default_scope { where(deleted_at: nil) }
+
   has_many :assignments,       dependent: :destroy
   has_many :groupings,         dependent: :destroy
   has_many :group_assignments, dependent: :destroy

--- a/db/migrate/20150806032053_soft_delete.rb
+++ b/db/migrate/20150806032053_soft_delete.rb
@@ -1,0 +1,18 @@
+class SoftDelete < ActiveRecord::Migration
+  def change
+    add_column :organizations, :deleted_at, :datetime
+    add_index  :organizations, :deleted_at
+
+    add_column :assignments, :deleted_at, :datetime
+    add_index  :assignments, :deleted_at
+
+    add_column :assignment_invitations, :deleted_at, :datetime
+    add_index  :assignment_invitations, :deleted_at
+
+    add_column :group_assignments, :deleted_at, :datetime
+    add_index  :group_assignments, :deleted_at
+
+    add_column :group_assignment_invitations, :deleted_at, :datetime
+    add_index  :group_assignment_invitations, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729210740) do
+ActiveRecord::Schema.define(version: 20150806032053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,9 +21,11 @@ ActiveRecord::Schema.define(version: 20150729210740) do
     t.integer  "assignment_id"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.datetime "deleted_at"
   end
 
   add_index "assignment_invitations", ["assignment_id"], name: "index_assignment_invitations_on_assignment_id", using: :btree
+  add_index "assignment_invitations", ["deleted_at"], name: "index_assignment_invitations_on_deleted_at", using: :btree
   add_index "assignment_invitations", ["key"], name: "index_assignment_invitations_on_key", unique: true, using: :btree
 
   create_table "assignment_repos", force: :cascade do |t|
@@ -46,8 +48,10 @@ ActiveRecord::Schema.define(version: 20150729210740) do
     t.datetime "updated_at",                          null: false
     t.integer  "starter_code_repo_id"
     t.integer  "creator_id"
+    t.datetime "deleted_at"
   end
 
+  add_index "assignments", ["deleted_at"], name: "index_assignments_on_deleted_at", using: :btree
   add_index "assignments", ["organization_id"], name: "index_assignments_on_organization_id", using: :btree
 
   create_table "group_assignment_invitations", force: :cascade do |t|
@@ -55,8 +59,10 @@ ActiveRecord::Schema.define(version: 20150729210740) do
     t.integer  "group_assignment_id"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.datetime "deleted_at"
   end
 
+  add_index "group_assignment_invitations", ["deleted_at"], name: "index_group_assignment_invitations_on_deleted_at", using: :btree
   add_index "group_assignment_invitations", ["group_assignment_id"], name: "index_group_assignment_invitations_on_group_assignment_id", using: :btree
   add_index "group_assignment_invitations", ["key"], name: "index_group_assignment_invitations_on_key", unique: true, using: :btree
 
@@ -80,8 +86,10 @@ ActiveRecord::Schema.define(version: 20150729210740) do
     t.datetime "updated_at",                          null: false
     t.integer  "starter_code_repo_id"
     t.integer  "creator_id"
+    t.datetime "deleted_at"
   end
 
+  add_index "group_assignments", ["deleted_at"], name: "index_group_assignments_on_deleted_at", using: :btree
   add_index "group_assignments", ["organization_id"], name: "index_group_assignments_on_organization_id", using: :btree
 
   create_table "groupings", force: :cascade do |t|
@@ -117,8 +125,10 @@ ActiveRecord::Schema.define(version: 20150729210740) do
     t.string   "title",      null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
   end
 
+  add_index "organizations", ["deleted_at"], name: "index_organizations_on_deleted_at", using: :btree
   add_index "organizations", ["github_id"], name: "index_organizations_on_github_id", unique: true, using: :btree
   add_index "organizations", ["title"], name: "index_organizations_on_title", unique: true, using: :btree
 

--- a/spec/models/assignment_invitation_spec.rb
+++ b/spec/models/assignment_invitation_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe AssignmentInvitation, type: :model do
 
   it { is_expected.to belong_to(:assignment) }
 
+  it_behaves_like 'a default scope where deleted_at is not present'
+
   describe 'validations and uniqueness' do
     subject { AssignmentInvitation.new }
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Assignment, type: :model do
   it { is_expected.to belong_to(:creator).class_name(User) }
   it { is_expected.to belong_to(:organization) }
 
+  it_behaves_like 'a default scope where deleted_at is not present'
+
   describe 'validation and uniqueness' do
     subject { Assignment.new }
 

--- a/spec/models/group_assignment_invitation_spec.rb
+++ b/spec/models/group_assignment_invitation_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
 
   it { is_expected.to belong_to(:group_assignment) }
 
+  it_behaves_like 'a default scope where deleted_at is not present'
+
   describe 'validations and uniqueness' do
     subject { GroupAssignmentInvitation.new }
 

--- a/spec/models/group_assignment_spec.rb
+++ b/spec/models/group_assignment_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe GroupAssignment, type: :model do
   it { is_expected.to belong_to(:creator) }
   it { is_expected.to belong_to :organization }
 
+  it_behaves_like 'a default scope where deleted_at is not present'
+
   describe 'validation and uniqueness' do
     subject { GroupAssignment.new }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Organization, type: :model do
 
   it { is_expected.to have_and_belong_to_many(:users) }
 
+  it_behaves_like 'a default scope where deleted_at is not present'
+
   describe 'validation and uniqueness' do
     subject { build(:organization) }
 

--- a/spec/support/shared_examples/default_scope_examples.rb
+++ b/spec/support/shared_examples/default_scope_examples.rb
@@ -1,0 +1,5 @@
+shared_examples_for 'a default scope where deleted_at is not present' do
+  it 'has the same SQL query' do
+    expect(described_class.all.to_sql).to eq described_class.unscoped.all.where(deleted_at: nil).to_sql
+  end
+end


### PR DESCRIPTION
This adds the `deleted_at` column to several models. This enables the user to delete something, and even if the process of it and it's resources are still being deleted the user won't be able to access it.