### PR TITLE
Set Chewy to log level info

### DIFF
--- a/config/chewy.rb
+++ b/config/chewy.rb
@@ -1,4 +1,5 @@
-Chewy.logger = Rails.logger
+Chewy.logger = Logger.new(STDOUT)
+Chewy.logger.level = Logger::INFO
 
 # Use ActiveJob config for async index updates.
 Chewy.strategy(:active_job)


### PR DESCRIPTION
Our logs are full of Chewy debug info, this will reduce the noise.