### PR TITLE
Stop users from removing each other

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,12 +9,10 @@ class Organization < ActiveRecord::Base
   has_many :group_assignments, dependent: :destroy
   has_many :repo_accesses,     dependent: :destroy
 
-  has_and_belongs_to_many :users
+  has_and_belongs_to_many :users, presence: true, before_remove: [:verify_not_assignment_creator, :verify_not_last_user]
 
   validates :github_id, presence: true, uniqueness: true
   validates :title,     presence: true, uniqueness: { case_sensitive: false }
-
-  after_save :validate_minimum_number_of_users
 
   # Public
   #
@@ -32,10 +30,20 @@ class Organization < ActiveRecord::Base
 
   # Internal
   #
-  def validate_minimum_number_of_users
-    return if users.count > 0
-    error_message = 'must have at least one user'
-    errors.add(:users, error_message)
-    fail ActiveRecord::RecordInvalid.new(self), error_message
+  def verify_not_last_user(_user)
+    return if users.where(state: 'active').count > 1
+    errors.add(:base, 'This organization must have at least one active user')
+    fail ActiveRecord::RecordInvalid.new(self), 'unable to remove user'
+  end
+
+  # Internal
+  #
+  def verify_not_assignment_creator(user)
+    users_assignments = assignments.where(creator: user) + group_assignments.where(creator: user)
+
+    return unless users_assignments.present?
+
+    errors.add(:user, 'is the creator of one or more assignments, and cannot be removed at this time')
+    fail ActiveRecord::RecordInvalid.new(self), 'unable to remove user'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
-  has_many :repo_accesses,    dependent: :destroy
-  has_many :assignment_repos, through: :repo_accesses
+  has_many :assignments,       foreign_key: :creator_id
+  has_many :group_assignments, foreign_key: :creator_id
+  has_many :assignment_repos,  through:     :repo_accesses
+  has_many :repo_accesses,     dependent:   :destroy
 
   has_and_belongs_to_many :organizations
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -21,15 +21,39 @@ RSpec.describe Organization, type: :model do
   end
 
   describe 'callbacks' do
-    describe 'after_save' do
-      describe '#validate_minimum_number_of_users' do
-        subject { create(:organization) }
+    describe 'assocation callbacks' do
+      describe 'before_remove' do
+        describe '#verify_not_last_user' do
+          subject { create(:organization) }
 
-        it 'validates that there is at least one user' do
-          subject.users.destroy_all
-          subject.save
+          it 'verifies that the last users is not being removed' do
+            begin
+              subject.users.destroy_all
+            rescue => e
+              expect(e.message).to eql('unable to remove user')
+              expect(subject.errors.count).to eql(1)
+              expect(subject.users.count).to eql(1)
+              expect(subject.errors.full_messages.first).to eql('This organization must have at least one active user')
+            end
+          end
+        end
 
-          expect(subject.errors.count).to be(1)
+        describe '#verify_not_assignment_creator' do
+          subject          { create(:organization)                                                                }
+          let(:assignment) { Assignment.create(title: 'Ruby', creator: subject.users.last, organization: subject) }
+
+          it 'verifies that the user being removed is not the creator of an assignment' do
+            begin
+              assignment # For some reason the object isn't actually created until called
+              error_message = 'User is the creator of one or more assignments, and cannot be removed at this time'
+              subject.users.destroy_all
+            rescue => e
+              expect(e.message).to eql('unable to remove user')
+              expect(subject.errors.count).to eql(1)
+              expect(subject.users.count).to eql(1)
+              expect(subject.errors.full_messages.first).to eql(error_message)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
For an organization, there are times when removing a user should not be
possible.

* When there is only one active user left
* When a user has created an assignment

Using the before_remove callback we can check for this and stop the
transaction if one of these things happen.

The front end for this will come in another PR.