### PR TITLE
Team management style update

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -653,9 +653,8 @@ hr {
   }
 }
 
-.team-grid {
 
-  margin-top: 1rem;
+.team-grid {
 
   .team-left {
     float: left;
@@ -667,95 +666,54 @@ hr {
     padding-left: 5px;
   }
 
-  .team-panel {
-    position: relative;
-    margin-right: 10px;
-    margin-bottom: 20px;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 3px;
-
-    .team-actions-form {
-      float: right;
-    }
-
-    .team-name {
-      margin-right: 3px;
-      font-size: 1rem;
-      font-weight: bold;
-    }
-
-    .team-info {
-      padding: 10px 15px 5px;
-      background-color: #f8f8f8;
-
-      .btn {
-        margin: -4px -8px 0 0;
-      }
-
-      .team-description {
-        line-height: 0;
-        color: #777;
-      }
-    }
-
-    .team-members {
-      padding: 10px 15px 5px;
-      list-style-type: none;
-      border-top: 1px solid #eee;
-      border-radius: 0 0 3px 3px;
-
-      a.student-avatar {
-        display: inline-block;
-        width: 40px;
-        height: 40px;
-        vertical-align: top;
-      }
-
-      .member {
-        overflow: hidden;
-      }
-
-      .member:not(:first-child) {
-        margin-top: 10px;
-      }
-    }
+  .team {
+    padding-right: 10px;
   }
 }
 
+.team-description {
+  font-size: 13px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 0;
+  color: #777;
+}
+
 .team-members {
+  padding: 5px 0 0;
+
   .team-member:not(:first-child) {
     margin-top: 10px;
   }
 }
 
-.member-list-draggable {
+.member-list {
   min-height: 35px;
-}
 
-.member-draggable {
-  display: inline-block;
-  width: 30px;
-  height: 30px;
-  margin: 0 5px 5px 0;
+  .member {
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    margin: 0 5px 5px 0;
 
-  a {
+    .avatar {
+      vertical-align: baseline;
+    }
+  }
+
+  .member-draggable a {
     cursor: grab;
   }
 
-  .avatar {
-    vertical-align: baseline;
+  .no-scroll {
+    height: 100%;
+    overflow: hidden;
   }
-}
 
-.no-scroll {
-  height: 100%;
-  overflow: hidden;
-}
-
-.student-avatar {
-  float: left;
-  margin-right: 10px;
+  .student-avatar {
+    float: left;
+    margin-right: 10px;
+  }
 }
 
 .student-information {

--- a/app/views/group_assignment_invitations/_group_assignment_team.erb
+++ b/app/views/group_assignment_invitations/_group_assignment_team.erb
@@ -1,31 +1,30 @@
-<div class="one-half left team">
   <div class="team-panel">
-    <div class="team-info">
-      <% group_member_count = group_assignment_repo.group.repo_accesses.count %>
+    <div class="boxed-group">
+      <% group = group_assignment_repo.group %>
       <%= form_tag({ controller: :group_assignment_invitations, action: :accept_invitation}, :class => "team-actions-form", method: :patch) do %>
-          <%= hidden_field_tag 'group[id]', group_assignment_repo.group.id %>
-          <% if group_assignment.max_members.present? && group_member_count >= group_assignment.max_members %>
-              <%= submit_tag 'Full', class: 'btn', disabled: true %>
+          <%= hidden_field_tag 'group[id]', group.id %>
+          <% if group_assignment.max_members.present? && group.repo_accesses.count >= group_assignment.max_members %>
+              <%= submit_tag 'Full', class: 'btn btn-sm boxed-group-action', disabled: true %>
           <% else %>
-              <%= submit_tag 'Join', class: 'btn' %>
+              <%= submit_tag 'Join', class: 'btn btn-sm boxed-group-action' %>
           <% end %>
       <% end %>
-
-      <span class="team-name" itemprop="name"><%= group_assignment_repo.github_team.name %></span>
-      <p class="team-description" itemprop="description"><%= pluralize(group_member_count, 'member') %></p>
-    </div>
-    <div class="team-members">
-      <% group_assignment_repo.group.repo_accesses.limit(7).each do |repo_access| %>
-          <% student = repo_access.user %>
-          <%= link_to student.github_user.html_url, class: "tooltipped tooltipped-s #{'disabled' if group_assignment_repo.disabled?}", 'aria-label' => student.github_user.login do %>
-            <%= image_tag student.github_user.github_avatar_url(30), class: 'avatar avatar-small ', height: 30, width: 30, alt: "@#{student.github_user.login}" %>
-          <% end %>
-      <% end %>
-      <% if group_member_count > 7 %>
-        <%= link_to group_assignment_repo.github_team.html_url, class: "#{'disabled' if group_assignment_repo.disabled?}" do %>
-          <%= image_tag 'student-ellipse@2x.png', class: 'avatar avatar-small', height: 30, width: 30, alt: 'student ellipse' %>
-        <% end %>
-      <% end %>
+      <h3><%= group.title %>
+        <span class="team-description"><%= pluralize(group.repo_accesses.count, 'student') %></span>
+      </h3>
+      <div class="boxed-group-inner clearfix">
+        <div class="team-members">
+          <ul class="member-list" group-id="<%= group.slug %>">
+            <% group.repo_accesses.each do |repo_access| %>
+                <% student = repo_access.user %>
+                <li class="member">
+                  <%= link_to student.github_user.html_url, class: "tooltipped tooltipped-s", 'aria-label' => student.github_user.login, 'user-id' => student.id do %>
+                      <%= image_tag student.github_user.github_avatar_url(60), class: 'avatar avatar-small ', height: 30, width: 30, alt: "@#{student.github_user.login}" %>
+                  <% end %>
+                </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
-</div>

--- a/app/views/group_assignment_invitations/show.html.erb
+++ b/app/views/group_assignment_invitations/show.html.erb
@@ -21,9 +21,24 @@
     <hr>
     <p><label>Join an existing team</label></p>
     <div class="team-grid">
-      <% @group_assignment.group_assignment_repos.each do |group_assignment_repo| %>
-        <%= render partial: 'group_assignment_team', locals: { group_assignment_repo: group_assignment_repo} %>
-      <% end %>
+      <div class="columns">
+        <div class="one-half team-left">
+          <% @group_assignment.group_assignment_repos.each do |group_assignment_repo| %>
+              <% if cycle('odd', 'even') == 'odd' %>
+                <%= render partial: 'group_assignment_team', locals: { group_assignment_repo: group_assignment_repo } %>
+              <% end %>
+          <% end %>
+        </div>
+        <% reset_cycle %>
+        <div class="one-half team-right">
+          <% @group_assignment.group_assignment_repos.each do |group_assignment_repo| %>
+              <% if cycle('odd', 'even') == 'even' %>
+                <%= render partial: 'group_assignment_team', locals: { group_assignment_repo: group_assignment_repo } %>
+              <% end %>
+          <% end %>
+        </div>
+      </div>
+
       <div style="clear:both"></div>
     </div>
   <% end %>

--- a/app/views/group_assignment_invitations/show.html.erb
+++ b/app/views/group_assignment_invitations/show.html.erb
@@ -19,7 +19,10 @@
 
   <% if @groups.present? %>
     <hr>
-    <p><label>Join an existing team</label></p>
+
+    <div class="markdown-body">
+      <p><label>Join an existing team</label></p>
+    </div>
     <div class="team-grid">
       <div class="columns">
         <div class="one-half team-left">

--- a/app/views/groupings/_group.html.erb
+++ b/app/views/groupings/_group.html.erb
@@ -1,21 +1,24 @@
 <div class="team-panel">
-  <div class="team-info">
-    <a class="right btn btn-sm" href="#">
+  <div class="boxed-group">
+    <a class="btn btn-sm boxed-group-action" href="#">
       Manage
     </a>
-    <strong class="team-name" itemprop="name"><%= group.title %></strong>
-    <span class="team-description" group-description-id="<%= group.slug %>" itemprop="description"><%= pluralize(group.repo_accesses.count, 'student') %></span>
-  </div>
-  <div class="team-members">
-    <ul class="member-list-draggable" group-id="<%= group.slug %>">
-      <% group.repo_accesses.each do |repo_access| %>
-        <% student = repo_access.user %>
-        <div class="member-draggable">
-          <%= link_to student.github_user.html_url, class: "tooltipped tooltipped-s", 'aria-label' => student.github_user.login, 'user-id' => student.id do %>
-            <%= image_tag student.github_user.github_avatar_url(60), class: 'avatar avatar-small ', height: 30, width: 30, alt: "@#{student.github_user.login}" %>
+    <h3><%= group.title %>
+      <span class="team-description" group-description-id="<%= group.slug %>" itemprop="description"><%= pluralize(group.repo_accesses.count, 'student') %></span>
+    </h3>
+    <div class="boxed-group-inner clearfix">
+      <div class="team-members">
+        <ul class="member-list member-list-draggable" group-id="<%= group.slug %>">
+          <% group.repo_accesses.each do |repo_access| %>
+              <% student = repo_access.user %>
+              <li class="member member-draggable">
+                <%= link_to student.github_user.html_url, class: "tooltipped tooltipped-s", 'aria-label' => student.github_user.login, 'user-id' => student.id do %>
+                    <%= image_tag student.github_user.github_avatar_url(60), class: 'avatar avatar-small ', height: 30, width: 30, alt: "@#{student.github_user.login}" %>
+                <% end %>
+              </li>
           <% end %>
-        </div>
-      <% end %>
-    </ul>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### Changes

1. **Dropped some redundant CSS code.**

  From [app/assets/stylesheets/layout.scss#L656](https://github.com/education/classroom/blob/837242724122c0a6ed047fb487ad6b6cf488f011/app/assets/stylesheets/layout.scss#L656) we can see that I've written some CSS code for this kind of style for groups:

  ![screen shot 2016-08-17 at 10 40 00 pm](https://cloud.githubusercontent.com/assets/1311594/17760159/924081de-64cb-11e6-866b-c0e7902203cb.png)

  However, we don't actually need those CSS lines since we already have [app/assets/stylesheets/components/boxed-group.scss](https://github.com/education/classroom/blob/837242724122c0a6ed047fb487ad6b6cf488f011/app/assets/stylesheets/components/boxed-group.scss), which can achieve exactly the same style.

  So in this PR I removed most of the CSS lines above, and adopted `boxed-group` for the groups.

2. **Removed group member display limit in group assignment invitation page.**

  Currently, if there are more than 7 members in a group, we'll only show 7 of the members in the group with a ![screen shot 2016-08-17 at 10 54 10 pm](https://cloud.githubusercontent.com/assets/1311594/17760405/900daebc-64cd-11e6-9f38-6b4ce23d69fc.png) link which leads the current user to the GitHub team page.

  ![screen shot 2016-08-17 at 11 00 24 pm](https://cloud.githubusercontent.com/assets/1311594/17760527/66c0368c-64ce-11e6-9dac-072d4a5973fe.png)

  However, since [the default privacy level of a created GitHub team is `secret`](https://developer.github.com/v3/orgs/teams/#create-team), only organization owners and members of the team can see it. So if a user clicks into the link, he would get a 404 page for sure.

  So I removed the link from the group assignment invitation page, and adopted 2-column masonry style layout for it. Now students can see all of the members in a group from the group assignment invitation page.

  ![screen shot 2016-08-17 at 11 04 44 pm](https://cloud.githubusercontent.com/assets/1311594/17760613/07dd799e-64cf-11e6-9cd0-825dcbcaa317.png)

### Team management preview

Before:

![screen shot 2016-08-17 at 10 27 22 pm](https://cloud.githubusercontent.com/assets/1311594/17760009/427d583a-64ca-11e6-9d88-c69e9c26fefc.png)

After:

![screen shot 2016-08-17 at 10 25 02 pm](https://cloud.githubusercontent.com/assets/1311594/17759934/ac111d8c-64c9-11e6-9c50-6ecbfd68e498.png)

### Group assignment invitation preview

Before:

![screen shot 2016-08-17 at 10 27 29 pm](https://cloud.githubusercontent.com/assets/1311594/17760017/56c5f3ba-64ca-11e6-9657-a3beb0987ec5.png)

After:

![after_group_assignment_invitation](https://cloud.githubusercontent.com/assets/1311594/17760082/e6497c3c-64ca-11e6-8307-896a592a9a01.png)

