### PR TITLE
Allow public assignments for orgs that don't have a plan.

### DIFF
--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -150,6 +150,8 @@ class AssignmentRepo
     #
     # Returns True or raises a Result::Error with a helpful message.
     def verify_organization_has_private_repos_available!
+      return true if assignment.public?
+
       github_organization_plan = GitHubOrganization.new(organization.github_client, organization.github_id).plan
 
       owned_private_repos = github_organization_plan[:owned_private_repos]


### PR DESCRIPTION
Closes #808 because I'm an idiot.

I was making public assignments during my tests, but my test org has a plan so I never ran into this issue.

/cc @tamastompa @immanuelfodor