### PR TITLE
Make sure all organization routes on stafftools are by id only

### DIFF
--- a/app/views/stafftools/assignment_repos/show.html.erb
+++ b/app/views/stafftools/assignment_repos/show.html.erb
@@ -25,7 +25,7 @@
         </tr>
         <tr>
           <td class="text-emphasized">Owned by</td>
-          <td><%= link_to organization.title, stafftools_organization_path(organization) %></td>
+          <td><%= link_to organization.title, stafftools_organization_path(organization.id) %></td>
         </tr>
         <tr>
           <td class="text-emphasized">Created by</td>

--- a/app/views/stafftools/assignments/show.html.erb
+++ b/app/views/stafftools/assignments/show.html.erb
@@ -21,7 +21,7 @@
       <table>
         <tr>
           <td class="text-emphasized">Owned by</td>
-          <td><%= link_to organization.title, stafftools_organization_path(organization) %></td>
+          <td><%= link_to organization.title, stafftools_organization_path(organization.id) %></td>
         </tr>
         <tr>
           <td class="text-emphasized">Created by</td>

--- a/app/views/stafftools/group_assignment_repos/show.html.erb
+++ b/app/views/stafftools/group_assignment_repos/show.html.erb
@@ -25,7 +25,7 @@
         </tr>
         <tr>
           <td class="text-emphasized">Owned by</td>
-          <td><%= link_to organization.title, stafftools_organization_path(organization) %></td>
+          <td><%= link_to organization.title, stafftools_organization_path(organization.id) %></td>
         </tr>
         <tr>
           <td class="text-emphasized">Created by</td>

--- a/app/views/stafftools/group_assignments/show.html.erb
+++ b/app/views/stafftools/group_assignments/show.html.erb
@@ -21,7 +21,7 @@
       <table>
         <tr>
           <td class="text-emphasized">Owned by</td>
-          <td><%= link_to organization.title, stafftools_organization_path(organization) %></td>
+          <td><%= link_to organization.title, stafftools_organization_path(organization.id) %></td>
         </tr>
         <tr>
           <td class="text-emphasized">Created by</td>


### PR DESCRIPTION
Closes #403 for stafftools I set it up so that we do all routes by id instead of by slug.

I missed some of the paths when making all of the templates.

/cc @johndbritton 