### PR TITLE
ActiveJob doesn't recognize custom classes.

### DIFF
--- a/app/jobs/push_starter_code_job.rb
+++ b/app/jobs/push_starter_code_job.rb
@@ -1,7 +1,10 @@
 class PushStarterCodeJob < ActiveJob::Base
   queue_as :starter_code
 
-  def perform(assignment_repository, starter_code_repository)
+  def perform(assignment_repository_id, starter_code_repository_id)
+    assignment_repository   = GitHubRepository.new(creator.github_client, assignment_repository_id)
+    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repository_id)
+
     assignment_repository.get_starter_code_from(starter_code_repository.full_name)
   end
 end

--- a/app/models/concerns/git_hub_repoable.rb
+++ b/app/models/concerns/git_hub_repoable.rb
@@ -42,11 +42,7 @@ module GitHubRepoable
   #
   def push_starter_code
     return true unless starter_code_repo_id
-
-    assignment_repository   = GitHubRepository.new(creator.github_client, github_repo_id)
-    starter_code_repository = GitHubRepository.new(creator.github_client, starter_code_repo_id)
-
-    PushStarterCodeJob.perform_later(assignment_repository, starter_code_repository)
+    PushStarterCodeJob.perform_later(github_repo_id, starter_code_repo_id)
   end
 
   private


### PR DESCRIPTION
This fixes the ActiveJob::SerializationError - Unsupported argument type: GitHubRepository issue that I just created.