### PR TITLE
Add :students_are_repo_admins to permitted params

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -88,7 +88,7 @@ class AssignmentsController < ApplicationController
   def update_assignment_params
     params
       .require(:assignment)
-      .permit(:title, :slug, :public_repo)
+      .permit(:title, :slug, :public_repo, :students_are_repo_admins)
       .merge(starter_code_repo_id: starter_code_repo_id_param, student_identifier_type: student_identifier_type_param)
   end
 

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -119,7 +119,7 @@ class GroupAssignmentsController < ApplicationController
   def update_group_assignment_params
     params
       .require(:group_assignment)
-      .permit(:title, :slug, :public_repo, :max_members)
+      .permit(:title, :slug, :public_repo, :max_members, :students_are_repo_admins)
       .merge(starter_code_repo_id: starter_code_repo_id_param, student_identifier_type: student_identifier_type_param)
   end
 


### PR DESCRIPTION
Updating the `Give students Admin permissions on their repository` of assignments / group assignments does not work since `students_are_repo_admins` is not permitted in the `update_group_assignment_params` / `update_group_assignment_params`.

```
09:52:33 rails.1 | Started PATCH "/classrooms/19820098-classroom/group-assignments/homework" for 127.0.0.1 at 2016-09-12 09:52:33 +0800
09:52:33 rails.1 | Unpermitted parameter: students_are_repo_admins
```
