### PR TITLE
Add vim projections to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dump.rdb
 
 # RubyMine
 /.idea
+
+# Vim Projections
+config/projections.json


### PR DESCRIPTION
I'm a pretty big vim nerd and I keep my extra configs under the `config` folder for vim rails.

This ignores it for the project.