### PR TITLE
Added some spacing to navigation icons

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -67,6 +67,10 @@ main {
   }
 
   a {
+    display: block;
+    height: 28px;
+    padding-top: 4px;
+    padding-bottom: 4px;
     color: rgba(255, 255, 255, 0.5);
 
     @media (max-width: 34em) {


### PR DESCRIPTION
This gives the tooltip more spacing above and is now the same as github.com

Fixes #289