### PR TITLE
Fix loading indicator positioning.

### DIFF
--- a/app/assets/javascripts/navigation.coffee
+++ b/app/assets/javascripts/navigation.coffee
@@ -10,7 +10,12 @@ is_new_window_or_tab_event = (event) ->
 ready = ->
   $('.js-navigation').on('click', (event) ->
     return if is_new_window_or_tab_event(event)
-    $('.loading-indicator').show())
+    $('.loading-indicator').show()
+
+    $('body').addClass('no-scroll')
+    # disable mobile scrolling event
+    $('body').on('touchmove', (e) -> e.preventDefault())
+  )
 
 $(document).ready(ready)
 $(document).on('page:load', ready)

--- a/app/assets/stylesheets/components/loading-indicator.scss
+++ b/app/assets/stylesheets/components/loading-indicator.scss
@@ -1,6 +1,6 @@
 .loading-indicator {
   &::after {
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     bottom: 0;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -680,3 +680,8 @@ hr {
     vertical-align: top;
   }
 }
+
+.no-scroll {
+  height: 100%;
+  overflow: hidden;
+}


### PR DESCRIPTION
Hello guys,

Here's another minor UI tweak.

**Problem:**
When clicking a button located at the lower part of a long page, the loading indicator will not be placed at the right place.

![5711071b61f44133576366](https://cloud.githubusercontent.com/assets/1046917/14566827/c1f901ea-0363-11e6-8e5a-03d2b7f993d3.gif)

**About this PR:**
1. Make loading indicator spans the whole viewport.
2. Disable scrolling when loading indicator is shown.

**Result**

![2016-04-15 23_35_49](https://cloud.githubusercontent.com/assets/1046917/14567747/26a2008e-0368-11e6-90dd-3cb4d922b30d.gif)
