### PR TITLE
Added Elasticsearch status to ``GET /_ping``

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,11 @@ module Classroom
           Sidekiq.redis { |redis| redis.ping }
           'ok'
         end
+
+        ping.check :elasticsearch do
+          Chewy.client.cluster.health["status"] == "green"
+          'ok'
+        end
       end
     end
   end


### PR DESCRIPTION
We use Chewy for Elasticsearch, checking health of cluster tells us
Elasticsearch's status. i.e. ``Chewy.client.cluster.health["status"] == "green"``

Fixes #424