### PR TITLE
Cache bundler to speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
 
 bundler_args: --without development production --deployment --jobs=3 --retry=3
 
+cache: bundler
+
 notifications:
   email: false
 


### PR DESCRIPTION
Caching bundler will speed up your travis builds (mine dropped from 2:30 to about 1:00).

More info can be found [here](https://docs.travis-ci.com/user/caching).

Small note: in their docs it says that it is only available for private repos; however, in my public repos it works well.