### PR TITLE
Remove N+1 from organizations

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -10,7 +10,7 @@ class OrganizationsController < ApplicationController
   decorates_assigned :organization
 
   def index
-    @organizations = current_user.organizations.page(params[:page])
+    @organizations = current_user.organizations.includes(:users).page(params[:page])
   end
 
   def new


### PR DESCRIPTION
Looking at my local bullet log I realized that we weren't including the `users` when we loaded the organizations on the index page.

Since we request a `github_client` from one of the users we were making more queries than we needed.

/cc @johndbritton  