### PR TITLE
Design tweaks

### DIFF
--- a/app/assets/stylesheets/.scss-lint.yml
+++ b/app/assets/stylesheets/.scss-lint.yml
@@ -1,0 +1,406 @@
+# This is the lint file for .scss files. It uses https://github.com/brigade/scss-lint
+# to search through .scss files and point out errors.
+# You can view these errors in your editor.
+#
+# Here's a link to all the default configurations
+# https://github.com/brigade/scss-lint/blob/master/config/default.yml
+# below is our settings.
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+    severity: error
+
+  BemDepth:
+    enabled: false
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+    severity: error
+
+  ColorKeyword:
+    enabled: true
+    severity: error
+
+  ColorVariable:
+    enabled: false
+
+  Comment:
+    enabled: false
+
+  DebugStatement:
+    enabled: true
+    severity: error
+
+  DeclarationOrder:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+    severity: error
+
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+    severity: error
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+    severity: error
+
+  EmptyRule:
+    enabled: false
+
+  FinalNewline:
+    enabled: true
+    present: true
+    severity: error
+
+  HexLength:
+    enabled: true
+    style: short # or 'long'
+    severity: error
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+    severity: error
+
+  HexValidation:
+    enabled: true
+    severity: error
+
+  IdSelector:
+    enabled: true
+    severity: warning
+
+  ImportantRule:
+    enabled: false
+    severity: error
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+    severity: warning # need to allow .css vs .scss in some cases
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space # or 'tab'
+    width: 2
+    severity: error
+
+  LeadingZero:
+    enabled: true
+    style: include_zero
+    severity: error
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+    severity: error
+
+  NameFormat:
+    enabled: false
+
+  NestingDepth:
+    enabled: true
+    max_depth: 5
+    severity: error
+
+  PlaceholderInExtend:
+    enabled: false
+
+  PropertyCount:
+    enabled: false
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: true
+    severity: warning
+    order:
+      - position
+      - top
+      - right
+      - bottom
+      - left
+      - z-index
+      - display
+      - float
+      - width
+      - min-width
+      - max-width
+      - height
+      - min-height
+      - max-height
+      - box-sizing
+      - padding
+      - padding-top
+      - padding-right
+      - padding-bottom
+      - padding-left
+      - margin
+      - margin-top
+      - margin-right
+      - margin-bottom
+      - margin-left
+      - overflow
+      - overflow-x
+      - overflow-y
+      - clip
+      - clear
+      - font
+      - font-family
+      - font-size
+      - font-style
+      - font-weight
+      - font-variant
+      - font-size-adjust
+      - font-stretch
+      - font-effect
+      - font-emphasize
+      - font-emphasize-position
+      - font-emphasize-style
+      - font-smooth
+      - hyphens
+      - line-height
+      - color
+      - text-align
+      - text-align-last
+      - text-emphasis
+      - text-emphasis-color
+      - text-emphasis-style
+      - text-emphasis-position
+      - text-decoration
+      - text-indent
+      - text-justify
+      - text-outline
+      - text-overflow
+      - text-overflow-ellipsis
+      - text-overflow-mode
+      - text-shadow
+      - text-transform
+      - text-wrap
+      - letter-spacing
+      - word-break
+      - word-spacing
+      - word-wrap
+      - tab-size
+      - white-space
+      - vertical-align
+      - list-style
+      - list-style-position
+      - list-style-type
+      - list-style-image
+      - pointer-events
+      - fill
+      - fill-opacity
+      - stroke
+      - stroke-opacity
+      - stroke-width
+      - shape-rendering
+      - cursor
+      - visibility
+      - zoom
+      - flex-direction
+      - flex-order
+      - flex-pack
+      - flex-align
+      - table-layout
+      - empty-cells
+      - caption-side
+      - border-spacing
+      - border-collapse
+      - content
+      - quotes
+      - counter-reset
+      - counter-increment
+      - resize
+      - user-select
+      - nav-index
+      - nav-up
+      - nav-right
+      - nav-down
+      - nav-left
+      - background
+      - background-color
+      - background-image
+      - filter
+      - background-repeat
+      - background-attachment
+      - background-position
+      - background-position-x
+      - background-position-y
+      - background-clip
+      - background-origin
+      - background-size
+      - border
+      - border-color
+      - border-style
+      - border-width
+      - border-top
+      - border-top-color
+      - border-top-style
+      - border-top-width
+      - border-right
+      - border-right-color
+      - border-right-style
+      - border-right-width
+      - border-bottom
+      - border-bottom-color
+      - border-bottom-style
+      - border-bottom-width
+      - border-left
+      - border-left-color
+      - border-left-style
+      - border-left-width
+      - border-radius
+      - border-top-left-radius
+      - border-top-right-radius
+      - border-bottom-right-radius
+      - border-bottom-left-radius
+      - border-image
+      - border-image-source
+      - border-image-slice
+      - border-image-width
+      - border-image-outset
+      - border-image-repeat
+      - outline
+      - outline-width
+      - outline-style
+      - outline-color
+      - outline-offset
+      - box-shadow
+      - opacity
+      - transition
+      - transition-delay
+      - transition-timing-function
+      - transition-duration
+      - transition-property
+      - transform
+      - transform-origin
+      - animation
+      - animation-name
+      - animation-duration
+      - animation-fill-mode
+      - animation-play-state
+      - animation-timing-function
+      - animation-delay
+      - animation-iteration-count
+      - animation-direction
+
+  PropertySpelling:
+    enabled: true
+    severity: error
+    extra_properties: []
+
+  PropertyUnits:
+    enabled: false
+    severity: error
+    global: ['em', 'rem', '%'] # Allow relative units globally
+    properties:
+      border: ['px'] # Only pixels
+      line-height: [] # No units allowed
+      margin: ['em', 'rem']
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: warning
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 4
+    severity: error
+
+  SelectorFormat:
+    enabled: true
+    convention: ^((?!js\-))[a-z1-2\-\_]+
+    severity: error
+
+  Shorthand:
+    enabled: true
+    severity: error
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+    severity: error
+
+  SingleLinePerSelector:
+    enabled: true
+    severity: error
+
+  SpaceAfterComma:
+    enabled: true
+    severity: error
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+    severity: error
+
+  SpaceAfterPropertyName:
+    enabled: true
+    severity: error
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space # or 'new_line'
+    allow_single_line_padding: true
+    severity: error
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+    severity: error
+
+  StringQuotes:
+    enabled: true
+    style: double_quotes
+    severity: error
+
+  TrailingSemicolon:
+    enabled: true
+    severity: error
+
+  TrailingZero:
+    enabled: true
+    severity: error
+
+  UnnecessaryMantissa:
+    enabled: true
+    severity: error
+
+  UnnecessaryParentReference:
+    enabled: true
+    severity: error
+
+  UrlFormat:
+    enabled: true
+    severity: error
+
+  UrlQuotes:
+    enabled: true
+    severity: error
+
+  VariableForProperty:
+    enabled: false
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+    severity: error
+
+  ZeroUnit:
+    enabled: true
+    severity: error

--- a/app/assets/stylesheets/grid-system.scss
+++ b/app/assets/stylesheets/grid-system.scss
@@ -12,13 +12,13 @@
 
   @media (max-width: 43em) {
     .one-half:not(:last-child) {
-      margin-bottom: $grid-gutter * 2;
       padding-bottom: $grid-gutter * 2;
+      margin-bottom: $grid-gutter * 2;
     }
 
     .one-third:not(:last-child) {
-      margin-bottom: $grid-gutter;
       padding-bottom: $grid-gutter;
+      margin-bottom: $grid-gutter;
     }
   }
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -41,11 +41,11 @@ main {
   margin-top: 0.3rem;
 
   @media (max-width: 34em) {
-    margin-bottom: 1rem;
     display: block;
     float: none;
-    margin-left: auto;
     margin-right: auto;
+    margin-bottom: 1rem;
+    margin-left: auto;
   }
 }
 
@@ -56,12 +56,12 @@ main {
   font-size: 0.9rem;
 
   ul {
-    list-style-type: none;
     display: inline-block;
+    list-style-type: none;
 
     li {
-      float: left;
       display: block;
+      float: left;
       margin-left: 2rem;
 
       @media (max-width: 34em) {
@@ -82,8 +82,8 @@ main {
     color: rgba(255, 255, 255, 0.5);
 
     @media (max-width: 34em) {
-      margin-left: 1rem;
       margin-right: 1rem;
+      margin-left: 1rem;
     }
   }
 
@@ -92,11 +92,11 @@ main {
   }
 
   @media (max-width: 34em) {
+    width: 100%;
     padding-top: 1rem;
     margin-bottom: 0.8rem;
-    border-top: 0.075rem solid rgba(255, 255, 255, 0.25);
     text-align: center;
-    width: 100%;
+    border-top: 0.075rem solid rgba(255, 255, 255, 0.25);
   }
 }
 
@@ -112,8 +112,8 @@ main {
   }
 
   @media (max-width: 34em) {
-    padding-left: 1rem;
     padding-right: 1rem;
+    padding-left: 1rem;
 
     .btn {
       display: none;
@@ -182,12 +182,12 @@ main {
 }
 
 .site-content-heading {
+  padding-top: 0.3rem;
   margin-top: 0;
   margin-bottom: 0;
   font-size: 20px;
   font-weight: normal;
   color: #5d666f;
-  padding-top: 0.3rem;
 }
 
 .assignment-option-name {
@@ -207,9 +207,9 @@ main {
   display: inline-block;
   width: 45px;
   height: 45px;
+  margin-right: 0.7rem;
   text-align: center;
   border-radius: 50%;
-  margin-right: 0.7rem;
 
   .octicon {
     font-size: 22px;
@@ -229,13 +229,13 @@ main {
 
 .assignment-list-items {
   .assignment-list-item:not(:first-child) {
-    border-top: 1px solid #e3e3e3;
-    margin-top: 1rem;
     padding-top: 1rem;
+    margin-top: 1rem;
+    border-top: 1px solid #e3e3e3;
 
     @media (max-width: 34em) {
-      margin-top: 0.5rem;
       padding-top: 1rem;
+      margin-top: 0.5rem;
     }
   }
 
@@ -284,15 +284,15 @@ hr {
 }
 
 .dangerzone-container {
+  padding-bottom: 13px;
   border: 1px solid #e3e3e3;
   border-radius: 3px;
-  padding-bottom: 13px;
 }
 
 .invitation-content {
-  border-bottom: 1px solid #e3e3e3;
   padding-bottom: 2rem;
   margin-bottom: 2rem;
+  border-bottom: 1px solid #e3e3e3;
 
   @media (max-width: 34em) {
     padding-bottom: 1rem;
@@ -302,9 +302,9 @@ hr {
 
 .assignment-repo-list {
   .assignment-repo-list-item:not(:first-child) {
-    border-top: 1px solid #e3e3e3;
-    margin-top: 1rem;
     padding-top: 1rem;
+    margin-top: 1rem;
+    border-top: 1px solid #e3e3e3;
 
     @media (max-width: 34em) {
       margin-bottom: 0;
@@ -338,9 +338,9 @@ hr {
   }
 
   .student-login {
-    color: $brand-gray-dark;
     display: block;
     padding-top: 4px;
+    color: $brand-gray-dark;
 
     &:hover {
       color: $brand-blue;
@@ -350,9 +350,9 @@ hr {
 
 .group-assignment-repo-list {
   .group-assignment-repo-list-item:not(:first-child) {
-    border-top: 1px solid #e3e3e3;
-    margin-top: 1rem;
     padding-top: 1rem;
+    margin-top: 1rem;
+    border-top: 1px solid #e3e3e3;
   }
 }
 
@@ -378,8 +378,8 @@ hr {
   }
 
   .team-name {
-    color: $brand-gray-dark;
     display: block;
+    color: $brand-gray-dark;
 
     &:hover {
       color: $brand-blue;
@@ -401,13 +401,13 @@ hr {
 
 .organization-list-items {
   .organization-list-item:not(:first-child) {
-    border-top: 1px solid #e3e3e3;
-    margin-top: 2rem;
     padding-top: 2rem;
+    margin-top: 2rem;
+    border-top: 1px solid #e3e3e3;
 
     @media (max-width: 34em) {
-      margin-top: 1rem;
       padding-top: 1rem;
+      margin-top: 1rem;
     }
   }
 }
@@ -429,17 +429,17 @@ hr {
   }
 
   .organization-stats {
-    vertical-align: inherit;
+    padding-top: 0.5em;
     font-size: 14px;
     font-weight: bold;
-    padding-top: 0.5em;
+    vertical-align: inherit;
 
     .organization-stat-item {
       margin-right: 0.6em;
 
       .octicon {
-        font-size: 16px;
         margin-right: 4px;
+        font-size: 16px;
       }
     }
 
@@ -479,11 +479,11 @@ hr {
 }
 
 .signin-section {
-  background-color: #5fb27b;
   padding-top: 6.154em;
   padding-bottom: 6.154em;
-  color: #fff;
   margin-bottom: 3em;
+  color: #fff;
+  background-color: #5fb27b;
 
   .heading {
     font-size: 48px;
@@ -495,8 +495,8 @@ hr {
   }
 
   .subheading {
-    font-size: 21px;
     margin-bottom: 2rem;
+    font-size: 21px;
 
     @media (max-width: 34em) {
       font-size: 18px;
@@ -543,15 +543,15 @@ hr {
 }
 
 .organization-select-target {
+  float: left;
   padding: 10px;
   margin: 0 10px 20px;
+  font-weight: bold;
   text-align: center;
+  background-color: #f2f2f2;
+  background-image: none;
   border: 0;
   border-radius: 3px;
-  font-weight: bold;
-  background-image: none;
-  background-color: #f2f2f2;
-  float: left;
 
   &:hover,
   &:active,
@@ -563,8 +563,8 @@ hr {
   }
 
   &.disabled {
-    cursor: not-allowed;
     color: #999;
+    cursor: not-allowed;
 
     .organization-select-avatar {
       opacity: 0.3;
@@ -599,8 +599,8 @@ hr {
 }
 
 .classroom-user {
-  margin-top: 1rem;
   padding-top: 1rem;
+  margin-top: 1rem;
   font-size: 14px;
   border-top: 1px solid #e3e3e3;
 
@@ -635,9 +635,9 @@ hr {
   }
 
   .login {
-    color: $brand-gray-dark;
     display: block;
     padding-top: 4px;
+    color: $brand-gray-dark;
 
     &:hover {
       color: $brand-blue;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -461,7 +461,7 @@ hr {
 
   a {
     position: relative;
-    top: 1px;
+    top: 2px;
     color: #777;
     text-decoration: none;
     transition: 0.2s color ease-in 0;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -450,8 +450,24 @@ hr {
 }
 
 .site-footer {
-  margin-top: 1em;
-  margin-bottom: 1em;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  color: #777;
+}
+
+.made-with-heart {
+  margin-bottom: 0.3em;
+  font-size: 15px;
+
+  a {
+    position: relative;
+    top: 1px;
+    color: #777;
+    text-decoration: none;
+    transition: 0.2s color ease-in 0;
+
+    &:hover { color: #333; }
+  }
 }
 
 .desktop-invitation-content,

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -125,6 +125,7 @@ main {
   margin-bottom: 0;
   font-size: 2.2rem;
   font-weight: normal;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.15);
 
   a {
     color: inherit;
@@ -138,6 +139,7 @@ main {
 .organization-login {
   margin-top: 0.2rem;
   font-size: 1rem;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.15);
   opacity: 0.8;
 
   a {

--- a/app/views/organizations/_invite_users.html.erb
+++ b/app/views/organizations/_invite_users.html.erb
@@ -13,7 +13,7 @@
     <%= link_to organization_url(@organization), organization_url(@organization), class: 'mobile-invitation-content' %>
 
     <div class="columns desktop-invitation-content">
-      <div class="two-thirds column">
+      <div class="two-thirds">
         <div class="input-group">
           <%= content_tag :input, '', type: 'text', id: "organization-#{@organization.github_id}", value: organization_url(@organization), readonly: 'readonly' %>
           <span class="input-group-button">

--- a/app/views/organizations/new_assignment.html.erb
+++ b/app/views/organizations/new_assignment.html.erb
@@ -23,7 +23,7 @@
           <%= octicon('organization') %>
         </span>
         <h3 class="assignment-option-name">Group assignment</h3>
-        <p class="assignment-option-description">Participants form teams and each team works together on a shared repository.</p>
+        <p class="assignment-option-description">Participants form teams that work together on a shared repository.</p>
 
         <%= link_to new_organization_group_assignment_path(@organization), class: 'btn btn-green', role: 'button' do %>
           Create a group assignment

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,8 @@
 <footer class="site-footer text-center">
   <div class="container">
-    <%= link_to(image_tag('made_with_love@2x.png', height: 26, :class => 'made-by-logo', :alt => 'Made by GitHub Education'), 'https://education.github.com') %>
+    <div class="made-with-heart">
+      <span class="octicon octicon-mortar-board"></span> with <span class="octicon octicon-heart"></span> by <a href="https://education.github.com" class="octicon octicon-logo-github"></a>
+    </div>
   </div>
-  Classroom for GitHub is <%= link_to 'open source', 'https://github.com/education/classroom' %>
+  Classroom for GitHub is <%= link_to 'open source', 'https://github.com/education/classroom' %>.
 </footer>


### PR DESCRIPTION
While getting back up to speed in preparation to review the upcoming staff tools changes, I noticed a few minor unrelated design things I could clean up.

First, I updated the CSS rule ordering based on our existing, preferred order. I've added an `.scss-lint.yml` which includes this ordering.

I added a subtle drop shadow to the text in the heading to help it stand out better against the patterned backgrounds. This matches what we do on https://guides.github.com and https://github.com/explore.

**Before**

![screen shot 2015-12-09 at 12 33 35 pm](https://cloud.githubusercontent.com/assets/6104/11694812/14830f04-9e7a-11e5-88f3-57658a0ebaf2.png)

**After**

![screen shot 2015-12-09 at 12 33 11 pm](https://cloud.githubusercontent.com/assets/6104/11694815/1a39dd10-9e7a-11e5-9c2d-1af7d0383e5b.png)

I removed the indentation before this text field:

![screen shot 2015-12-09 at 1 04 08 pm](https://cloud.githubusercontent.com/assets/6104/11694832/2a731e9e-9e7a-11e5-8672-f180fb75412f.png)

Now:

![screen shot 2015-12-09 at 1 06 48 pm](https://cloud.githubusercontent.com/assets/6104/11694841/31477da0-9e7a-11e5-8f33-1e095f6a083f.png)

The longer group assignment description here makes this UI unbalanced. 

![screen shot 2015-12-09 at 1 29 57 pm](https://cloud.githubusercontent.com/assets/6104/11694975/dbd71316-9e7a-11e5-9aef-805d900bc276.png)

I'm proposing this change which I hope is still clear enough.

![screen shot 2015-12-09 at 1 30 53 pm](https://cloud.githubusercontent.com/assets/6104/11695040/32300e20-9e7b-11e5-87e3-99a9310ba118.png)

And finally, the current footer seems really ginormous.

![screen shot 2015-12-09 at 1 11 27 pm](https://cloud.githubusercontent.com/assets/6104/11695063/46e66468-9e7b-11e5-870f-2d46e52f8315.png)

I made this smaller to match our other sites (like [Octicons](https://octicons.github.com/)) and updated it to use Octicons + text rather than an image.

![screen shot 2015-12-09 at 1 26 56 pm](https://cloud.githubusercontent.com/assets/6104/11695108/724bfdca-9e7b-11e5-8956-159c4fb4da98.png)

/cc @tarebyte @johndbritton 