### PR TITLE
set Rack::Timeout logger to warn

### DIFF
--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,1 +1,6 @@
 Rack::Timeout.timeout = 25
+
+# Rack::Timeout::Logger in info mode is very noisy. Setting to WARN so that
+# Rack::Timeout request timing info is not logged for every request.
+Rack::Timeout::Logger.logger = Rails.logger
+Rack::Timeout::Logger.level = Logger::Severity::WARN


### PR DESCRIPTION
Rack::Timeout logging in info mode is way too noisy. After this change, we will only get logs like the following when a request exceeds the timeout:

```
17:54:10 rails.1         | Rack::Timeout::RequestTimeoutException - Request ran for longer than 25000ms:
17:54:10 rails.1         |   app/controllers/pages_controller.rb:7:in `home'
17:54:10 rails.1         |   actionpack (4.2.6) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
17:54:10 rails.1         |   actionpack (4.2.6) lib/abstract_controller/base.rb:198:in `process_action'
17:54:10 rails.1         |   actionpack (4.2.6) lib/action_controller/metal/rendering.rb:10:in `process_action'
17:54:10 rails.1         |   actionpack (4.2.6) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
17:54:10 rails.1         |   activesupport (4.2.6) lib/active_support/callbacks.rb:117:in `call'
...
```