### PR TITLE
Fix redis for flipper

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
     },
 
     "REDIS_PROVIDER": {
-      "value": "REDISTOGO_URL"
+      "value": "REDIS_URL"
     },
 
     "NON_STAFF_GITHUB_ADMIN_IDS": {
@@ -43,8 +43,8 @@
   "addons": [
     "bonsai",
     "heroku-postgresql",
+    "heroku-redis",
     "memcachedcloud",
-    "newrelic",
-    "redistogo"
+    "newrelic"
   ]
 }

--- a/config/initializers/01_redis.rb
+++ b/config/initializers/01_redis.rb
@@ -1,5 +1,5 @@
 module Classroom
-  REDIS_URL = ENV['REDISTOGO_URL'] || 'redis://localhost:6379/0'
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def self.redis
     @redis ||= Redis.new(url: REDIS_URL)


### PR DESCRIPTION
Fixes: https://github-education.airbrake.io/projects/116727/groups/1731215870832639699

When we moved over 🔪 redis to go, I forgot to fix the internal configuration for Flipper.

This also updates the `app.json` file so people don't have to suffer using redis to go like we did.