### PR TITLE
Handle missing api resources in views

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -17,6 +17,11 @@ a {
   &:hover {
     text-decoration: none;
   }
+
+  &.disabled {
+    pointer-events: none;
+    cursor: default;
+  }
 }
 
 main {
@@ -294,6 +299,16 @@ hr {
 .assignment-repo-list-item {
   font-size: 14px;
 
+  &.disabled {
+    a {
+      color: $brand-gray;
+    }
+
+    .avatar {
+      filter: grayscale(1);
+    }
+  }
+
   .avatar {
     margin-right: 10px;
 
@@ -327,6 +342,16 @@ hr {
 
 .group-assignment-repo-list-item {
   font-size: 14px;
+
+  &.disabled {
+    a {
+      color: $brand-gray;
+    }
+
+    .avatar {
+      filter: grayscale(1);
+    }
+  }
 
   .css-truncate-target {
     max-width: 20rem;

--- a/app/decorators/assignment_decorator.rb
+++ b/app/decorators/assignment_decorator.rb
@@ -4,6 +4,8 @@ class AssignmentDecorator < Draper::Decorator
   def full_name
     return unless starter_code?
     github_repository.full_name
+  rescue GitHub::NotFound
+    "Deleted repository"
   end
 
   private

--- a/app/decorators/assignment_decorator.rb
+++ b/app/decorators/assignment_decorator.rb
@@ -10,7 +10,7 @@ class AssignmentDecorator < Draper::Decorator
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, starter_code_repo_id).repository
-  rescue
+  rescue GitHub::NotFound
     NullGitHubRepository.new
   end
 end

--- a/app/decorators/assignment_decorator.rb
+++ b/app/decorators/assignment_decorator.rb
@@ -4,13 +4,13 @@ class AssignmentDecorator < Draper::Decorator
   def full_name
     return unless starter_code?
     github_repository.full_name
-  rescue GitHub::NotFound
-    NullGitHubRepository.full_name
   end
 
   private
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, starter_code_repo_id).repository
+  rescue
+    NullGitHubRepository.new
   end
 end

--- a/app/decorators/assignment_decorator.rb
+++ b/app/decorators/assignment_decorator.rb
@@ -5,7 +5,7 @@ class AssignmentDecorator < Draper::Decorator
     return unless starter_code?
     github_repository.full_name
   rescue GitHub::NotFound
-    "Deleted repository"
+    NullGitHubRepository.full_name
   end
 
   private

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -8,25 +8,25 @@ class AssignmentRepoDecorator < Draper::Decorator
   def full_name
     github_repository.full_name
   rescue GitHub::NotFound
-    "Deleted repository"
+    NullGitHubRepository.full_name
   end
 
   def github_url
     github_repository.html_url
   rescue GitHub::NotFound
-    "#"
+    NullGitHubRepository.html_url
   end
 
   def student_login
     student.login
   rescue GitHub::NotFound
-    "ghost"
+    NullGitHubUser.login
   end
 
   def student_name
     student.name
   rescue GitHub::NotFound
-    "Deleted user"
+    NullGitHubUser.login
   end
 
   private

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -25,19 +25,19 @@ class AssignmentRepoDecorator < Draper::Decorator
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, github_repo_id).repository
-  rescue
+  rescue GitHub::NotFound
     NullGitHubRepository.new
   end
 
   def student
     @student ||= GitHubUser.new(creator.github_client, user.uid).user
-  rescue
+  rescue GitHub::NotFound
     NullGitHubUser.new
   end
 
   def user
     @user ||= repo_access.user
-  rescue
+  rescue GitHub::NotFound
     NullGitHubUser.new
   end
 end

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -37,7 +37,5 @@ class AssignmentRepoDecorator < Draper::Decorator
 
   def user
     @user ||= repo_access.user
-  rescue GitHub::NotFound
-    NullGitHubUser.new
   end
 end

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -7,18 +7,26 @@ class AssignmentRepoDecorator < Draper::Decorator
 
   def full_name
     github_repository.full_name
+  rescue GitHub::NotFound
+    "Deleted repository"
   end
 
   def github_url
     github_repository.html_url
+  rescue GitHub::NotFound
+    "#"
   end
 
   def student_login
     student.login
+  rescue GitHub::NotFound
+    "ghost"
   end
 
   def student_name
     student.name
+  rescue GitHub::NotFound
+    "Deleted user"
   end
 
   private

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -7,39 +7,37 @@ class AssignmentRepoDecorator < Draper::Decorator
 
   def full_name
     github_repository.full_name
-  rescue GitHub::NotFound
-    NullGitHubRepository.full_name
   end
 
   def github_url
     github_repository.html_url
-  rescue GitHub::NotFound
-    NullGitHubRepository.html_url
   end
 
   def student_login
     student.login
-  rescue GitHub::NotFound
-    NullGitHubUser.login
   end
 
   def student_name
     student.name
-  rescue GitHub::NotFound
-    NullGitHubUser.login
   end
 
   private
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, github_repo_id).repository
+  rescue
+    NullGitHubRepository.new
   end
 
   def student
     @student ||= GitHubUser.new(creator.github_client, user.uid).user
+  rescue
+    NullGitHubUser.new
   end
 
   def user
     @user ||= repo_access.user
+  rescue
+    NullGitHubUser.new
   end
 end

--- a/app/decorators/assignment_repo_decorator.rb
+++ b/app/decorators/assignment_repo_decorator.rb
@@ -13,6 +13,10 @@ class AssignmentRepoDecorator < Draper::Decorator
     github_repository.html_url
   end
 
+  def disabled?
+    github_repository.null? || student.null?
+  end
+
   def student_login
     student.login
   end

--- a/app/decorators/group_assignment_decorator.rb
+++ b/app/decorators/group_assignment_decorator.rb
@@ -5,7 +5,7 @@ class GroupAssignmentDecorator < Draper::Decorator
     return unless starter_code?
     github_repository.full_name
   rescue GitHub::NotFound
-    "Deleted repository"
+    NullGitHubRepository.full_name
   end
 
   private

--- a/app/decorators/group_assignment_decorator.rb
+++ b/app/decorators/group_assignment_decorator.rb
@@ -10,7 +10,7 @@ class GroupAssignmentDecorator < Draper::Decorator
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, starter_code_repo_id).repository
-  rescue
+  rescue GitHub::NotFound
     NullGitHubRepository.new
   end
 end

--- a/app/decorators/group_assignment_decorator.rb
+++ b/app/decorators/group_assignment_decorator.rb
@@ -4,6 +4,8 @@ class GroupAssignmentDecorator < Draper::Decorator
   def full_name
     return unless starter_code?
     github_repository.full_name
+  rescue GitHub::NotFound
+    "Deleted repository"
   end
 
   private

--- a/app/decorators/group_assignment_decorator.rb
+++ b/app/decorators/group_assignment_decorator.rb
@@ -4,13 +4,13 @@ class GroupAssignmentDecorator < Draper::Decorator
   def full_name
     return unless starter_code?
     github_repository.full_name
-  rescue GitHub::NotFound
-    NullGitHubRepository.full_name
   end
 
   private
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, starter_code_repo_id).repository
+  rescue
+    NullGitHubRepository.new
   end
 end

--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -4,7 +4,7 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
   def full_name
     github_repository.full_name
   rescue GitHub::NotFound
-    "Deleted repository"
+    NullGitHubRepository.full_name
   end
 
   def github_team_url
@@ -16,7 +16,7 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
   def github_repo_url
     github_repository.html_url
   rescue GitHub::NotFound
-    "#"
+    NullGitHubRepository.html_url
   end
 
   def team_name

--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -1,6 +1,10 @@
 class GroupAssignmentRepoDecorator < Draper::Decorator
   delegate_all
 
+  def disabled?
+    github_repository.null? || github_team.null?
+  end
+
   def full_name
     github_repository.full_name
   end

--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -3,35 +3,31 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
 
   def full_name
     github_repository.full_name
-  rescue GitHub::NotFound
-    NullGitHubRepository.full_name
   end
 
   def github_team_url
     "https://github.com/orgs/#{github_team.organization.login}/teams/#{github_team.slug}"
-  rescue GitHub::NotFound
-    "#"
   end
 
   def github_repo_url
     github_repository.html_url
-  rescue GitHub::NotFound
-    NullGitHubRepository.html_url
   end
 
   def team_name
     github_team.name
-  rescue GitHub::NotFound
-    "Deleted team"
   end
 
   private
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, github_repo_id).repository
+  rescue
+    NullGitHubRepository.new
   end
 
   def github_team
     @github_team ||= GitHubTeam.new(creator.github_client, github_team_id).team
+  rescue
+    NullGitHubTeamTeam.new
   end
 end

--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -21,13 +21,13 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
 
   def github_repository
     @github_repository ||= GitHubRepository.new(creator.github_client, github_repo_id).repository
-  rescue
+  rescue GitHub::NotFound
     NullGitHubRepository.new
   end
 
   def github_team
     @github_team ||= GitHubTeam.new(creator.github_client, github_team_id).team
-  rescue
+  rescue GitHub::NotFound
     NullGitHubTeamTeam.new
   end
 end

--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -3,18 +3,26 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
 
   def full_name
     github_repository.full_name
+  rescue GitHub::NotFound
+    "Deleted repository"
   end
 
   def github_team_url
     "https://github.com/orgs/#{github_team.organization.login}/teams/#{github_team.slug}"
+  rescue GitHub::NotFound
+    "#"
   end
 
   def github_repo_url
     github_repository.html_url
+  rescue GitHub::NotFound
+    "#"
   end
 
   def team_name
     github_team.name
+  rescue GitHub::NotFound
+    "Deleted team"
   end
 
   private

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -3,10 +3,14 @@ class GroupDecorator < Draper::Decorator
 
   def name
     github_team.name
+  rescue GitHub::NotFound
+    "Deleted team"
   end
 
   def slug
     github_team.slug
+  rescue GitHub::NotFound
+    'ghost'
   end
 
   private

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -13,7 +13,7 @@ class GroupDecorator < Draper::Decorator
 
   def github_team
     @github_team ||= GitHubTeam.new(organization.github_client, github_team_id).team
-  rescue
+  rescue GitHub::NotFound
     NullGitHubTeam.new
   end
 end

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -3,19 +3,17 @@ class GroupDecorator < Draper::Decorator
 
   def name
     github_team.name
-  rescue GitHub::NotFound
-    NullGitHubTeam.name
   end
 
   def slug
     github_team.slug
-  rescue GitHub::NotFound
-    NullGitHubTeam.slug
   end
 
   private
 
   def github_team
     @github_team ||= GitHubTeam.new(organization.github_client, github_team_id).team
+  rescue
+    NullGitHubTeam.new
   end
 end

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -4,13 +4,13 @@ class GroupDecorator < Draper::Decorator
   def name
     github_team.name
   rescue GitHub::NotFound
-    "Deleted team"
+    NullGitHubTeam.name
   end
 
   def slug
     github_team.slug
   rescue GitHub::NotFound
-    'ghost'
+    NullGitHubTeam.slug
   end
 
   private

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -11,8 +11,6 @@ class OrganizationDecorator < Draper::Decorator
 
   def github_url
     github_organization.html_url
-  rescue GitHub::NotFound
-    NullGitHubOrganization.html_url
   end
 
   def github_team_invitations_url
@@ -21,13 +19,13 @@ class OrganizationDecorator < Draper::Decorator
 
   def login
     github_organization.login
-  rescue GitHub::NotFound
-    NullGitHubOrganization.login
   end
 
   private
 
   def github_organization
     @github_organization ||= GitHubOrganization.new(github_client, github_id).organization
+  rescue
+    NullGitHubOrganization.new
   end
 end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -25,7 +25,7 @@ class OrganizationDecorator < Draper::Decorator
 
   def github_organization
     @github_organization ||= GitHubOrganization.new(github_client, github_id).organization
-  rescue
+  rescue GitHub::NotFound
     NullGitHubOrganization.new
   end
 end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -12,19 +12,17 @@ class OrganizationDecorator < Draper::Decorator
   def github_url
     github_organization.html_url
   rescue GitHub::NotFound
-    "#"
+    NullGitHubOrganization.html_url
   end
 
   def github_team_invitations_url
-    "https://github.com/orgs/#{github_organization.login}/invitations/new"
-  rescue GitHub::NotFound
-    "#"
+    "https://github.com/orgs/#{login}/invitations/new"
   end
 
   def login
     github_organization.login
   rescue GitHub::NotFound
-    "ghost"
+    NullGitHubOrganization.login
   end
 
   private

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -11,14 +11,20 @@ class OrganizationDecorator < Draper::Decorator
 
   def github_url
     github_organization.html_url
+  rescue GitHub::NotFound
+    "#"
   end
 
   def github_team_invitations_url
     "https://github.com/orgs/#{github_organization.login}/invitations/new"
+  rescue GitHub::NotFound
+    "#"
   end
 
   def login
     github_organization.login
+  rescue GitHub::NotFound
+    "ghost"
   end
 
   private

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -7,10 +7,14 @@ class UserDecorator < Draper::Decorator
 
   def github_url
     github_user.html_url
+  rescue GitHub::NotFound
+    "#"
   end
 
   def login
     github_user.login
+  rescue GitHub::NotFound
+    "ghost"
   end
 
   private

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -17,7 +17,7 @@ class UserDecorator < Draper::Decorator
 
   def github_user
     @github_user ||= GitHubUser.new(github_client, uid).user
-  rescue
+  rescue GitHub::NotFound
     NullGitHubUser
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -7,19 +7,17 @@ class UserDecorator < Draper::Decorator
 
   def github_url
     github_user.html_url
-  rescue GitHub::NotFound
-    NullGitHubUser.html_url
   end
 
   def login
     github_user.login
-  rescue GitHub::NotFound
-    NullGitHubUser.login
   end
 
   private
 
   def github_user
     @github_user ||= GitHubUser.new(github_client, uid).user
+  rescue
+    NullGitHubUser
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -8,13 +8,13 @@ class UserDecorator < Draper::Decorator
   def github_url
     github_user.html_url
   rescue GitHub::NotFound
-    "#"
+    NullGitHubUser.html_url
   end
 
   def login
     github_user.login
   rescue GitHub::NotFound
-    "ghost"
+    NullGitHubUser.login
   end
 
   private

--- a/app/models/null_git_hub_organization.rb
+++ b/app/models/null_git_hub_organization.rb
@@ -1,0 +1,9 @@
+class NullGitHubOrganization
+  def html_url
+    '#'
+  end
+
+  def login
+    'ghost'
+  end
+end

--- a/app/models/null_git_hub_organization.rb
+++ b/app/models/null_git_hub_organization.rb
@@ -1,4 +1,4 @@
-class NullGitHubOrganization
+class NullGitHubOrganization < NullGitHubResource
   def html_url
     '#'
   end

--- a/app/models/null_git_hub_repository.rb
+++ b/app/models/null_git_hub_repository.rb
@@ -1,4 +1,4 @@
-class NullGitHubRepository
+class NullGitHubRepository < NullGitHubResource
   def full_name
     'Deleted repository'
   end

--- a/app/models/null_git_hub_repository.rb
+++ b/app/models/null_git_hub_repository.rb
@@ -1,0 +1,9 @@
+class NullGitHubRepository
+  def full_name
+    'Deleted repository'
+  end
+
+  def html_url
+    '#'
+  end
+end

--- a/app/models/null_git_hub_resource.rb
+++ b/app/models/null_git_hub_resource.rb
@@ -1,0 +1,5 @@
+class NullGitHubResource
+  def null?
+    true
+  end
+end

--- a/app/models/null_git_hub_team.rb
+++ b/app/models/null_git_hub_team.rb
@@ -1,4 +1,4 @@
-class NullGitHubTeam
+class NullGitHubTeam < NullGitHubResource
   def name
     'ghost'
   end

--- a/app/models/null_git_hub_team.rb
+++ b/app/models/null_git_hub_team.rb
@@ -1,0 +1,9 @@
+class NullGitHubTeam
+  def name
+    'ghost'
+  end
+
+  def slug
+    'ghost'
+  end
+end

--- a/app/models/null_git_hub_user.rb
+++ b/app/models/null_git_hub_user.rb
@@ -1,4 +1,4 @@
-class NullGitHubUser
+class NullGitHubUser < NullGitHubResource
   def html_url
     '#'
   end

--- a/app/models/null_git_hub_user.rb
+++ b/app/models/null_git_hub_user.rb
@@ -1,0 +1,9 @@
+class NullGitHubUser
+  def html_url
+    '#'
+  end
+
+  def login
+    'ghost'
+  end
+end

--- a/app/models/null_github_team.rb
+++ b/app/models/null_github_team.rb
@@ -1,4 +1,4 @@
-class NullGitHubTeam
+class NullGitHubTeam < NullGitHubResource
   def name
     'Deleted team'
   end

--- a/app/models/null_github_team.rb
+++ b/app/models/null_github_team.rb
@@ -1,0 +1,9 @@
+class NullGitHubTeam
+  def name
+    'Deleted team'
+  end
+
+  def slug
+    'ghost'
+  end
+end

--- a/app/models/null_github_team.rb
+++ b/app/models/null_github_team.rb
@@ -1,9 +1,0 @@
-class NullGitHubTeam < NullGitHubResource
-  def name
-    'Deleted team'
-  end
-
-  def slug
-    'ghost'
-  end
-end

--- a/app/views/assignment_repos/_assignment_repo.html.erb
+++ b/app/views/assignment_repos/_assignment_repo.html.erb
@@ -1,6 +1,6 @@
 <% assignment_repo = assignment_repo.decorate %>
 
-<div class="flex-table assignment-repo-list-item">
+<div class="flex-table assignment-repo-list-item<%= ' disabled' if assignment_repo.disabled? %>">
   <div class="flex-table-item">
     <%= image_tag assignment_repo.avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{assignment_repo.student_login}" %>
 

--- a/app/views/assignment_repos/_assignment_repo.html.erb
+++ b/app/views/assignment_repos/_assignment_repo.html.erb
@@ -5,7 +5,9 @@
     <%= image_tag assignment_repo.avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{assignment_repo.student_login}" %>
 
     <div class="student-information">
-      <%= link_to "https://github.com/#{assignment_repo.student_login}", class: 'css-truncate css-truncate-target student-login' do %>
+      <% css_class  = 'css-truncate css-truncate-target student-login' %>
+      <% css_class += ' disabled' if assignment_repo.disabled? %>
+      <%= link_to "https://github.com/#{assignment_repo.student_login}", class: css_class do %>
         <strong class="css-truncate-target"><%= assignment_repo.student_login %></strong>
       <% end %>
 
@@ -15,7 +17,7 @@
 
   <div class="flex-table-item text-right">
     <strong class="css-truncate css-truncate-target">
-      <%= link_to assignment_repo.full_name, assignment_repo.github_url %>
+      <%= link_to assignment_repo.full_name, assignment_repo.github_url, class: "#{'disabled' if assignment_repo.disabled?}" %>
     </strong>
   </div>
 </div>

--- a/app/views/group_assignment_repos/_group_assignment_repo.html.erb
+++ b/app/views/group_assignment_repos/_group_assignment_repo.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex-table group-assignment-repo-list-item<%= ' disabled' if group_assignment_repo.disabled? %>">
   <div class="flex-table-item">
-    <%= link_to group_assignment_repo.github_team_url, class: 'team-name' do %>
+    <%= link_to group_assignment_repo.github_team_url, class: "team-name #{'disabled' if group_assignment_repo.disabled?}" do %>
       <strong class="css-truncate css-truncate-target"><%= group_assignment_repo.team_name %></strong>
     <% end %>
 
@@ -11,7 +11,7 @@
         <% student = repo_access.user.decorate %>
 
         <li>
-          <%= link_to student.github_url, class: 'tooltipped tooltipped-s', 'aria-label' => student.login do %>
+          <%= link_to student.github_url, class: "tooltipped tooltipped-s #{'disabled' if group_assignment_repo.disabled?}", 'aria-label' => student.login do %>
             <%= image_tag student.avatar_url(60), class: 'avatar avatar-small ', height: 30, width: 30, alt: "@#{student.login}" %>
           <% end %>
         </li>
@@ -19,7 +19,7 @@
 
       <% if group_assignment_repo.group.repo_accesses.count > 4 %>
         <li>
-          <%= link_to group_assignment_repo.github_team_url do %>
+          <%= link_to group_assignment_repo.github_team_url, class: "#{'disabled' if group_assignment_repo.disabled?}" do %>
             <%= image_tag 'student-ellipse@2x.png', class: 'avatar avatar-small', height: 30, width: 30, alt: 'student ellipse' %>
           <% end %>
         </li>
@@ -29,7 +29,7 @@
 
   <div class="flex-table-item text-right">
     <strong class="css-truncate css-truncate-target">
-      <%= link_to group_assignment_repo.full_name, group_assignment_repo.github_repo_url, class: 'assignment-repo-github-url' %>
+      <%= link_to group_assignment_repo.full_name, group_assignment_repo.github_repo_url, class: "assignment-repo-github-url #{'disabled' if group_assignment_repo.disabled?}" %>
     </strong>
   </div>
 </div>

--- a/app/views/group_assignment_repos/_group_assignment_repo.html.erb
+++ b/app/views/group_assignment_repos/_group_assignment_repo.html.erb
@@ -1,6 +1,6 @@
 <% group_assignment_repo = group_assignment_repo.decorate %>
 
-<div class="flex-table group-assignment-repo-list-item">
+<div class="flex-table group-assignment-repo-list-item<%= ' disabled' if group_assignment_repo.disabled? %>">
   <div class="flex-table-item">
     <%= link_to group_assignment_repo.github_team_url, class: 'team-name' do %>
       <strong class="css-truncate css-truncate-target"><%= group_assignment_repo.team_name %></strong>


### PR DESCRIPTION
This handles `GitHub::NotFound` errors, replacing expected data with default null object data and adds disabled styles to views:

<img width="993" alt="screen shot 2015-09-24 at 6 33 07 pm" src="https://cloud.githubusercontent.com/assets/123345/10080993/c035644e-62ea-11e5-9664-e175c55e9761.png">

Fixes #254 