### PR TITLE
Disable group if the team resource is missing

### DIFF
--- a/app/decorators/group_assignment_repo_decorator.rb
+++ b/app/decorators/group_assignment_repo_decorator.rb
@@ -32,6 +32,6 @@ class GroupAssignmentRepoDecorator < Draper::Decorator
   def github_team
     @github_team ||= GitHubTeam.new(creator.github_client, github_team_id).team
   rescue GitHub::NotFound
-    NullGitHubTeamTeam.new
+    NullGitHubTeam.new
   end
 end

--- a/app/models/null_git_hub_team.rb
+++ b/app/models/null_git_hub_team.rb
@@ -3,6 +3,10 @@ class NullGitHubTeam < NullGitHubResource
     'ghost'
   end
 
+  def organization
+    NullGitHubOrganization.new
+  end
+
   def slug
     'ghost'
   end

--- a/app/models/null_git_hub_team.rb
+++ b/app/models/null_git_hub_team.rb
@@ -1,6 +1,6 @@
 class NullGitHubTeam < NullGitHubResource
   def name
-    'ghost'
+    'Deleted team'
   end
 
   def organization


### PR DESCRIPTION
Fixes #291 

`NullGitHubTeam#organization` now returns an instance of `NullGitHubOrganization.