### PR TITLE
Disable rack timeout in devopment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'pg'
 gem 'puma'
 
 gem 'rack-canonical-host'
-gem 'rack-timeout'
+gem 'rack-timeout', require: false
 gem 'redis-namespace'
 
 gem 'sprockets'

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,6 +1,14 @@
-Rack::Timeout.timeout = 25
+# The rack-timeout gem inserts itself into the Rails middleware automatically
+# upon requiring. We wait to require it until here so that we may skip using it
+# in the development and test environments.
+unless Rails.env.test? || Rails.env.development?
+  require 'rack-attack'
 
-# Rack::Timeout::Logger in info mode is very noisy. Setting to WARN so that
-# Rack::Timeout request timing info is not logged for every request.
-Rack::Timeout::Logger.logger = Rails.logger
-Rack::Timeout::Logger.level = Logger::Severity::WARN
+  # Raise an error when the request time exceeds 25 seconds.
+  Rack::Timeout.timeout = 25
+
+  # Rack::Timeout::Logger in info mode is very noisy. Setting to WARN so that
+  # Rack::Timeout request timing info is not logged for every request.
+  Rack::Timeout::Logger.logger = Rails.logger
+  Rack::Timeout::Logger.level = Logger::Severity::WARN
+end


### PR DESCRIPTION
Rack timeout can get rather annoying while debugging in development mode. This PR disables rack-timeout in development mode.