### PR TITLE
Add users GitHub login to the impersonate modal

### DIFF
--- a/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
+++ b/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
@@ -15,7 +15,7 @@
 
   <%= form_tag impersonate_stafftools_user_path(user.id), 'data-name' => user.login do %>
     <dl class="form js-normalize-submit">
-      <dt>Please type the users GitHub login to confirm</dt>
+      <dt>Please type the users GitHub login <strong>(<%= user.login %>)</strong> to confirm</dt>
       <dd><input type="text" class="js-input-block"></dd>
     </dl>
 

--- a/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
+++ b/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
@@ -15,7 +15,7 @@
 
   <%= form_tag impersonate_stafftools_user_path(user.id), 'data-name' => user.login do %>
     <dl class="form js-normalize-submit">
-      <dt>Please type the users GitHub login <strong>(<%= user.login %>)</strong> to confirm</dt>
+      <dt>Please type the user's GitHub login <strong>(<%= user.login %>)</strong> to confirm</dt>
       <dd><input type="text" class="js-input-block"></dd>
     </dl>
 


### PR DESCRIPTION
The modal wasn't really clear.

This is what it looks like now

![screen shot 2015-12-17 at 4 12 59 pm](https://cloud.githubusercontent.com/assets/564113/11882179/1088a584-a4d9-11e5-9241-209f898368fc.png)