### PR TITLE
Add classroom link to stafftools page

### DIFF
--- a/app/views/stafftools/organizations/show.html.erb
+++ b/app/views/stafftools/organizations/show.html.erb
@@ -17,6 +17,10 @@
     <div class="boxed-group-inner">
       <table>
         <tr>
+          <td class="text-emphasized">Classroom</td>
+          <td><%= link_to organization_url(organization), organization_url(organization) %></td>
+        </tr>
+        <tr>
           <td class="text-emphasized">GitHub</td>
           <td><%= link_to organization.github_url, organization.github_url %></td>
         </tr>


### PR DESCRIPTION
![screen shot 2016-03-07 at 7 48 17 pm](https://cloud.githubusercontent.com/assets/564113/13588423/95748d4a-e49d-11e5-9ea6-68a3d034aca9.png)

This adds a link to the Classroom URL.

/cc @johndbritton 