### PR TITLE
Fix double flashes in `group_assignment_invitations/accept.html.erb`

### DIFF
--- a/app/views/group_assignment_invitations/accept.html.erb
+++ b/app/views/group_assignment_invitations/accept.html.erb
@@ -12,8 +12,6 @@
 </div>
 
 <div class="site-content-body">
-  <%= render 'shared/flash_messages' %>
-
   <%= form_tag({ controller: :group_assignment_invitations, action: :accept_assignment}, method: :patch) do %>
     <div class="markdown-body">
       <p>Accepting this assignment will give your team (<%= decorated_group.name %>) access to the <strong><%= "#{group_assignment.slug}-#{decorated_group.slug}" %></strong> repository in the <%= link_to "@#{decorated_organization.login}", decorated_organization.github_url %> organization on GitHub.</p>
@@ -24,4 +22,3 @@
     </div>
   <% end %>
 </div>
-


### PR DESCRIPTION
While trying to reproduce #319, I found that `group_assignment_invitations/accept.html.erb` would render 2 flash messages :zap: :zap: when the repo name already exists.

![double_flash](https://cloud.githubusercontent.com/assets/1046917/14048948/b54ca384-f2ec-11e5-99e6-070071961348.png)

The extra flash message (the lower one) is removed in the PR.