### PR TITLE
Fixed undefined behavior on re-accepting an invitation link of a deleted repo

### DIFF
--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -6,9 +6,11 @@ class AssignmentInvitationsController < ApplicationController
   def accept_invitation
     users_assignment_repo = invitation.redeem_for(current_user)
 
-    if users_assignment_repo.present?
+    if users_assignment_repo.present? && decorated_assignment_repo.github_url != "#"
       redirect_to successful_invitation_assignment_invitation_path
-    else
+    elsif decorated_assignment_repo.github_url == "#"
+      redirect_to unsuccessful_invitation_assignment_invitation_path
+    else 
       flash[:error] = 'An error has occured, please refresh the page and try again.'
       redirect_to :show
     end

--- a/app/views/assignment_invitations/unsuccessful_invitation.html.erb
+++ b/app/views/assignment_invitations/unsuccessful_invitation.html.erb
@@ -1,0 +1,18 @@
+<%= render 'organizations/organization_invitation_banner' %>
+
+<div class="site-content">
+  <div class="site-content-cap">
+    <h2 class="site-content-heading">
+      <span class="assignment-icon assignment-icon-individual">
+        <%= octicon('person') %>
+      </span>
+      Cannot accept the <strong><%= assignment.title %></strong> assignment
+    </h2>
+  </div>
+</div>
+
+<div class="site-content-body">
+  <div class="markdown-body">
+    <p> This repository no longer exists. It must have been deleted. Contact the instructor for more details. </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     member do
       patch :accept_invitation
       get   :successful_invitation, path: :success
-      get   :unsuccessful_invitation
+      get   :unsuccessful_invitation, path: :success
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     member do
       patch :accept_invitation
       get   :successful_invitation, path: :success
+      get   :unsuccessful_invitation
     end
   end
 


### PR DESCRIPTION
If a repo is deleted and the student uses the invitation link again it results in an undefined behavior. This has been fixed by showing that repo has been deleted.