### PR TITLE
Allow GitHub Staff members to be staff on Classroom for GitHub

### DIFF
--- a/app/services/auth_hash.rb
+++ b/app/services/auth_hash.rb
@@ -36,7 +36,7 @@ class AuthHash
 
   def non_staff_github_admins_ids
     return [] unless ENV['NON_STAFF_GITHUB_ADMIN_IDS'].present?
-    ENV['NON_STAFF_GITHUB_ADMIN_IDS'].split(',')
+    ENV['NON_STAFF_GITHUB_ADMIN_IDS'].split(',').compact.delete_if(&:empty?)
   end
 
   def raw_info

--- a/app/services/auth_hash.rb
+++ b/app/services/auth_hash.rb
@@ -36,7 +36,7 @@ class AuthHash
 
   def non_staff_github_admins_ids
     return [] unless ENV['NON_STAFF_GITHUB_ADMIN_IDS'].present?
-    ENV['NON_STAFF_GITHUB_ADMINS_IDS'].split(',')
+    ENV['NON_STAFF_GITHUB_ADMIN_IDS'].split(',')
   end
 
   def raw_info

--- a/app/services/auth_hash.rb
+++ b/app/services/auth_hash.rb
@@ -9,8 +9,9 @@ class AuthHash
 
   def user_info
     {
-      uid:      uid,
-      token:    token
+      uid:        uid,
+      token:      token,
+      site_admin: site_admin
     }
   end
 
@@ -26,10 +27,16 @@ class AuthHash
     user_hash.fetch('credentials', {}).fetch('token')
   end
 
+  def site_admin
+    return true if non_staff_github_admins_ids.include?(uid)
+    raw_info[:site_admin]
+  end
+
   private
 
-  def info
-    user_hash.fetch('info', {})
+  def non_staff_github_admins_ids
+    return [] unless ENV['NON_STAFF_GITHUB_ADMIN_IDS'].present?
+    ENV['NON_STAFF_GITHUB_ADMINS_IDS'].split(',')
   end
 
   def raw_info

--- a/spec/services/auth_hash_spec.rb
+++ b/spec/services/auth_hash_spec.rb
@@ -1,8 +1,28 @@
 require 'rails_helper'
 
 describe AuthHash do
-  it 'extracts the users information' do
-    auth = AuthHash.new(OmniAuth.config.mock_auth[:github])
-    expect(auth.user_info[:token]).to eq('some-token')
+  let(:auth_hash) { AuthHash.new(OmniAuth.config.mock_auth[:github]) }
+
+  describe '#extract_user_info' do
+    it 'extracts the users information' do
+      expect(auth_hash.user_info[:token]).to eq('some-token')
+    end
+  end
+
+  describe '#non_staff_github_admins_ids' do
+    it 'returns an empty array if there the ENV is not set' do
+      ENV['NON_STAFF_GITHUB_ADMIN_IDS'] = nil
+      expect(auth_hash.instance_eval { non_staff_github_admins_ids }).to eql([])
+    end
+
+    it 'returns only one id' do
+      ENV['NON_STAFF_GITHUB_ADMIN_IDS'] = ',,1'
+      expect(auth_hash.instance_eval { non_staff_github_admins_ids }).to eql(['1'])
+    end
+
+    it 'returns multiple ids' do
+      ENV['NON_STAFF_GITHUB_ADMIN_IDS'] = '1,2,3'
+      expect(auth_hash.instance_eval { non_staff_github_admins_ids }).to eql(%w(1 2 3))
+    end
   end
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -11,5 +11,7 @@ OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
     'name'     => 'Test User'
   },
 
+  'extra' => { 'raw_info' => { 'site_admin' => false } },
+
   'credentials' => { 'token' => 'some-token' }
 )


### PR DESCRIPTION
If the user is a staff member (the `site_admin` column) on GitHub then when they login they will
become staff on Classroom for GitHub.

Or if their uid is included in the NON_STAFF_GITHUB_ADMIN_IDS string
then they will also be updated to become an admin on sign in (for people like me :grin:)

/cc @johndbritton 