### PR TITLE
Add Probot stale config file

### DIFF
--- a/.github/stable.yml
+++ b/.github/stable.yml
@@ -1,0 +1,11 @@
+daysUntilStale: 60
+daysUntilClose: 7
+exemptLabels:
+  - Security
+  - feature-request
+staleLabel: wontfix
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false


### PR DESCRIPTION
@tarebyte has installed Probot: Stale to Classroom, this PR adds the necessary config file. 

I've left most of the config defaults alone, but added feature-request to the exempt list. I don't think feature requests really go stale, it might be a while until we can get around to a specific one but I think we can assume it's still a valid feature unless we close ourselves.