### PR TITLE
Replace `:stub` with new RSpec syntax 

### DIFF
--- a/spec/models/assignment_repo_spec.rb
+++ b/spec/models/assignment_repo_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe AssignmentRepo, type: :model do
 
           before do
             github_organization.create_repository(long_repo_name, private: true, description: 'Nothing here')
-            new_assignment_repo.stub(:base_name).and_return(long_repo_name)
+            allow(new_assignment_repo).to receive(:base_name).and_return(long_repo_name)
           end
 
           it 'truncates the repository name into 100 characters' do


### PR DESCRIPTION
There's a deprecation warning when running tests:

```
Deprecation Warnings:
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /home/travis/build/education/classroom/spec/models/assignment_repo_spec.rb:110:in `block (6 levels) in <top (required)>'.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```

Looks like the `stub` method is deprecated. 

New syntax is adopted to fix this warning.