### PR TITLE
Remove staff access to organization pages

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -76,7 +76,7 @@ class OrganizationsController < ApplicationController
   private
 
   def authorize_organization_access
-    return if @organization.users.include?(current_user) || current_user.staff?
+    return if @organization.users.include?(current_user)
 
     begin
       github_organization.admin?(decorated_current_user.login) ? @organization.users << current_user : not_found

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -75,16 +75,6 @@ class OrganizationsController < ApplicationController
 
   private
 
-  def authorize_organization_access
-    return if @organization.users.include?(current_user)
-
-    begin
-      github_organization.admin?(decorated_current_user.login) ? @organization.users << current_user : not_found
-    rescue
-      not_found
-    end
-  end
-
   def authorize_organization_addition
     new_github_organization = github_organization_from_params
 


### PR DESCRIPTION
This removes the ability for users with `#staff? == true` to access organization pages that they're not an admin of.

Previously, this was required for debugging. It's unnecessary now since we have an impersonation feature for staff.

I also noticed that this code is duplicated in `OrganizationAuthorization`.

I'm good with just removing this for consistency, but if you want to remove the duplication I'm for it @tarebyte.