### PR TITLE
"Create New" tile to link to organization creation page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -597,6 +597,24 @@ hr {
   margin-bottom: 9px;
 }
 
+.organization-select-avatar-mega-octicon {
+  display: block;
+  padding: 15px 18px;
+  color: $brand-gray;
+
+  .mega-octicon {
+    font-size: 64px;
+  }
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+.organization-new {
+  width: 100px;
+}
+
 .search-results {
   margin-top: 2em;
 }

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -4,17 +4,12 @@
   </div>
 
   <div class="site-content-body">
-    <% if @users_github_organizations.empty? %>
-      <div class="blankslate large-format spacious clean-background">
-        <h3>Oh, you don’t have any organizations on your GitHub account.</h3>
 
-        <p>Please <a href="https://github.com/organizations/new">create an organization on GitHub.com</a> and then come back.</p>
-      </div>
-    <% else %>
-      <%= form_for @organization do |f| %>
-        <%= render 'shared/error_messages', object: f.object %>
+    <%= form_for @organization do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
 
-        <div class="org-select-grid">
+      <div class="org-select-grid">
+        <% if @users_github_organizations %>
           <% @users_github_organizations.each do |org| %>
             <% if org[:role] == 'admin' && !org[:classroom].present? %>
               <%= render partial: 'organization_select', locals: { org: org } %>
@@ -22,9 +17,17 @@
               <%= render partial: 'disabled_organization_select', locals: { org: org } %>
             <% end %>
           <% end %>
-          <div style="clear:both"></div>
-        </div>
-      <% end %>
+        <% end %>
+
+        <a class="organization-select-target" href="https://github.com/organizations/new" target="_blank">
+          <div class="avatar organization-select-avatar-mega-octicon">
+            <div class="mega-octicon octicon-organization"></div>
+          </div>
+          <div class="organization-new">Create new organization</div>
+        </a>
+
+        <div style="clear:both"></div>
+      </div>
     <% end %>
 
     <%= render partial: 'shared/pagination', locals: { collection: @users_github_organizations } %>


### PR DESCRIPTION
I noticed that if you have a GitHub account that belongs to at least one organization that you don't have admin access to, this is what you would see:

![what now?](http://i.imgur.com/uB8wuWm.png)

There's no CTA at this point, and if you were not super familiar with GitHub or how to create a new organization, then it would be slightly confusing.

This PR is to create a new tile for creating a new organization, a link that opens in a new window. 

This is what it would look like:

![create new link](http://i.imgur.com/kicpxGc.png) 

I realize that the PR is very rough (the `src` for the image is an imgur link, the html that I added is not in a partial, etc) but I thought opening this PR would be a good start to discussing and learning more about this particular codebase's conventions.

Please let me know of any comments, suggestions or violent reactions :D Thank you!
