### PR TITLE
Logout button missing and other things

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'friendly_id'
 gem 'geo_pattern'
 
 gem 'jbuilder'
+gem 'jquery-turbolinks'
 
 gem 'kaminari'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.3)
     jwt (1.5.1)
     kaminari (0.16.3)
@@ -365,6 +368,7 @@ DEPENDENCIES
   friendly_id
   geo_pattern
   jbuilder
+  jquery-turbolinks
   kaminari
   octokit
   omniauth

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -11,6 +11,7 @@
 # about supported directives.
 #
 #= require jquery/dist/jquery
+#= require jquery.turbolinks
 #= require jquery-ujs/src/rails
 #
 #= require turbolinks

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -5,6 +5,10 @@ class GroupDecorator < Draper::Decorator
     github_team.name
   end
 
+  def slug
+    github_team.slug
+  end
+
   private
 
   def github_team

--- a/app/models/group_assignment_repo.rb
+++ b/app/models/group_assignment_repo.rb
@@ -39,7 +39,7 @@ class GroupAssignmentRepo < ActiveRecord::Base
   #
   def repo_name
     github_team = GitHubTeam.new(creator.github_client, github_team_id).team
-    "#{group_assignment.slug}-#{github_team.name}"
+    "#{group_assignment.slug}-#{github_team.slug}"
   end
 
   # Public

--- a/app/views/group_assignment_invitations/accept.html.erb
+++ b/app/views/group_assignment_invitations/accept.html.erb
@@ -16,7 +16,7 @@
 
   <%= form_tag({ controller: :group_assignment_invitations, action: :accept_assignment}, method: :patch) do %>
     <div class="markdown-body">
-      <p>Accepting this assignment will give your team (<%= decorated_group.name %>) access to the <strong><%= group_assignment.title %></strong> repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
+      <p>Accepting this assignment will give your team (<%= decorated_group.name %>) access to the <strong><%= "#{group_assignment.slug}-#{decorated_group.slug}" %></strong> repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
     </div>
 
     <div class="form-actions">

--- a/app/views/group_assignment_invitations/show.html.erb
+++ b/app/views/group_assignment_invitations/show.html.erb
@@ -13,7 +13,7 @@
 
 <div class="site-content-body">
   <div class="markdown-body">
-    <p>Accepting this assignment will give you access to the <strong><%= "#{group_assignment.slug}-#{decorated_group.name}" %></strong> repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
+    <p>Accepting this assignment will give you access to the assignment repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
   </div>
 
   <hr>

--- a/app/views/group_assignment_invitations/show.html.erb
+++ b/app/views/group_assignment_invitations/show.html.erb
@@ -13,7 +13,7 @@
 
 <div class="site-content-body">
   <div class="markdown-body">
-    <p>Accepting this assignment will give you access to the assignment repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
+    <p>Accepting this assignment will give your team access to the assignment repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
   </div>
 
   <hr>

--- a/app/views/group_assignments/_group_assignment.html.erb
+++ b/app/views/group_assignments/_group_assignment.html.erb
@@ -4,7 +4,7 @@
       <%= octicon('organization') %>
     </span>
     <h3 class="assignment-name-link">
-      <%= link_to group_assignment.title, organization_group_assignment_path(@organization, group_assignment) %>
+      <%= link_to group_assignment.title, organization_group_assignment_path(@organization, group_assignment), class: 'js-navigation' %>
     </h3>
     <p class="assignment-type text-muted">Group assigment</p>
   </div>

--- a/app/views/shared/_invitation_header.html.erb
+++ b/app/views/shared/_invitation_header.html.erb
@@ -6,6 +6,10 @@
       <%= link_to decorated_current_user.github_url do %>
         <%= image_tag decorated_current_user.avatar_url(40), class: 'avatar', alt: "@#{decorated_current_user.login}", height: 20, width: 20 %>
       <% end %>
+
+      <%= link_to logout_path, method: :post do %>
+        <%= octicon('sign-out') %>
+      <% end %>
     </nav>
 
     <%= image_tag('logo@2x.png', :class => 'site-logo', :alt => 'GitHub for Classrooms') %>


### PR DESCRIPTION
* Adds the sign out link to the invitation header
* Use the slug instead of the name for group repo creation
* Don't try to show the team name before we can

Closes #168 