### PR TITLE
Receive webhooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ notifications:
   email: false
 
 env:
-  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret WEBHOOK_SECRET='12345'
+  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret WEBHOOK_SECRET=abcdefg

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ notifications:
   email: false
 
 env:
-  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret
+  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret WEBHOOK_SECRET=12345

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ notifications:
   email: false
 
 env:
-  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret WEBHOOK_SECRET=12345
+  - GITHUB_CLIENT_ID=client_id GITHUB_CLIENT_SECRET=client_secret WEBHOOK_SECRET='12345'

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,7 +10,7 @@ class GroupsController < ApplicationController
 
     if repo_access.present?
       group.repo_accesses << repo_access
-      render nothing: true, status: 204
+      head :no_content
     else
       render json: {
         message: "User isn't a member of this classroom."
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
 
     if repo_access.present?
       group.repo_accesses.delete(repo_access)
-      render nothing: true, status: 204
+      head :no_content
     else
       render json: {
         message: "User isn't a member of this classroom."

--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class HooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
+
+  before_action :verify_payload
+
+  def receive
+    send_github_payload_to_job(JSON.parse(payload_body))
+    head :ok
+  end
+
+  private
+
+  def payload_body
+    @payload_body ||= request.body.read
+  end
+
+  def send_github_payload_to_job(payload_body)
+    github_event = request.env['HTTP_X_GITHUB_EVENT']
+    return unless GitHub::WebHook::ACCEPTED_EVENTS.include?(github_event)
+    "#{github_event}_event_job".classify.constantize.perform_later(payload_body)
+  end
+
+  def verify_payload
+    return render json: { message: 'No payload received' }, status: 400 if payload_body == 'null'
+
+    expected_signature = "sha1=#{GitHub::WebHook.generate_hmac(payload_body)}"
+    received_signature = request.env['HTTP_X_HUB_SIGNATURE']
+
+    unless received_signature && Rack::Utils.secure_compare(received_signature, expected_signature)
+      return render json: { message: 'Invalid payload signature' }, status: :forbidden
+    end
+  end
+end

--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -28,8 +28,10 @@ class HooksController < ApplicationController
     expected_signature = "sha1=#{GitHub::WebHook.generate_hmac(payload_body)}"
     received_signature = request.env['HTTP_X_HUB_SIGNATURE']
 
+    # rubocop:disable GuardClause
     unless received_signature && Rack::Utils.secure_compare(received_signature, expected_signature)
       return render json: { message: 'Invalid payload signature' }, status: :forbidden
     end
+    # rubocop:enable GuardClause
   end
 end

--- a/app/jobs/ping_event_job.rb
+++ b/app/jobs/ping_event_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class PingEventJob < ApplicationJob
+  queue_as :ping_event
+
+  def perform(payload_body)
+    # Do Nothing Right now
+  end
+end

--- a/app/models/github_repository.rb
+++ b/app/models/github_repository.rb
@@ -8,8 +8,13 @@ class GitHubRepository < GitHubResource
 
   def get_starter_code_from(source)
     GitHub::Errors.with_error_handling do
-      credentials = { vcs_username: @client.login, vcs_password: @client.access_token }
-      @client.start_source_import(@id, 'git', "https://github.com/#{source.full_name}", credentials)
+      options = {
+        accept:       Octokit::Preview::PREVIEW_TYPES[:source_imports],
+        vcs_username: @client.login,
+        vcs_password: @client.access_token
+      }
+
+      @client.start_source_import(@id, 'git', "https://github.com/#{source.full_name}", options)
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,12 @@ Rails.application.routes.draw do
 
   get '/autocomplete/github_repos', to: 'autocomplete#github_repos'
 
+  scope 'github', as: 'github' do
+    constraints user_agent: %r{\AGitHub-Hookshot/\w+\z}, format: 'json' do
+      post :hooks, to: 'hooks#receive'
+    end
+  end
+
   resources :assignment_invitations, path: 'assignment-invitations', only: [:show] do
     member do
       get   :identifier

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,7 @@
+---
+:concurrency: <%= Integer(ENV['SIDEKIQ_CONCURRENCY'] || 5) %>
+:verbose: false
 :queues:
-  - chewy
-  - trash_can
+  - [chewy, 1]
+  - [trash_can, 1]
+  - [ping_event, 2]

--- a/lib/github/web_hook.rb
+++ b/lib/github/web_hook.rb
@@ -27,7 +27,7 @@ module GitHub
       def webhook_secret
         @webhook_secret ||= Rails.application.secrets.webhook_secret
         return @webhook_secret if @webhook_secret.present?
-        raise 'GITHUB_WEBHOOK_SECRET is not set, please check you .env file'
+        raise 'WEBHOOK_SECRET is not set, please check you .env file'
       end
     end
   end

--- a/lib/github/web_hook.rb
+++ b/lib/github/web_hook.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module GitHub
+  class WebHook
+    ACCEPTED_EVENTS = %w(ping).freeze
+
+    class << self
+      # Public: Generate the [HMAC](https://tools.ietf.org/html/rfc2104)
+      # for the given JSON payload.
+      #
+      # payload - A String representing a JSON payload.
+      #
+      # Example:
+      #
+      #   GitHub::WebHook.generate_hmac("{\"login\":\"tarebyte\"}")
+      #   # => "fa3d036eb7f341ececf629f5e631e96db778c69e"
+      #
+      # Returns the HMAC string.
+      def generate_hmac(payload)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), webhook_secret, payload)
+      end
+
+      private
+
+      # Internal: Returns the GitHub Webhook secret for the application.
+      #
+      # Returns the secret String or raises an error if it is not defined.
+      def webhook_secret
+        @webhook_secret ||= Rails.application.secrets.webhook_secret
+        return @webhook_secret if @webhook_secret.present?
+        raise 'GITHUB_WEBHOOK_SECRET is not set, please check you .env file'
+      end
+    end
+  end
+end

--- a/spec/controllers/hooks_controller_spec.rb
+++ b/spec/controllers/hooks_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe HooksController, type: :controller do
+  include ActiveJob::TestHelper
+
+  before do
+    set_http_header('HTTP_X_HUB_SIGNATURE', "sha1=#{GitHub::WebHook.generate_hmac('{"foo":"bar"}')}")
+  end
+
+  describe 'invalid webhook request' do
+    it 'responds with a 400 if there is not payload' do
+      send_webhook(nil)
+      expect(response).to have_http_status(400)
+    end
+
+    it 'responds with :forbidden if the signatures are not a match' do
+      set_http_header('HTTP_X_HUB_SIGNATURE', 'foo')
+      send_webhook(foo: 'bar')
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'valid webhook request' do
+    it 'responds :ok for a valid request' do
+      send_webhook(foo: 'bar')
+      expect(response).to have_http_status(:ok)
+    end
+
+    GitHub::WebHook::ACCEPTED_EVENTS.map do |event|
+      it "queues a job for the '#{event}' event" do
+        set_http_header('HTTP_X_GITHUB_EVENT', event)
+        job_class = "#{event}_event_job".classify.constantize
+
+        expect do
+          send_webhook(foo: 'bar')
+        end.to have_enqueued_job(job_class)
+      end
+    end
+  end
+
+  private
+
+  def set_http_header(header, value)
+    request.env[header] = value
+  end
+
+  def send_webhook(payload)
+    post :receive, body: payload.to_json, as: :json
+  end
+end

--- a/spec/controllers/stafftools/users_controller_spec.rb
+++ b/spec/controllers/stafftools/users_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Stafftools::UsersController, type: :controller do
       end
 
       before(:each) do
-        post :impersonate, id: student.id
+        post :impersonate, params: { id: student.id }
       end
 
       it 'sets the :impersonated_user_id on the session' do


### PR DESCRIPTION
Largely off based on the work of @cyhsutw in https://github.com/education/classroom/pull/694.

This allows Classroom to start receiving [GitHub webhook events](https://developer.github.com/webhooks/#events).

Each event will have it's own background job, so for example  the [`ping`](https://developer.github.com/webhooks/#ping-event) event has the job `PingEventJob`. Which as of right now does nothing.

I'm extracting this work for a few reasons:

- The original PR is rather large, and I'd like to break it down for easier reviewing
- I wanted to make the route more flexible for all kind of events
- I wanted to move responsibility to the background job instead of at the controller level.

/cc @cyhsutw 