### PR TITLE
Created Stafftools dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '4.2.4'
 gem 'airbrake'
 gem 'autoprefixer-rails'
 
+gem 'chartkick'
 gem 'chewy'
 gem 'coffee-rails', '~> 4.1.0'
 
@@ -14,6 +15,7 @@ gem 'draper'
 gem 'faraday-http-cache'
 
 gem 'geo_pattern'
+gem 'groupdate'
 
 gem 'jbuilder'
 gem 'jquery-turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       nenv
       rspec-logsplit (>= 0.1.2)
       timers (>= 4.1.1)
+    chartkick (1.4.1)
     chewy (0.8.2)
       activesupport (>= 3.2)
       elasticsearch (>= 1.0.0)
@@ -169,6 +170,8 @@ GEM
     get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    groupdate (2.5.0)
+      activesupport (>= 3)
     hashie (3.4.2)
     hitimes (1.2.3)
     i18n (0.7.0)
@@ -390,6 +393,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bullet
+  chartkick
   chewy
   coffee-rails (~> 4.1.0)
   dalli
@@ -401,6 +405,7 @@ DEPENDENCIES
   faraday-http-cache
   foreman
   geo_pattern
+  groupdate
   jbuilder
   jquery-turbolinks
   kaminari

--- a/app/controllers/stafftools/dashboards_controller.rb
+++ b/app/controllers/stafftools/dashboards_controller.rb
@@ -1,0 +1,6 @@
+module Stafftools
+  class DashboardsController < StafftoolsController
+    def show
+    end
+  end
+end

--- a/app/views/layouts/staff.html.erb
+++ b/app/views/layouts/staff.html.erb
@@ -8,7 +8,10 @@
     <title>Classroom for GitHub</title>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
+
+    <%= javascript_include_tag "//www.google.com/jsapi", "chartkick" %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+
     <%= csrf_meta_tags %>
 
     <%= render 'shared/open_graph' %>

--- a/app/views/stafftools/_navigation.html.erb
+++ b/app/views/stafftools/_navigation.html.erb
@@ -1,5 +1,10 @@
 <nav class="menu">
-  <%= link_to stafftools_root_path, class: 'menu-item selected' do %>
+  <%= link_to stafftools_root_path, class: "menu-item #{'selected' if controller_name == 'dashboards'}" do %>
+    <%= octicon('graph') %>
+    Dashboard
+  <% end %>
+
+  <%= link_to stafftools_resources_path, class: "menu-item #{'selected' if controller_name == 'resources' }" do %>
     <%= octicon('search') %>
     Resources
   <% end %>

--- a/app/views/stafftools/dashboards/show.html.erb
+++ b/app/views/stafftools/dashboards/show.html.erb
@@ -4,5 +4,9 @@
   </div>
 
   <div class="site-content-body">
+    <%= line_chart [
+      { name: 'Assignment repos created', data: Assignment.group_by_day(:created_at).count },
+      { name: 'Group Assignment repos created', data: GroupAssignment.group_by_day(:created_at).count }
+    ] %>
   </div>
 </div>

--- a/app/views/stafftools/dashboards/show.html.erb
+++ b/app/views/stafftools/dashboards/show.html.erb
@@ -1,0 +1,8 @@
+<div class="site-content">
+  <div class="site-content-cap">
+    <h2 class="site-content-heading">Dashboard</h2>
+  </div>
+
+  <div class="site-content-body">
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,9 @@ Rails.application.routes.draw do
   namespace :stafftools do
     mount Sidekiq::Web  => '/sidekiq', constraints: StaffConstraint.new
 
-    root to: 'resources#index'
+    root to: 'dashboards#show'
+
+    get :resources,         to: 'resources#index'
     get '/resource_search', to: 'resources#search'
 
     resources :users, only: [] do


### PR DESCRIPTION
This sets the new `/stafftools` route to be the dashboard of the application with useful charts and stats for the application.

@johndbritton per our discussion in chat the dashboard will include.

* Overall resource counts for Classroom
* Assignment Submissions
* Assignment Creation
* Organizations Addition

Is there anything else you think would be useful for the page?
