### PR TITLE
Add repo scope for students

### DIFF
--- a/config/initializers/scopes.rb
+++ b/config/initializers/scopes.rb
@@ -2,7 +2,7 @@
 module GitHubClassroom
   module Scopes
     TEACHER                  = %w(user:email repo delete_repo admin:org admin:org_hook).freeze
-    GROUP_ASSIGNMENT_STUDENT = %w(admin:org user:email).freeze
-    ASSIGNMENT_STUDENT       = %w(user:email).freeze
+    GROUP_ASSIGNMENT_STUDENT = %w(repo admin:org user:email).freeze
+    ASSIGNMENT_STUDENT       = %w(repo user:email).freeze
   end
 end

--- a/spec/lib/github_classroom/scopes_spec.rb
+++ b/spec/lib/github_classroom/scopes_spec.rb
@@ -9,11 +9,11 @@ describe GitHubClassroom::Scopes do
   end
 
   it 'has the correct scopes for a student accepting a group assignment' do
-    expect(subject::GROUP_ASSIGNMENT_STUDENT).to eql(%w(admin:org user:email))
+    expect(subject::GROUP_ASSIGNMENT_STUDENT).to eql(%w(repo admin:org user:email))
   end
 
   it 'has the correct scopes for a student accepting an individual assignment' do
-    expect(subject::ASSIGNMENT_STUDENT).to eql(%w(user:email))
+    expect(subject::ASSIGNMENT_STUDENT).to eql(%w(repo user:email))
   end
 
   it 'ensures that the scopes are correctly sized' do


### PR DESCRIPTION
Closes #817 

There was a change in the [Preview Repository Invitations API](https://developer.github.com/v3/repos/invitations/) where we now need to include the `repo` scope in order to accept the invitation on the students behalf.

This updates students scopes on Classroom so that everything should work again.