### PR TITLE
Revert use of Repository Invitations

### DIFF
--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -87,23 +87,15 @@ class AssignmentRepo
     # Internal: Add the User to the GitHub repository
     # as a collaborator.
     #
-    # NOTE: Because of the API changes https://developer.github.com/changes/2016-06-14-repository-invitations
-    # we now have create an invitation for the repository, and then have the student accept it with their
-    # own token.
-    #
     # Returns true if successful, otherwise raises a Result::Error
-    # rubocop:disable AbcSize
     def add_user_to_repository!(github_repository_id)
       options = {}.tap { |opt| opt[:permission] = 'admin' if assignment.students_are_repo_admins? }
 
       github_repository = GitHubRepository.new(organization.github_client, github_repository_id)
-      invitation_id = github_repository.invite(user.github_user.login_no_cache, options).id
-
-      user.github_user.accept_repository_invitation(invitation_id)
+      github_repository.add_collaborator(user.github_user.login_no_cache, options)
     rescue GitHub::Error
       raise Result::Error, REPOSITORY_COLLABORATOR_ADDITION_FAILED
     end
-    # rubocop:enable AbcSize
 
     # Internal: Create the GitHub repository for the AssignmentRepo.
     #

--- a/config/initializers/scopes.rb
+++ b/config/initializers/scopes.rb
@@ -2,7 +2,7 @@
 module GitHubClassroom
   module Scopes
     TEACHER                  = %w(user:email repo delete_repo admin:org admin:org_hook).freeze
-    GROUP_ASSIGNMENT_STUDENT = %w(repo admin:org user:email).freeze
-    ASSIGNMENT_STUDENT       = %w(repo user:email).freeze
+    GROUP_ASSIGNMENT_STUDENT = %w(admin:org user:email).freeze
+    ASSIGNMENT_STUDENT       = %w(user:email).freeze
   end
 end

--- a/spec/lib/github_classroom/scopes_spec.rb
+++ b/spec/lib/github_classroom/scopes_spec.rb
@@ -9,11 +9,11 @@ describe GitHubClassroom::Scopes do
   end
 
   it 'has the correct scopes for a student accepting a group assignment' do
-    expect(subject::GROUP_ASSIGNMENT_STUDENT).to eql(%w(repo admin:org user:email))
+    expect(subject::GROUP_ASSIGNMENT_STUDENT).to eql(%w(admin:org user:email))
   end
 
   it 'has the correct scopes for a student accepting an individual assignment' do
-    expect(subject::ASSIGNMENT_STUDENT).to eql(%w(repo user:email))
+    expect(subject::ASSIGNMENT_STUDENT).to eql(%w(user:email))
   end
 
   it 'ensures that the scopes are correctly sized' do


### PR DESCRIPTION
Closes #819 

Because of the scope changes in #818 I borked some students ability to accept assignments. I'm still on vacation so for the time being I'm going to revert the use of the Beta API so that we can use the old scopes.