### PR TITLE
Gracefully handle when a student rejects their authentication token

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -17,7 +17,7 @@ class UserDecorator < Draper::Decorator
 
   def github_user
     @github_user ||= GitHubUser.new(github_client, uid).user
-  rescue GitHub::NotFound
-    NullGitHubUser
+  rescue GitHub::Forbidden, GitHub::NotFound
+    NullGitHubUser.new
   end
 end

--- a/app/models/concerns/git_hub.rb
+++ b/app/models/concerns/git_hub.rb
@@ -5,6 +5,7 @@ module GitHub
 
   # Public
   #
+  # rubocop:disable Metrics/CyclomaticComplexity
   def with_error_handling
     yield
   rescue Octokit::Error => err
@@ -12,9 +13,11 @@ module GitHub
     when Octokit::Forbidden           then raise_github_forbidden_error
     when Octokit::NotFound            then raise_github_not_found_error
     when Octokit::ServerError         then raise_github_server_error
+    when Octokit::Unauthorized        then raise_github_forbidden_error
     when Octokit::UnprocessableEntity then raise_github_error(err)
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   protected
 


### PR DESCRIPTION
If a student rejects their auth token it raises a `Octokit::Unauthorized` error which we now handle.

/cc @johndbritton 