### PR TITLE
Fix styling issue with flash errors

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -891,3 +891,7 @@ hr {
     vertical-align: top;
   }
 }
+
+.flash.flash-error p:first-of-type {
+  margin-top: 0;
+}


### PR DESCRIPTION
Normally, we don't use `<p>` tags in flash messages. In assignment/new and group-assignment/new though, we use them to separate many different errors. This fixes a visual bug caused by `<p>` tags having a margin-top.

Before: 
<img width="582" alt="screen shot 2017-05-24 at 3 02 57 pm" src="https://cloud.githubusercontent.com/assets/4149056/26427597/5137b2f4-4092-11e7-96e5-a47ed4068886.png">

After:
<img width="579" alt="screen shot 2017-05-24 at 3 02 45 pm" src="https://cloud.githubusercontent.com/assets/4149056/26427604/560d7480-4092-11e7-9008-48eb9c4f1d5d.png">


