### PR TITLE
Make sure that we are getting the AssignmentRepos user for indexing

### DIFF
--- a/app/chewy/stafftools_index.rb
+++ b/app/chewy/stafftools_index.rb
@@ -40,7 +40,7 @@ class StafftoolsIndex < Chewy::Index
     field :assignment_title, value: ->(assignment_invitation) { assignment_invitation.assignment.title }
 
     field :user_login, value: (lambda do |assignment_repo|
-      user = assignment_repo.user
+      user = assignment_repo.user || assignment_repo.repo_access.user
 
       begin
         begin


### PR DESCRIPTION
There are quite a few models that didn't transition from using `RepoAccess` for `AssignmentRepo` therefore when we reran the index it would fail because we weren't actually grabbing the user and therefore the `github_client` was not present.

I deployed this to branch to production, and the reindexing of Classroom was successful.

/cc @johndbritton 