### PR TITLE
Remove starter_code background job queue

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -5,4 +5,4 @@
 
 redis: redis-server
 memcached: memcached
-worker: bundle exec sidekiq -q starter_code,2 -q trash_can
+worker: bundle exec sidekiq -q trash_can

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,2 @@
 :queues:
-  - [starter_code, 2]
-  - default
   - trash_can

--- a/script/sidekiq
+++ b/script/sidekiq
@@ -5,4 +5,4 @@ set -e
 cd "$(dirname "$0")/.."
 
 # Run the sidekiq background job
-bundle exec sidekiq -q starter_code,2 -q trash_can
+bundle exec sidekiq -q trash_can


### PR DESCRIPTION
Since we don't push code in the background anymore (#316) we don't need the queue.

/cc @johndbritton 