### PR TITLE
Require Ruby 2.4.0 in "Getting Started" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ New to Ruby? No worries! You can follow these instructions to install a local se
 
 #### Installing a Local Server
 
-First things first, you'll need to install Ruby 2.3.3. We recommend using the excellent [rbenv](https://github.com/sstephenson/rbenv),
+First things first, you'll need to install Ruby 2.4.0. We recommend using the excellent [rbenv](https://github.com/sstephenson/rbenv),
 and [ruby-build](https://github.com/sstephenson/ruby-build)
 
 ```bash
-rbenv install 2.3.3
-rbenv global 2.3.3
+rbenv install 2.4.0
+rbenv global 2.4.0
 ```
 
 Next, you'll need to make sure that you have Nodejs, PostgreSQL, Redis, Memcached, and Elasticsearch installed. This can be done easily :


### PR DESCRIPTION
I was getting ready to start over on a piece of work I was doing and going through the documentation again. I received the following failure when running the setup script:

```bash
vagrant@homestead:~/Code/classroom$ script/setup
==> Installing gem dependencies…
rbenv: version `2.4.0' is not installed (set by /home/vagrant/Code/classroom/.ruby-version)
```

After installing 2.4.0, reinstalling bundler and rehashing, the setup script started executing.