### PR TITLE
More informative error message when trying to create a classroom with an Org that's in use

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -108,16 +108,19 @@ class OrganizationsController < ApplicationController
     @organization = Organization.find_by!(slug: params[:id])
   end
 
+  # rubocop:disable AbcSize
   def set_users_github_organizations
     @users_github_organizations = current_user.github_user.organization_memberships.map do |membership|
       {
-        classroom: Organization.unscoped.includes(:users).find_by(github_id: membership.organization.id),
-        github_id: membership.organization.id,
-        login:     membership.organization.login,
-        role:      membership.role
+        classroom:   Organization.unscoped.includes(:users).find_by(github_id: membership.organization.id),
+        github_id:   membership.organization.id,
+        login:       membership.organization.login,
+        owner_login: membership.user.login,
+        role:        membership.role
       }
     end
   end
+  # rubocop:enable AbcSize
 
   # Check if the current user has any organizations with admin privilege,
   # if so add the user to the corresponding classroom automatically.

--- a/app/views/organizations/_disabled_organization_select.html.erb
+++ b/app/views/organizations/_disabled_organization_select.html.erb
@@ -1,4 +1,4 @@
-<% aria_label = org[:role] != 'admin' ? 'You cannot add this organization to classroom because you are not an owner' : 'Another owner has already added this organization to GitHub Classroom' %>
+<% aria_label = org[:role] != 'admin' ? 'You cannot add this organization to classroom because you are not an owner' : "@#{org[:owner_login]} has already added this organization to GitHub Classroom" %>
 
 <div class="organization-select-target disabled tooltipped tooltipped-s" aria-label="<%= aria_label %>">
   <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar organization-select-avatar', width: 100, height: 100, alt: "@#{org[:login]}" %>


### PR DESCRIPTION
Closes #845 

Display a more informative message with the owners login when we cannot use an org for a classroom because it is already used by another Classroom

<img width="1333" alt="screen shot 2017-05-23 at 9 24 02 am" src="https://cloud.githubusercontent.com/assets/4149056/26364676/f286516e-3f99-11e7-9497-a30ad0329c7f.png">

@johndbritton @tarebyte 

