### PR TITLE
Add source code links to stafftools

### DIFF
--- a/app/views/stafftools/assignment_repos/show.html.erb
+++ b/app/views/stafftools/assignment_repos/show.html.erb
@@ -33,6 +33,10 @@
           <td><%= link_to @assignment_repo.assignment.title, stafftools_assignment_path(@assignment_repo.assignment.id) %></td>
         </tr>
         <tr>
+          <td class="text-emphasized">Source code</td>
+          <td><%= link_to @assignment_repo.github_repository.html_url, @assignment_repo.github_repository.html_url %></td>
+        </tr>
+        <tr>
           <td class="text-emphasized">User</td>
           <td><%= link_to @assignment_repo.user.github_user.login, stafftools_user_path(@assignment_repo.user) %></td>
         </tr>

--- a/app/views/stafftools/group_assignment_repos/show.html.erb
+++ b/app/views/stafftools/group_assignment_repos/show.html.erb
@@ -33,6 +33,10 @@
           <td><%= link_to @group_assignment_repo.group_assignment.title, stafftools_group_assignment_path(@group_assignment_repo.group_assignment.id) %></td>
         </tr>
         <tr>
+          <td class="text-emphasized">Source code</td>
+          <td><%= link_to @group_assignment_repo.github_repository.html_url, @group_assignment_repo.github_repository.html_url %></td>
+        </tr>
+        <tr>
           <td class="text-emphasized">Group</td>
           <td><%= link_to @group_assignment_repo.group.title, stafftools_group_path(@group_assignment_repo.group) %></td>
         </tr>


### PR DESCRIPTION
This adds link us to the source code on GitHub for each `AssignmentRepo` and `GroupAssignmentRepo`.