### PR TITLE
Fix last active in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development, :test do
   gem 'scss_lint', require: false
   gem 'spring'
   gem 'terminal-notifier-guard'
+  gem 'timecop'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -474,6 +475,7 @@ DEPENDENCIES
   spring
   sprockets
   terminal-notifier-guard
+  timecop
   turbolinks (~> 2.5.3)
   uglifier (>= 1.3.0)
   vcr
@@ -483,4 +485,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   end
 
   def become_active
-    LastActiveJob.perform_later(current_user.id, Time.current.to_i)
+    LastActiveJob.perform_later(current_user, Time.zone.now)
   end
 
   def current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   end
 
   def become_active
-    LastActiveJob.perform_later(current_user, Time.zone.now)
+    LastActiveJob.perform_later(current_user, Time.zone.now.to_i)
   end
 
   def current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   end
 
   def become_active
-    LastActiveJob.perform_later(current_user, Time.current.to_i)
+    LastActiveJob.perform_later(current_user.id, Time.current.to_i)
   end
 
   def current_user

--- a/app/jobs/last_active_job.rb
+++ b/app/jobs/last_active_job.rb
@@ -4,12 +4,13 @@ class LastActiveJob < ApplicationJob
 
   # Public: Update the last time the User was active.
   #
-  # user_id          - The Integer id of the User that was active.
+  # user             - The User that was active.
   # time_last_active - The Integer representing the time the User was current.
   #
   # returns nothing.
-  def perform(user_id, time_last_active)
-    return true unless (user = User.find_by(id: user_id))
+  def perform(user, time_last_active)
+    # Do another lookup to make sure the User is still around
+    return true unless (user = User.find_by(id: user.id))
 
     time_last_active = Time.zone.at(time_last_active)
     user.update_columns(last_active_at: time_last_active)

--- a/app/jobs/last_active_job.rb
+++ b/app/jobs/last_active_job.rb
@@ -4,11 +4,13 @@ class LastActiveJob < ApplicationJob
 
   # Public: Update the last time the User was active.
   #
-  # user             - The User that was active.
+  # user_id          - The Integer id of the User that was active.
   # time_last_active - The Integer representing the time the User was current.
   #
   # returns nothing.
-  def perform(user, time_last_active)
+  def perform(user_id, time_last_active)
+    return true unless (user = User.find_by(id: user_id))
+
     time_last_active = Time.zone.at(time_last_active)
     user.update_columns(last_active_at: time_last_active)
     User.update_index('stafftools#user') { user }

--- a/spec/jobs/last_active_job_spec.rb
+++ b/spec/jobs/last_active_job_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe LastActiveJob, type: :job do
   let(:user) { create(:user) }
 
   before(:each) do
-    @time = (Time.current + 600).to_i
+    Timecop.freeze(Time.zone.now)
+    @time = (Time.zone.now + 600).to_i
+  end
+
+  after(:each) do
+    Timecop.return
   end
 
   it 'uses the :last_active_at queue' do
@@ -16,11 +21,11 @@ RSpec.describe LastActiveJob, type: :job do
 
   it 'updates the last_active_at attribute' do
     LastActiveJob.perform_now(user, @time)
-    expect(user.last_active_at).to eql(Time.zone.at(@time))
+    expect(user.reload.last_active_at).to eql(Time.zone.at(@time))
   end
 
   it 'does not change the updated_at column' do
     LastActiveJob.perform_now(user, @time)
-    expect(user.last_active_at).to_not eql(user.updated_at)
+    expect(user.reload.last_active_at).to_not eql(user.updated_at)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
+require 'timecop'
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.


### PR DESCRIPTION
During tests the records are deleted so quickly that the job can't find the record and deletes it.

~~This passes the id of the record and then does a query for it.~~

I'm just gonna do a second lookup using the old record.