### PR TITLE
Use group id for finding the group in invitations

### DIFF
--- a/app/views/group_assignment_invitations/_group_assignment_team.erb
+++ b/app/views/group_assignment_invitations/_group_assignment_team.erb
@@ -4,7 +4,7 @@
   <div class="team-panel">
     <% group_member_count = group_assignment_repo.group.repo_accesses.count %>
     <%= form_tag({ controller: :group_assignment_invitations, action: :accept_invitation}, :class => "team-actions-form", method: :patch) do %>
-        <%= hidden_field_tag 'group[id]', group_assignment_repo.id %>
+        <%= hidden_field_tag 'group[id]', group.id %>
         <% if group_assignment.max_members.present? && group_member_count >= group_assignment.max_members %>
             <%= submit_tag 'Full', class: 'btn', disabled: true %>
         <% else %>

--- a/app/views/group_assignment_invitations/_group_assignment_team.erb
+++ b/app/views/group_assignment_invitations/_group_assignment_team.erb
@@ -4,12 +4,12 @@
   <div class="team-panel">
     <% group_member_count = group_assignment_repo.group.repo_accesses.count %>
     <%= form_tag({ controller: :group_assignment_invitations, action: :accept_invitation}, :class => "team-actions-form", method: :patch) do %>
-        <%= hidden_field_tag 'group[id]', group.id %>
-        <% if group_assignment.max_members.present? && group_member_count >= group_assignment.max_members %>
-            <%= submit_tag 'Full', class: 'btn', disabled: true %>
-        <% else %>
-            <%= submit_tag 'Join', class: 'btn' %>
-        <% end %>
+      <%= hidden_field_tag 'group[id]', group_assignment_repo.group.id %>
+      <% if group_assignment.max_members.present? && group_member_count >= group_assignment.max_members %>
+        <%= submit_tag 'Full', class: 'btn', disabled: true %>
+      <% else %>
+        <%= submit_tag 'Join', class: 'btn' %>
+      <% end %>
     <% end %>
 
     <span class="team-name" itemprop="name"><%= group_assignment_repo.team_name %></span>


### PR DESCRIPTION
This closes #535 

When trying to find a group to join it was trying to find the group using the group assignment repo id.

/cc @johndbritton @dinever 