### PR TITLE
Cast webhook_id to be int instead of string

### DIFF
--- a/db/migrate/20161130020119_change_webhook_id_column_to_integer.rb
+++ b/db/migrate/20161130020119_change_webhook_id_column_to_integer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class ChangeWebhookIdColumnToInteger < ActiveRecord::Migration[5.0]
+  def change
+    change_column :organizations, :webhook_id, 'integer USING CAST(webhook_id AS integer)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621020153) do
+ActiveRecord::Schema.define(version: 20161130020119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 20160621020153) do
     t.datetime "updated_at",                        null: false
     t.datetime "deleted_at"
     t.string   "slug",                              null: false
-    t.string   "webhook_id"
+    t.integer  "webhook_id"
     t.boolean  "is_webhook_active", default: false
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at", using: :btree
     t.index ["github_id"], name: "index_organizations_on_github_id", unique: true, using: :btree


### PR DESCRIPTION
From https://github.com/education/classroom/pull/797

This casts the `Organizations` column `webhook_id` to be an `int` instead of a `string`