### PR TITLE
Make `_ping` for `elasticsearch` to actually report the status.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,7 @@ module Classroom
         end
 
         ping.check :elasticsearch do
-          Chewy.client.cluster.health["status"] == "green"
+          raise unless Chewy.client.cluster.health['status'] == 'green'
           'ok'
         end
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,12 @@ module Classroom
         end
 
         ping.check :elasticsearch do
-          Chewy.client.cluster.health['status'] == 'green' ? 'ok' : false  
+          status = Chewy.client.cluster.health['status'] || 'unavailable'
+          if status == 'green'
+            'ok'
+          else
+            raise "Elasticsearch status is #{status}"
+          end
         end
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,8 +66,7 @@ module Classroom
         end
 
         ping.check :elasticsearch do
-          raise unless Chewy.client.cluster.health['status'] == 'green'
-          'ok'
+          Chewy.client.cluster.health['status'] == 'green' ? 'ok' : false  
         end
       end
     end


### PR DESCRIPTION
Hey guys,

Thanks to @sahilshekhawat for #523 that added the ability to check the status of `elasticsearch`.

I've tried this locally but I found that it does not report the status correctly when my `elasticsearch` cluster is having `yellow` or `red` as its status.

This PR fixes the issue described above.