### PR TITLE
Use Marshal to serialize cache

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,5 +1,5 @@
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::HttpCache, store: Rails.cache, logger: Rails.logger, shared_cache: false
+  builder.use Faraday::HttpCache, store: Rails.cache, logger: Rails.logger, shared_cache: false, serializer: Marshal
   builder.use Octokit::Response::RaiseError
   builder.adapter Faraday.default_adapter
 end


### PR DESCRIPTION
Fixes #234 

By default `faraday-http-cache` uses the built-in `JSON` serializer, which breaks on some edge cases. This replaces the serializer with `Marshal`.