### PR TITLE
Destroy even when GitHub resources are missing

### DIFF
--- a/app/models/concerns/git_hub_repoable.rb
+++ b/app/models/concerns/git_hub_repoable.rb
@@ -36,6 +36,7 @@ module GitHubRepoable
   #
   def destroy_github_repository
     github_organization.delete_repository(github_repo_id)
+    true # Destroy ActiveRecord object even if we fail to delete the repository
   end
 
   # Public

--- a/app/models/concerns/git_hub_teamable.rb
+++ b/app/models/concerns/git_hub_teamable.rb
@@ -20,7 +20,7 @@ module GitHubTeamable
   #
   def destroy_github_team
     github_organization.delete_team(github_team_id)
-    true
+    true # Destroy ActiveRecord object even if we fail to delete the team
   end
 
   # Internal


### PR DESCRIPTION
Sometimes, a user will delete a repository by hand on github.com. When this happens, we'll now ignore the resource and continue deleting the ActiveRecord object.

Fixes #275