### PR TITLE
Move pry out of development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,9 @@ gem 'peek-git'
 gem 'peek-performance_bar'
 gem 'peek-pg'
 gem 'peek-sidekiq', github: 'Soliah/peek-sidekiq', ref: '261c857578ae6dc189506a35194785a4db51e54c'
-
 gem 'pg'
+gem 'pry-rails'
+gem 'pry-byebug'
 gem 'puma'
 
 gem 'rack-canonical-host'
@@ -63,8 +64,6 @@ group :development, :test do
   gem 'bullet'
   gem 'dotenv-rails'
   gem 'guard-rspec', require: false
-  gem 'pry-rails'
-  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rubocop',   require: false
   gem 'scss_lint', require: false

--- a/config/initializers/pry.rb
+++ b/config/initializers/pry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Show red environment name in pry prompt for non development environments
+unless Rails.env.development?
+  old_prompt = Pry.config.prompt
+  env = Pry::Helpers::Text.red(Rails.env.upcase)
+  Pry.config.prompt = [
+    proc { |*a| "#{env} #{old_prompt.first.call(*a)}"  },
+    proc { |*a| "#{env} #{old_prompt.second.call(*a)}" }
+  ]
+end


### PR DESCRIPTION
I'd really like to have Pry in the Heroku rails console. This PR moves pry out of the development group and into the normal gemset.