### PR TITLE
Use memcache in development and only show in peek bar when used

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -13,10 +14,10 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :dalli_store, 'localhost:11211'
     config.public_file_server.headers = {
       'Cache-Control' => 'public, max-age=172800'
     }

--- a/config/initializers/peek.rb
+++ b/config/initializers/peek.rb
@@ -1,8 +1,14 @@
+# frozen_string_literal: true
 unless Rails.env.test?
-  Peek.into Peek::Views::Git, :nwo => 'education/classroom'
+  Peek.into Peek::Views::Git, nwo: 'education/classroom'
   Peek.into Peek::Views::PerformanceBar
   Peek.into Peek::Views::GC
-  Peek.into Peek::Views::Dalli
+
+  # Only show the Dalli view if we are actually caching.
+  if Rails.env.production? || Rails.root.join('tmp', 'caching-dev.txt').exist?
+    Peek.into Peek::Views::Dalli
+  end
+
   Peek.into Peek::Views::PG
   Peek.into Peek::Views::Sidekiq
 end


### PR DESCRIPTION
We should use memcached in development as well as production. This also only shows the dalli peek view if we are caching.