### PR TITLE
fix subtle exit status bug

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -19,7 +19,9 @@ if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
   # time. Or things needed to be run to to reset the application back to first
   # use experience. These things are scoped to the application's domain.
 
-  cp -n .env-example .env
+  if ! [ -r ".env" ]; then
+      cp .env-example .env
+  fi
 fi
 
 echo "==> Your app is almost ready! Please make sure you fill out your .env file."


### PR DESCRIPTION
@tarebyte - after copying your script/setup contents I ran across a subtle bug that exists in classroom's code as well.

The `cp -n` returns non-zero status when the file already exists, which breaks out of the script because we have the '-e' parameter set.

You can verify this exists with: 

`cp -n .env-example .env; echo $?`

Cheers