### PR TITLE
Add message of the day banner to top of the page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,15 +191,15 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.1)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
     newrelic_rpm (3.13.1.300)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -444,4 +444,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ENV Variable | Description |
 `CANONICAL_HOST` | the preferred hostname for the application, if set requests served on other hostnames will be redirected
 `GOOGLE_ANALYTICS_TRACKING_ID` | identifier for Google Analytics in the format `UA-.*`
 `PINGLISH_ENABLED` | Enable the `/_ping` endpoint with relevant health checks
+`MOTD` | Show the message of the day banner at the top of the site
 
 ### Development environment variables
 These values must be present in your `.env` file (created by `script/setup`).

--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -1,9 +1,9 @@
 .message-of-the-day {
-  background-color: #246;
+  background-color: $brand-blue;
   color: #fff;
 
   a {
-    color: #d0a155;
+    color: #58d984;
     font-weight: bold;
   }
 }

--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -3,7 +3,7 @@
   color: #fff;
 
   a {
-    color: #D0A155;
+    color: #d0a155;
     font-weight: bold;
   }
 }

--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -1,0 +1,9 @@
+.message-of-the-day {
+  background-color: #246;
+  color: #fff;
+
+  a {
+    color: #D0A155;
+    font-weight: bold;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <div class="loading-indicator" style="display: none;"></div>
 
     <%= render 'peek/bar' %>
+    <%= render 'shared/message_of_the_day' %>
     <%= render 'shared/header' %>
 
     <main>

--- a/app/views/layouts/invitations.html.erb
+++ b/app/views/layouts/invitations.html.erb
@@ -15,6 +15,7 @@
   <body class="<%= controller_name %> <%= action_name %>">
     <div class="loading-indicator" style="display: none;"></div>
 
+    <%= render 'shared/message_of_the_day' %>
     <%= render 'shared/invitation_header' %>
 
     <%= yield :organization_invitation_banner %>

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -15,6 +15,7 @@
   <body class="site <%= controller_name %> <%= action_name %>">
 
     <main>
+      <%= render 'shared/message_of_the_day' %>
       <%= render 'shared/header' %>
       <%= yield %>
     </main>

--- a/app/views/shared/_message_of_the_day.html.erb
+++ b/app/views/shared/_message_of_the_day.html.erb
@@ -1,0 +1,7 @@
+<% if ENV['MOTD'].present? %>
+  <div class="message-of-the-day">
+    <div class="container">
+      <p><%= ENV['MOTD'].html_safe %></p>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
From @johndbritton's request by setting the `MOTD` on the server environment variable we can show a special banner at the top of all pages.

This is what it looks like right now

<img width="1440" alt="screen shot 2016-01-07 at 12 14 37 pm" src="https://cloud.githubusercontent.com/assets/564113/12177215/046547b0-b539-11e5-84c9-e7fe2c310240.png">

/cc @jasonlong because I'm sure there's a better color combination that works here, your help would be much appreciated.