### PR TITLE
Prevent Javascript event callbacks from firing multiple times

### DIFF
--- a/app/assets/javascripts/navigation.coffee
+++ b/app/assets/javascripts/navigation.coffee
@@ -13,4 +13,3 @@ ready = ->
     $('.loading-indicator').show())
 
 $(document).ready(ready)
-$(document).on('page:load', ready)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,6 @@
 
     <%= render 'shared/footer' %>
 
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true, 'data-turbolinks-eval' => false %>
   </body>
 </html>


### PR DESCRIPTION
Summary of changes:
- set `data-turbolinks-eval` to `false` in `javascript_include_tag 'application'` of `application.html.erb`
- remove `page:load` binding in `navigation.coffee`

Closes #607 