### PR TITLE
Move from Bonsai to Elastic Cloud

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,7 +41,7 @@
   },
 
   "addons": [
-    "bonsai",
+    "foundelasticsearch",
     "heroku-postgresql",
     "heroku-redis",
     "memcachedcloud",

--- a/config/chewy.yml
+++ b/config/chewy.yml
@@ -8,4 +8,4 @@ development:
   host: 'localhost:9200'
 
 production:
-  host: <%= ENV['BONSAI_URL'] %>
+  host: <%= ENV['FOUNDELASTICSEARCH_URL'] %>


### PR DESCRIPTION
I've been paged more times than I'd like to think about for Elasticsearch not being reliable.

This moves us from Bonsai to Elastic Cloud