### PR TITLE
Uniqueness of the Organization title should be case insensitive

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,7 +12,7 @@ class Organization < ActiveRecord::Base
   has_and_belongs_to_many :users
 
   validates :github_id, presence: true, uniqueness: true
-  validates :title,     presence: true, uniqueness: true
+  validates :title,     presence: true, uniqueness: { case_sensitive: false }
 
   after_save :validate_minimum_number_of_users
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Organization, type: :model do
     it { is_expected.to validate_presence_of(:github_id)   }
     it { is_expected.to validate_uniqueness_of(:github_id) }
 
-    it { is_expected.to validate_presence_of(:title)   }
-    it { is_expected.to validate_uniqueness_of(:title) }
+    it { is_expected.to validate_presence_of(:title)                    }
+    it { is_expected.to validate_uniqueness_of(:title).case_insensitive }
   end
 
   describe 'callbacks' do


### PR DESCRIPTION
If two organizations have the same title but with different cases, then we get weird slugs for their urls.