### PR TITLE
Make the bootstrapping for Classroom easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dump.rdb
 
 # RubyMine
 /.idea
+
+# Nginx
+config/dev/nginx.conf

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,11 @@
+# Helpers
+tap "homebrew/versions"
+tap "github/bootstrap"
+
+brew "nodejs"
+
+brew "elasticsearch17", restart_service: :changed
+brew "memcached",       restart_service: :changed
+brew "nginx",           restart_service: :changed
+brew "postgresql",      restart_service: :changed
+brew "redis",           restart_service: :changed

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,8 +1,8 @@
-# Start development mode executables. Assumes that postgresql is already
-# running. 'script/server' should be run in a separate terminal.
-#
-#   Run this file by executing: 'script/workers'
+# Start development mode executables.
+# This assumes the postgresql is already running
 
+web: bundle exec puma -C config/puma.rb > /dev/null 2>&1
+rails: tail -f log/development.log
 redis: redis-server
 memcached: memcached
 worker: bundle exec sidekiq -q chewy -q trash_can

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rbenv global 2.3.0
 ```
 
 Next, you'll need to make sure that you have Nodejs, PostgreSQL, Redis, Memcached, and Elasticsearch installed. This can be done easily :
-* For OSX using [Homebrew](http://brew.sh) : `brew install nodejs postgresql redis memcached elasticsearch`
+* For OSX using [Homebrew](http://brew.sh) : You don't have to do anything! When you run `script/setup` later on this will be taken care of for you.
 * For Linux : `apt-get install nodejs postgresql redis-server memcached`. For Elasticsearch, follow the instructions on [their website](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html).
 
 You will want to set PostgreSQL to autostart at login via launchctl, if not already. See `brew info postgresql`. Redis and memcached may be setup similarly via launchctl or setup project wide by using foreman, described below.
@@ -101,7 +101,7 @@ After that, you may start the rails server in a separate terminal with:
 script/server
 ```
 
-And that's it! You should have a working instance of Classroom for GitHub located [here](http://localhost:3000)
+And that's it! You should have a working instance of Classroom for GitHub located [here](http://localhost:5000)
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,7 @@ ENV Variable | Description |
 
 ### Running the application
 
-Foreman is setup to manage redis, memcached, sidekiq, and elasticsearch in development mode. Postgresql must be running prior executing foreman. It assumes that redis, memcached, and elasticsearch are not already running on the system. Alternatively, you may run `script/sidekiq`, if you have to have redis, memcached, and elasticsearch always running system wide. To execute foreman, and this application's dependencies, run:
-
-```bash
-script/workers
-```
+Foreman is setup to manage redis, memcached, sidekiq, and elasticsearch in development mode. Postgresql must be running prior executing foreman.
 
 After that, you may start the rails server in a separate terminal with:
 

--- a/config/dev/nginx.conf.erb
+++ b/config/dev/nginx.conf.erb
@@ -1,0 +1,25 @@
+upstream <%= name %> {
+ server 127.0.0.1:5000;
+}
+
+server {
+  access_log <%= root %>/log/<%= name %>.access.log;
+  listen 8080;
+  listen [::]:8080;
+
+  root <%= root %>/public;
+  server_name <%= name %>.dev ~^<%= name %>\.dev\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+
+  location / {
+    proxy_read_timeout 300;
+    proxy_connect_timeout   300;
+    proxy_redirect off;
+
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Frame-Options   SAMEORIGIN;
+    proxy_pass http://<%= name %>;
+  }
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,5 +7,11 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+if [ "$(uname -s)" = "Darwin" ]; then
+  echo "==> Bootstrapping Homebrew OSX environment"
+  brew update >/dev/null
+  brew bundle check &>/dev/null || brew bundle
+fi
+
 echo "==> Installing gem dependencies…"
 bundle install --without production

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,10 +1,8 @@
 #!/bin/sh
-
-# script/bootstrap: Resolve all dependencies that the application requires to
-#                   run.
+# Usage: script/boostrap
+# Ensures all dependencies are installed locally.
 
 set -e
-
 cd "$(dirname "$0")/.."
 
 if [ "$(uname -s)" = "Darwin" ]; then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,6 +9,8 @@ if [ "$(uname -s)" = "Darwin" ]; then
   echo "==> Bootstrapping Homebrew OSX environment"
   brew update >/dev/null
   brew bundle check &>/dev/null || brew bundle
+
+  brew setup-nginx-conf classroom . config/dev/nginx.conf.erb
 fi
 
 echo "==> Installing gem dependencies…"

--- a/script/server
+++ b/script/server
@@ -14,4 +14,4 @@ test -z "$RACK_ENV" &&
   RACK_ENV='development'
 
 # boot the app and any other necessary processes.
-bundle exec rails server
+bundle exec foreman start -f Procfile.dev

--- a/script/workers
+++ b/script/workers
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# script/workers: Run required executables and sidekiq using foreman
-
-set -e
-
-cd "$(dirname "$0")/.."
-
-bundle exec foreman start -f Procfile.dev


### PR DESCRIPTION
This adds some nice things for running Classroom.

* For OSX users with Homebrew
  * No longer have to run `brew install`
  * Can now access `http://classroom.dev` instead of localhost
* For all users
  * No longer have to open separate windows for the server and for workers.

/cc @johndbritton @mkcode 