### PR TITLE
Label new issues with `report`

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
 
         <% if logged_in? %>
           <li>
-            <%= link_to 'https://github.com/education/classroom/issues/new', class: 'tooltipped tooltipped-s', 'aria-label' => 'Report an issue' do %>
+            <%= link_to 'https://github.com/education/classroom/issues/new&labels[]=report', class: 'tooltipped tooltipped-s', 'aria-label' => 'Report an issue' do %>
               <%= octicon('bug') %>
             <% end %>
           </li>


### PR DESCRIPTION
Automatically label issues reported via the link in the app header.

https://github.com/education/classroom/labels/report