### PR TITLE
Fix Array values warning

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
Discussed here: https://github.com/rubygems/rubygems/issues/1551

I was this warning
```
Array values in the parameter to `Gem.paths=` are deprecated.
Please use a String or nil.
An Array ({"GEM_PATH"=>["/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0", "/Users/tarebyte/.gem/ruby/2.3.0"]}) was passed in from bin/rake:3:in `load'
Running via Spring preloader in process 23479
```