### PR TITLE
Report exceptions to Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '2.2.3'
 gem 'rails', '4.2.4'
 
+gem 'airbrake'
 gem 'autoprefixer-rails'
 
 gem 'coffee-rails', '~> 4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    airbrake (4.3.1)
+      builder
+      multi_json
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -358,6 +361,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake
   autoprefixer-rails
   awesome_print
   better_errors

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ script/setup
 ENV Variable | Description |
 :-------------------|:-----------------|
 `AIRBRAKE_API_KEY` | the API key for airbrake.io, if set Airbrake will be enabled
+`CANONICAL_HOST` | the preferred hostname for the applicaition, if set requests served on other hostnames will be redirected
+`GOOGLE_ANALYTICS_TRACKING_ID` | identifier for Google Analytics in the format `UA-.*`
+`PINGLISH_ENABLED` | Enable the `/_ping` endpoint with relevant health checks
 
 ### Development environment variables
 These values must be present in your `.env` file (created by `script/setup`).
@@ -59,7 +62,6 @@ ENV Variable | Description |
 `GITHUB_CLIENT_ID`| the GitHub Application Client ID.
 `GITHUB_CLIENT_SECRET`| the GitHub Application Client Secret.
 `NON_STAFF_GITHUB_ADMIN_IDS` | GitHub `user_ids` of users to be granted staff level access.
-`PINGLISH_ENABLED` | Enable the `/_ping` endpoint with relevant health checks
 
 ### Testing environment variables
 Classroom for GitHub uses [VCR](https://github.com/vcr/vcr) for recording and playing back API fixtures during test runs. These cassettes (fixtures) are part of the Git project in the `spec/support/cassettes` folder. If you're not recording new cassettes you can run the specs with existing cassettes with:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Once bundler is installed go ahead and run the `setup` script
 script/setup
 ```
 
+### Production environment variables
+ENV Variable | Description |
+:-------------------|:-----------------|
+`AIRBRAKE_API_KEY` | the API key for airbrake.io, if set Airbrake will be enabled
+
 ### Development environment variables
 These values must be present in your `.env` file (created by `script/setup`).
 

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,5 @@
+if ENV['AIRBRAKE_API_KEY'].present?
+  Airbrake.configure do |config|
+    config.api_key = ENV['AIRBRAKE_API_KEY']
+  end
+end

--- a/public/500.html
+++ b/public/500.html
@@ -62,5 +62,8 @@
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>
+  <div>
+    <!-- AIRBRAKE ERROR -->
+  </div>
 </body>
 </html>


### PR DESCRIPTION
This adds the `airbrake` gem to report exceptions.

We only send exceptions if the `AIRBRAKE_API_KEY` environment variable is set.