### PR TITLE
Add Error pages for RoutingError and RecordNotFound exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
               GitHub::Forbidden,
               GitHub::NotFound,
               NotAuthorized, with: :flash_and_redirect_back_with_message
+  rescue_from ActionController::RoutingError, ActiveRecord::RecordNotFound, with: :render_404
 
   def peek_enabled?
     logged_in? && current_user.staff?
@@ -32,5 +33,14 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_root
     redirect_to root_path
+  end
+
+  def render_404(exception)
+    case exception
+    when ActionController::RoutingError
+      render file: Rails.root.join('public', '404.html'), layout: false, status: :not_found
+    when ActiveRecord::RecordNotFound
+      render file: Rails.root.join('public', 'invalid_link_error.html'), layout: false, status: :not_found
+    end
   end
 end

--- a/public/404.html
+++ b/public/404.html
@@ -7,7 +7,7 @@
     html,body,div,h1,h3,a{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline;}
 
     a{
-      color:blue;
+      color: #4078c0;
       text-decoration: none;
     }
 

--- a/public/invalid_link_error.html
+++ b/public/invalid_link_error.html
@@ -79,7 +79,7 @@
 
     @media(max-width:1440px){
       .site-footer {
-        padding: 11em 5em 3em 0em;
+        padding: 12.2em 5em 3em 0em;
       }
     }
     @media(max-width:1366px){
@@ -251,7 +251,6 @@
     <div class="content">
       <h3>Invalid invitation link</h3>
       <h4>Recheck your invitation link or contact your organization.</h4>
-      <h4><a href="/">Go back to classroom dashboard</a></h4>
     </div>
     <div class="clear"></div>
   </div>

--- a/public/invalid_link_error.html
+++ b/public/invalid_link_error.html
@@ -7,7 +7,7 @@
     html,body,div,h1,h3,a{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline;}
 
     a{
-      color:blue;
+      color: blue;
       text-decoration: none;
     }
 
@@ -76,7 +76,6 @@
       font-weight: 400;
       color: #4078c0;
     }
-
 
     @media(max-width:1440px){
       .site-footer {
@@ -247,11 +246,11 @@
 <body>
   <div class="not-found-container">
     <div class="notfound-top">
-      <h1>404</h1>
+        <h1>404</h1>
     </div>
     <div class="content">
-      <h3>Page not found</h3>
-      <h4>The page you are trying to reach does not exist, or has been moved.</h4>
+      <h3>Invalid invitation link</h3>
+      <h4>Recheck your invitation link or contact your organization</h4>
       <h4><a href="/">Go back to classroom dashboard</a></h4>
     </div>
     <div class="clear"></div>

--- a/public/invalid_link_error.html
+++ b/public/invalid_link_error.html
@@ -7,7 +7,7 @@
     html,body,div,h1,h3,a{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline;}
 
     a{
-      color: blue;
+      color: #4078c0;
       text-decoration: none;
     }
 
@@ -250,7 +250,7 @@
     </div>
     <div class="content">
       <h3>Invalid invitation link</h3>
-      <h4>Recheck your invitation link or contact your organization</h4>
+      <h4>Recheck your invitation link or contact your organization.</h4>
       <h4><a href="/">Go back to classroom dashboard</a></h4>
     </div>
     <div class="clear"></div>

--- a/spec/controllers/groupings_controller_spec.rb
+++ b/spec/controllers/groupings_controller_spec.rb
@@ -60,32 +60,23 @@ RSpec.describe GroupingsController, type: :controller do
   context 'flipper is not enabled for the user' do
     describe 'GET #show', :vcr do
       it 'returns a 404' do
-        expect do
-          get :show, params: {
-            organization_id: organization.slug,
-            id: grouping.slug
-          }
-        end.to raise_error(ActionController::RoutingError)
+        get :show, params: { organization_id: organization.slug, id: grouping.slug }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'GET #edit', :vcr do
       it 'returns success status' do
-        expect do
-          get :edit, params: {
-            organization_id: organization.slug,
-            id: grouping.slug
-          }
-        end.to raise_error(ActionController::RoutingError)
+        get :edit, params: { organization_id: organization.slug, id: grouping.slug }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'PATCH #update', :vcr do
       it 'correctly updates the grouping' do
         update_options = { title: 'Fall 2015' }
-        expect do
-          patch :update, params: { organization_id: organization.slug, id: grouping.slug, grouping: update_options }
-        end.to raise_error(ActionController::RoutingError)
+        patch :update, params: { organization_id: organization.slug, id: grouping.slug, grouping: update_options }
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -75,27 +75,24 @@ RSpec.describe GroupsController, type: :controller do
   context 'flipper is not enabled for the user' do
     describe 'PATCH #remove_membership', :vcr do
       it 'returns a 404' do
-        expect do
-          patch :add_membership, params: {
-            organization_id: organization.slug,
-            grouping_id: grouping.slug,
-            id: group.slug,
-            user_id: user.id
-          }
-        end.to raise_error(ActionController::RoutingError)
+        patch :add_membership, params: {
+          organization_id: organization.slug,
+          grouping_id: grouping.slug,
+          id: group.slug, user_id: user.id
+        }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'DELETE #remove_membership', :vcr do
       it 'returns a 404' do
-        expect do
-          delete :remove_membership, params: {
-            organization_id: organization.slug,
-            grouping_id: grouping.slug,
-            id: group.slug,
-            user_id: user.id
-          }
-        end.to raise_error(ActionController::RoutingError)
+        delete :remove_membership, params: {
+          organization_id: organization.slug,
+          grouping_id: grouping.slug,
+          id: group.slug,
+          user_id: user.id
+        }
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -185,7 +185,8 @@ RSpec.describe OrganizationsController, type: :controller do
 
     context 'flipper is not enabled' do
       it 'returns success and sets the organization' do
-        expect { get :show_groupings, params: { id: organization.slug } }.to raise_error(ActionController::RoutingError)
+        get :show_groupings, params: { id: organization.slug }
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/stafftools/assignment_invitations_controller_spec.rb
+++ b/spec/controllers/stafftools/assignment_invitations_controller_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Stafftools::AssignmentInvitationsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: assignment_invitation.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: assignment_invitation.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/assignment_repos_controller_spec.rb
+++ b/spec/controllers/stafftools/assignment_repos_controller_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe Stafftools::AssignmentReposController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          get :show, params: { id: assignment_repo.id }
-        end.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: assignment_repo.id }
+        expect(response.status).to eq(404)
       end
     end
 
@@ -41,9 +40,8 @@ RSpec.describe Stafftools::AssignmentReposController, type: :controller do
   describe 'DELETE #destroy', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          delete :destroy, params: { id: assignment_repo.id }
-        end.to raise_error(ActionController::RoutingError)
+        delete :destroy, params: { id: assignment_repo.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/assignments_controller_spec.rb
+++ b/spec/controllers/stafftools/assignments_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Stafftools::AssignmentsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: assignment.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: assignment.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/group_assignment_invitations_controller_spec.rb
+++ b/spec/controllers/stafftools/group_assignment_invitations_controller_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe Stafftools::GroupAssignmentInvitationsController, type: :controll
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          get :show, params: { id: group_assignment_invitation.id }
-        end.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: group_assignment_invitation.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/group_assignment_repos_controller_spec.rb
+++ b/spec/controllers/stafftools/group_assignment_repos_controller_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Stafftools::GroupAssignmentReposController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: group_assignment_repo.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: group_assignment_repo.id }
+        expect(response.status).to eq(404)
       end
     end
 
@@ -54,9 +55,8 @@ RSpec.describe Stafftools::GroupAssignmentReposController, type: :controller do
   describe 'DELETE #destroy', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          delete :destroy, params: { id: group_assignment_repo.id }
-        end.to raise_error(ActionController::RoutingError)
+        delete :destroy, params: { id: group_assignment_repo.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/group_assignments_controller_spec.rb
+++ b/spec/controllers/stafftools/group_assignments_controller_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe Stafftools::GroupAssignmentsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          get :show, params: { id: group_assignment.id }
-        end.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: group_assignment.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/groupings_controller_spec.rb
+++ b/spec/controllers/stafftools/groupings_controller_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe Stafftools::GroupingsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect do
-          get :show, params: { id: grouping.id }
-        end.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: grouping.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/groups_controller_spec.rb
+++ b/spec/controllers/stafftools/groups_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Stafftools::GroupsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: group.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: group.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/organizations_controller_spec.rb
+++ b/spec/controllers/stafftools/organizations_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Stafftools::OrganizationsController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: organization.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: organization.id }
+        expect(response.status).to eq(404)
       end
     end
 
@@ -36,8 +37,8 @@ RSpec.describe Stafftools::OrganizationsController, type: :controller do
   describe 'DELETE #remove_user', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { delete :remove_user, params: { id: organization.id, user_id: user.id } }
-          .to raise_error(ActionController::RoutingError)
+        delete :remove_user, params: { id: organization.id, user_id: user.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/repo_accesses_controller_spec.rb
+++ b/spec/controllers/stafftools/repo_accesses_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Stafftools::RepoAccessesController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: repo_access.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: repo_access.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/resources_controller_spec.rb
+++ b/spec/controllers/stafftools/resources_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Stafftools::ResourcesController, type: :controller do
   describe 'GET #index', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :index }.to raise_error(ActionController::RoutingError)
+        get :index
+        expect(response.status).to eq(404)
       end
     end
 
@@ -56,7 +57,8 @@ RSpec.describe Stafftools::ResourcesController, type: :controller do
   describe 'GET #search', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :search }.to raise_error(ActionController::RoutingError)
+        get :search
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/stafftools/users_controller_spec.rb
+++ b/spec/controllers/stafftools/users_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Stafftools::UsersController, type: :controller do
   describe 'GET #show', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { get :show, params: { id: user.id } }.to raise_error(ActionController::RoutingError)
+        get :show, params: { id: user.id }
+        expect(response.status).to eq(404)
       end
     end
 
@@ -36,7 +37,8 @@ RSpec.describe Stafftools::UsersController, type: :controller do
   describe 'POST #impersonate', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { post :impersonate, params: { id: student.id } }.to raise_error(ActionController::RoutingError)
+        post :impersonate, params: { id: student.id }
+        expect(response.status).to eq(404)
       end
     end
 
@@ -62,7 +64,8 @@ RSpec.describe Stafftools::UsersController, type: :controller do
   describe 'DELETE #stop_impersonating', :vcr do
     context 'as an unauthorized user' do
       it 'returns a 404' do
-        expect { delete :stop_impersonating, params: { id: student.id } }.to raise_error(ActionController::RoutingError)
+        delete :stop_impersonating, params: { id: student.id }
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/controllers/student_identifier_types_controller_spec.rb
+++ b/spec/controllers/student_identifier_types_controller_spec.rb
@@ -117,61 +117,55 @@ RSpec.describe StudentIdentifierTypesController, type: :controller do
   context 'flipper is not enabled for the user' do
     describe 'GET #index', :vcr do
       it 'returns a 404' do
-        expect do
-          get :index, params: { organization_id: organization.slug }
-        end.to raise_error(ActionController::RoutingError)
+        get :index, params: { organization_id: organization.slug }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'GET #new', :vcr do
       it 'returns a 404' do
-        expect do
-          get :new, params: { organization_id: organization.slug }
-        end.to raise_error(ActionController::RoutingError)
+        get :new, params: { organization_id: organization.slug }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'POST #create', :vcr do
       it 'returns a 404' do
-        expect do
-          post :create, params: {
-            organization_id: organization.slug,
-            student_identifier_type: { name: 'Test', description: 'Test' }
-          }
-        end.to raise_error(ActionController::RoutingError)
+        post :create, params: {
+          organization_id: organization.slug,
+          student_identifier_type: { name: 'Test', description: 'Test' }
+        }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'GET #edit', :vcr do
       it 'returns a 404' do
         student_identifier_type
-        expect do
-          get :edit, params: { organization_id: organization.slug, id: student_identifier_type.id }
-        end.to raise_error(ActionController::RoutingError)
+        get :edit, params: { organization_id: organization.slug, id: student_identifier_type.id }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'PATCH #update', :vcr do
       it 'returns a 404' do
         options = { name: 'Test2', description: 'Test2' }
-        expect do
-          patch :update, params: {
-            organization_id: organization.slug,
-            id: student_identifier_type.id,
-            student_identifier_type: options
-          }
-        end.to raise_error(ActionController::RoutingError)
+        patch :update, params: {
+          organization_id: organization.slug,
+          id: student_identifier_type.id,
+          student_identifier_type: options
+        }
+        expect(response.status).to eq(404)
       end
     end
 
     describe 'DELETE #destroy', :vcr do
       it 'returns a 404' do
         student_identifier_type
-        expect do
-          delete :destroy, params: {
-            id: student_identifier_type.id, organization_id: organization
-          }
-        end.to raise_error(ActionController::RoutingError)
+        delete :destroy, params: {
+          id: student_identifier_type.id, organization_id: organization
+        }
+        expect(response.status).to eq(404)
       end
     end
   end


### PR DESCRIPTION
Modify existing `404.html` to handle Routing Exception and add `invalid_link_error.html` to handle RecordNotFound exception.

Closes #432

Screenshots: 
- `invalid_link_error.html`

![link](https://cloud.githubusercontent.com/assets/14261624/26072031/c2566650-39c7-11e7-87f9-cd3794896e02.png)



- `404.html`

![404](https://cloud.githubusercontent.com/assets/14261624/26072034/c71c465a-39c7-11e7-8729-cecc9159b8d9.png)




