### PR TITLE
[Development] Remove duplicate gem entry `timecop`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ group :development, :test do
   gem 'spring'
   gem 'timecop', require: false
   gem 'terminal-notifier-guard'
-  gem 'timecop'
 end
 
 group :production do


### PR DESCRIPTION
Fix a slight warning while installing gems:

```bash
$ bundle        
Your Gemfile lists the gem timecop (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
....
```

/cc @tarebyte