### PR TITLE
Enable Turbolinks progress bar

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -15,7 +15,9 @@
 #= require jquery-ujs/src/rails
 #
 #= require turbolinks
-#
+
+Turbolinks.ProgressBar.enable()
+
 #= require local_time
 #
 #= require jquery-readyselector/jquery.readyselector

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -15,9 +15,7 @@
 #= require jquery-ujs/src/rails
 #
 #= require turbolinks
-
-Turbolinks.ProgressBar.enable()
-
+#
 #= require local_time
 #
 #= require jquery-readyselector/jquery.readyselector
@@ -35,5 +33,7 @@ Turbolinks.ProgressBar.enable()
 #= require transliteration/lib/browser/transliteration
 #
 #= require js-cookie/src/js.cookie
-#
+
+Turbolinks.enableProgressBar()
+
 #= require_tree .

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -33,7 +33,7 @@
 #= require transliteration/lib/browser/transliteration
 #
 #= require js-cookie/src/js.cookie
+#
+#= require_tree .
 
 Turbolinks.enableProgressBar()
-
-#= require_tree .

--- a/app/assets/stylesheets/components/progress-bar.scss
+++ b/app/assets/stylesheets/components/progress-bar.scss
@@ -1,5 +1,7 @@
+// scss-lint:disable ImportantRule
 html.turbolinks-progress-bar::before {
   height: 2px !important;
   background-color: #77b6ff !important;
   box-shadow: 0 0 10px rgba(#77b6ff, 0.7) !important;
 }
+// scss-lint:enable ImportantRule

--- a/app/assets/stylesheets/components/progress-bar.scss
+++ b/app/assets/stylesheets/components/progress-bar.scss
@@ -1,5 +1,5 @@
-.turbolinks-progress-bar {
-  height: 2px;
-  background: #77b6ff;
-  box-shadow: 0 0 10px rgba(#77b6ff, 0.7);
+html.turbolinks-progress-bar::before {
+  height: 2px !important;
+  background-color: #77b6ff !important;
+  box-shadow: 0 0 10px rgba(#77b6ff, 0.7) !important;
 }

--- a/app/views/assignments/_assignment.html.erb
+++ b/app/views/assignments/_assignment.html.erb
@@ -5,7 +5,7 @@
     </span>
 
     <h3 class="assignment-name-link">
-      <%= link_to assignment.title, organization_assignment_path(@organization, assignment), class: 'js-navigation' %>
+      <%= link_to assignment.title, organization_assignment_path(@organization, assignment) %>
     </h3>
 
     <p class="assignment-type text-muted">Individual assigment</p>

--- a/app/views/assignments/_delete_assignment_modal.html.erb
+++ b/app/views/assignments/_delete_assignment_modal.html.erb
@@ -21,6 +21,6 @@
       <dd><input type="text" class="js-input-block" autofocus></dd>
     </dl>
 
-    <%= f.submit 'Delete this assignment', class: 'btn btn-danger btn-block js-navigation js-submit', disabled: true %>
+    <%= f.submit 'Delete this assignment', class: 'btn btn-danger btn-block js-submit', disabled: true %>
   <% end %>
 </div>

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class="form-actions">
-      <%= f.submit 'Save changes', class: 'btn btn-green js-navigation' %>
+      <%= f.submit 'Save changes', class: 'btn btn-green' %>
       <%= link_to 'Cancel', [@organization, @assignment], class: 'btn', role: 'button' %>
     </div>
   <% end %>

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -16,7 +16,7 @@
       </div>
 
       <div class="flex-table-item settings">
-        <%= link_to edit_organization_assignment_path(@organization, @assignment), class: 'btn js-navigation right' do %>
+        <%= link_to edit_organization_assignment_path(@organization, @assignment), class: 'btn right' do %>
           <%= octicon 'gear' %>
           Assignment settings
         <% end %>

--- a/app/views/group_assignment_invitations/accept.html.erb
+++ b/app/views/group_assignment_invitations/accept.html.erb
@@ -18,7 +18,7 @@
     </div>
 
     <div class="form-actions">
-      <%= submit_tag 'Accept this assignment', class: 'btn btn-green js-navigation' %>
+      <%= submit_tag 'Accept this assignment', class: 'btn btn-green' %>
     </div>
   <% end %>
 </div>

--- a/app/views/group_assignments/_delete_group_assignment_modal.html.erb
+++ b/app/views/group_assignments/_delete_group_assignment_modal.html.erb
@@ -19,6 +19,6 @@
       <dd><input type="text" class="js-input-block" autofocus></dd>
     </dl>
 
-    <%= f.submit 'Delete this group assignment', class: 'btn btn-danger btn-block js-navigation js-submit', disabled: true %>
+    <%= f.submit 'Delete this group assignment', class: 'btn btn-danger btn-block js-submit', disabled: true %>
   <% end %>
 </div>

--- a/app/views/group_assignments/_group_assignment.html.erb
+++ b/app/views/group_assignments/_group_assignment.html.erb
@@ -4,7 +4,7 @@
       <%= octicon 'organization', height: 22 %>
     </span>
     <h3 class="assignment-name-link">
-      <%= link_to group_assignment.title, organization_group_assignment_path(@organization, group_assignment), class: 'js-navigation' %>
+      <%= link_to group_assignment.title, organization_group_assignment_path(@organization, group_assignment) %>
     </h3>
     <p class="assignment-type text-muted">Group assignment for <strong><%= group_assignment.grouping.title %></strong></p>
   </div>

--- a/app/views/group_assignments/edit.html.erb
+++ b/app/views/group_assignments/edit.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="form-actions">
-      <%= f.submit 'Save changes', class: 'btn btn-green js-navigation' %>
+      <%= f.submit 'Save changes', class: 'btn btn-green' %>
       <%= link_to 'Cancel', [@organization, @group_assignment], class: 'btn', role: 'button' %>
     </div>
   <% end %>

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -15,7 +15,7 @@
       </div>
 
       <div class="flex-table-item settings">
-        <%= link_to edit_organization_group_assignment_path(@organization, @group_assignment), class: 'btn js-navigation right' do %>
+        <%= link_to edit_organization_group_assignment_path(@organization, @group_assignment), class: 'btn right' do %>
           <%= octicon 'gear' %>
           Group assignment settings
         <% end %>

--- a/app/views/groupings/edit.html.erb
+++ b/app/views/groupings/edit.html.erb
@@ -17,7 +17,7 @@
       <%= render partial: 'groupings/grouping_form_options', locals: { f: f } %>
 
       <div class="form-actions">
-        <%= f.submit 'Save changes', class: 'btn btn-green js-navigation' %>
+        <%= f.submit 'Save changes', class: 'btn btn-green' %>
         <%= link_to 'Cancel', settings_teams_organization_path(@organization), class: 'btn', role: 'button' %>
       </div>
   <% end %>

--- a/app/views/organizations/_organization_select.html.erb
+++ b/app/views/organizations/_organization_select.html.erb
@@ -1,4 +1,4 @@
-<%= button_tag type: 'submit', name: "organization[github_id]", class: 'organization-select-target js-navigation', value: org[:github_id] do %>
+<%= button_tag type: 'submit', name: "organization[github_id]", class: 'organization-select-target', value: org[:github_id] do %>
   <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar organization-select-avatar', width: 100, height: 100, alt: "@#{org[:login]}" %>
   <span class="organization css-truncate css-truncate-target" title=<%= "@#{org[:login]}" %>><%= "@#{org[:login]}" %></span>
 <% end %>

--- a/app/views/organizations/_reset_and_remove_organization_modal.html.erb
+++ b/app/views/organizations/_reset_and_remove_organization_modal.html.erb
@@ -19,6 +19,6 @@
       <dd><input type="text" class="js-input-block" autofocus></dd>
     </dl>
 
-    <%= f.submit 'Reset and remove this classroom', class: 'btn btn-danger btn-block js-navigation js-submit', disabled: true %>
+    <%= f.submit 'Reset and remove this classroom', class: 'btn btn-danger btn-block js-submit', disabled: true %>
   <% end %>
 </div>

--- a/app/views/shared/_assignment_student_identifier_type_options.html.erb
+++ b/app/views/shared/_assignment_student_identifier_type_options.html.erb
@@ -10,7 +10,7 @@
           </p>
         </dl>
     <% else %>
-        <%= link_to new_organization_student_identifier_type_path(@organization), class: 'btn btn-green js-navigation' do %>
+        <%= link_to new_organization_student_identifier_type_path(@organization), class: 'btn btn-green' do %>
             <%= t('views.shared.create_first_identifier')%>
         <% end %>
         <p class="note">

--- a/app/views/shared/_identifier_form.html.erb
+++ b/app/views/shared/_identifier_form.html.erb
@@ -14,4 +14,4 @@
     <% end %>
   </dd>
 </dl>
-<%= submit_tag 'Continue', class: 'btn btn-green js-navigation js-form-submit', disabled: true %>
+<%= submit_tag 'Continue', class: 'btn btn-green js-form-submit', disabled: true %>

--- a/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
+++ b/app/views/stafftools/users/_impersonate_user_confirmation_modal.html.erb
@@ -19,6 +19,6 @@
       <dd><input type="text" class="js-input-block"></dd>
     </dl>
 
-    <%= submit_tag "Impersonate @#{user.github_user.login}", class: 'btn btn-block btn-danger js-navigation js-submit', disabled: true %>
+    <%= submit_tag "Impersonate @#{user.github_user.login}", class: 'btn btn-block btn-danger js-submit', disabled: true %>
   <% end %>
 </div>

--- a/app/views/student_identifier_types/_student_identifier_type.html.erb
+++ b/app/views/student_identifier_types/_student_identifier_type.html.erb
@@ -22,6 +22,6 @@
   </div>
 
   <%= form_for [@organization, student_identifier_type], html: { method: 'delete' } do |f| %>
-      <%= f.submit 'I understand, delete this identifier', class: 'btn btn-danger btn-block js-navigation js-submit' %>
+      <%= f.submit 'I understand, delete this identifier', class: 'btn btn-danger btn-block js-submit' %>
   <% end %>
 </div>

--- a/app/views/student_identifier_types/edit.html.erb
+++ b/app/views/student_identifier_types/edit.html.erb
@@ -14,7 +14,7 @@
   <%= form_for [@organization, @student_identifier_type] do |f| %>
       <%= render partial: 'student_identifier_types/form_options', locals: { f: f } %>
       <div class="form-actions">
-        <%= f.submit 'Save changes', class: 'btn btn-green js-navigation' %>
+        <%= f.submit 'Save changes', class: 'btn btn-green' %>
         <%= link_to 'Cancel', organization_student_identifier_types_path(@organization), class: 'btn', role: 'button'%>
       </div>
   <% end %>

--- a/app/views/student_identifier_types/new.html.erb
+++ b/app/views/student_identifier_types/new.html.erb
@@ -16,7 +16,7 @@
   <%= form_for [@organization, @student_identifier_type] do |f| %>
       <%= render partial: 'student_identifier_types/form_options', locals: { f: f } %>
       <div class="form-actions">
-        <%= f.submit 'Create Identifier', class: 'btn btn-green js-navigation' %>
+        <%= f.submit 'Create Identifier', class: 'btn btn-green' %>
         <%= link_to 'Cancel', session[:return_to], class: 'btn', role: 'button'%>
       </div>
   <% end %>


### PR DESCRIPTION
Closes https://github.com/education/classroom/issues/750

I don't really want to update all of our javascript for Turbolinks 5 right now. In the mean time this enables the progress bar for [Turbolinks 2.5.3](https://github.com/turbolinks/turbolinks-classic/tree/v2.5.3#progress-bar) and fixes the styling.

I've also remove all of the places I think the `js-navigation` class was a problem.

@dinever @cyhsutw if you see a place I removed that it was not an issue, please let me know.