### PR TITLE
Fix the ability to copy classroom url for invite

### DIFF
--- a/app/views/organizations/_invite_users.html.erb
+++ b/app/views/organizations/_invite_users.html.erb
@@ -15,9 +15,9 @@
     <div class="columns desktop-invitation-content">
       <div class="two-thirds column">
         <div class="input-group">
-          <%= content_tag :input, '', type: 'text', id: @organization.slug, value: organization_url(@organization), readonly: 'readonly' %>
+          <%= content_tag :input, '', type: 'text', id: "organization-#{@organization.github_id}", value: organization_url(@organization), readonly: 'readonly' %>
           <span class="input-group-button">
-            <button data-clipboard-target=<%= "##{@organization.slug}" %> class="js-clipboard btn tooltipped tooltipped-s" data-copied-hint="Copied!" type="button">
+            <button aria-label="Copy to clipboard" data-clipboard-target=<%= "#organization-#{@organization.github_id}" %> class="js-clipboard btn tooltipped tooltipped-s" data-copied-hint="Copied!" type="button">
               <%= octicon('clippy') %>
               Copy classroom link
             </button>


### PR DESCRIPTION
I must have missed this one when I was [removing Zeroclipboard](https://github.com/education/classroom/pull/336)