### PR TITLE
Downgrade turbolinks to last known version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'sidekiq', '~> 4.1.0'
 gem 'sinatra'
 gem 'octicons_helper', github: 'primer/octicons_helper', ref: 'fa28cb06c67ce0a1974a9e3238483d79157503c2'
 
-gem 'turbolinks'
+gem 'turbolinks', '~> 2.5.3'
 
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,9 +383,8 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
+    turbolinks (2.5.3)
+      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.1)
@@ -462,7 +461,7 @@ DEPENDENCIES
   spring
   sprockets
   terminal-notifier-guard
-  turbolinks
+  turbolinks (~> 2.5.3)
   uglifier (>= 1.3.0)
   vcr
   webmock


### PR DESCRIPTION
I updated turbolinks to v5 in https://github.com/education/classroom/pull/692

I'm reverting it back down to the original version we had https://github.com/education/classroom/pull/692/files#diff-e79a60dc6b85309ae70a6ea8261eaf95L385