### PR TITLE
adding code coverage analysis tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+/coverage
 
 # Ignore local environment variables
 .env

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'simplecov', require: false
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     database_cleaner (1.5.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     dotenv (2.0.2)
     dotenv-rails (2.0.2)
       dotenv (= 2.0.2)
@@ -342,6 +343,11 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    simplecov (0.11.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -423,6 +429,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   sidekiq
+  simplecov
   sinatra
   spring
   sprockets (= 3.3.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,11 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'simplecov'
+
+SimpleCov.start 'rails'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Proposal to add **simplecov** as analysis tool for tests, hence on long run it helps to increase quality and will encourage contributors to increase it as well ;) 

```
Coverage report generated for RSpec to /Users/cwirth/Workspace/classroom/coverage. 933 / 1264 LOC (73.81%) covered.
```

