### PR TITLE
Request more, but not less scopes than we have for the user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,13 +34,17 @@ class ApplicationController < ActionController::Base
     required_scopes.all? { |scope| current_scopes.include?(scope) }
   end
 
+  def request_scopes
+    required_scopes | current_scopes
+  end
+
   def authenticate_user!
     auth_redirect unless logged_in? && adequate_scopes?
   end
 
   def auth_redirect
     session[:pre_login_destination] = "#{request.base_url}#{request.path}"
-    session[:required_scopes] = required_scopes.join(',')
+    session[:required_scopes] = request_scopes.join(',')
     redirect_to login_path
   end
 


### PR DESCRIPTION
This adds a new method `ApplicationController#request_scopes` which makes it so that we request more scopes when necessary, but if we need fewer scopes for a given action we don't ask GitHub to reduce the scopes for the user token.

@mastahyeti for a quick once over.

Fixes #460