### PR TITLE
Fix invitation header

### DIFF
--- a/app/views/shared/_invitation_header.html.erb
+++ b/app/views/shared/_invitation_header.html.erb
@@ -4,7 +4,9 @@
 
     <nav class="site-nav">
       <ul>
-        <%= link_to "GitHub Education", 'https://education.github.com', target: '_blank' %>
+        <li>
+          <%= link_to "GitHub Education", 'https://education.github.com', target: '_blank' %>
+        </li>
 
         <li>
           <%= link_to 'https://github.com/education/classroom/issues/new', class: 'tooltipped tooltipped-s', 'aria-label' => 'Report an issue' do %>


### PR DESCRIPTION
Closes #314 
The Classroom for GitHub tag wasn't wrapped in an `<li>` in the `<ul>` throwing everything else off.