### PR TITLE
Move starter code cloning and pushing to a background job

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -q starter_code,2 -q default

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -2,7 +2,8 @@ class AssignmentInvitationsController < InvitationsController
   def accept_invitation
     if (full_repo_name = @invitation.redeem_for(current_user))
       render partial: 'invitations/success',
-             locals: { repo_url: "https://github.com/#{full_repo_name}" },
+             locals: { repo_url: "https://github.com/#{full_repo_name}",
+                       has_starter_code: @invitation.assignment.starter_code? },
              layout: 'invitations'
     else
       flash[:error] = 'An error has occured, please refresh the page and try again.'

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -8,8 +8,8 @@ class GroupAssignmentInvitationsController < InvitationsController
     group_title = group_params[:title]
 
     if (full_repo_name = @invitation.redeem_for(current_user, group, group_title))
-      render partial: 'success',
-             locals: { repo_url: "https://github.com/#{full_repo_name}" },
+      render partial: 'success', locals: { repo_url: "https://github.com/#{full_repo_name}",
+                                           has_starter_code: @invitation.group_assignment.starter_code? },
              layout: 'invitations'
     else
       flash[:error] = 'An error has occured, please refresh the page and try again.'

--- a/app/jobs/push_starter_code_job.rb
+++ b/app/jobs/push_starter_code_job.rb
@@ -1,0 +1,10 @@
+class PushStarterCodeJob < ActiveJob::Base
+  queue_as :starter_code
+
+  def perform(creator, assignment_repo_id, starter_code_repo_id)
+    assignment_repository   = GitHubRepository.new(creator.github_client, assignment_repo_id)
+    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repo_id)
+
+    assignment_repository.get_starter_code_from(starter_code_repository.full_name)
+  end
+end

--- a/app/jobs/push_starter_code_job.rb
+++ b/app/jobs/push_starter_code_job.rb
@@ -1,10 +1,7 @@
 class PushStarterCodeJob < ActiveJob::Base
   queue_as :starter_code
 
-  def perform(creator, assignment_repo_id, starter_code_repo_id)
-    assignment_repository   = GitHubRepository.new(creator.github_client, assignment_repo_id)
-    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repo_id)
-
+  def perform(assignment_repository, starter_code_repository)
     assignment_repository.get_starter_code_from(starter_code_repository.full_name)
   end
 end

--- a/app/models/concerns/git_hub_repoable.rb
+++ b/app/models/concerns/git_hub_repoable.rb
@@ -42,11 +42,7 @@ module GitHubRepoable
   #
   def push_starter_code
     return true unless starter_code_repo_id
-
-    repository              = GitHubRepository.new(creator.github_client, github_repo_id)
-    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repo_id)
-
-    repository.get_starter_code_from(starter_code_repository.full_name)
+    PushStarterCodeJob.perform_later(creator, github_repo_id, starter_code_repo_id)
   end
 
   private

--- a/app/models/concerns/git_hub_repoable.rb
+++ b/app/models/concerns/git_hub_repoable.rb
@@ -42,7 +42,11 @@ module GitHubRepoable
   #
   def push_starter_code
     return true unless starter_code_repo_id
-    PushStarterCodeJob.perform_later(creator, github_repo_id, starter_code_repo_id)
+
+    assignment_repository   = GitHubRepository.new(creator.github_client, github_repo_id)
+    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repo_id)
+
+    PushStarterCodeJob.perform_later(assignment_repository, starter_code_repository)
   end
 
   private

--- a/app/views/invitations/_success.html.erb
+++ b/app/views/invitations/_success.html.erb
@@ -1,4 +1,4 @@
 <h1>You are Ready to Go!</h1>
 <p>
-  Head on over to: <%= link_to repo_url, repo_url %>
+  The assignment is located at: <%= link_to repo_url, repo_url %> <%= ', and your starter code will be available shortly.' if has_starter_code %>
 </p>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:queues:
+  - [starter_code, 2]
+  - default


### PR DESCRIPTION
Closes #94

If the user has a really large repo, the application has the potential to time out while performing the action.

This moves the process out to a background job on it's own queue `starter_code` which has a higher weight than the default queue so that the assignments will be cloned and pushed faster.

The copy and style still needs some work, but I think that's for another PR.

/cc @johndbritton 