### PR TITLE
Add functionality to watch AssignmentRepo and GroupAssignmentRepo

### DIFF
--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -67,6 +67,8 @@ class GroupAssignmentInvitationsController < ApplicationController
     users_group_assignment_repo = invitation.redeem_for(current_user, selected_group, new_group_title)
 
     if users_group_assignment_repo.present?
+      options = { subscribed: true }
+      current_user.github_client.update_subscription(users_group_assignment_repo.github_repository.full_name, options)
       yield if block_given?
     else
       flash[:error] = 'An error has occurred, please refresh the page and try again.'

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -67,8 +67,7 @@ class GroupAssignmentInvitationsController < ApplicationController
     users_group_assignment_repo = invitation.redeem_for(current_user, selected_group, new_group_title)
 
     if users_group_assignment_repo.present?
-      options = { subscribed: true }
-      current_user.github_client.update_subscription(users_group_assignment_repo.github_repository.full_name, options)
+      current_user.github_user.watch_repository(users_group_assignment_repo)
       yield if block_given?
     else
       flash[:error] = 'An error has occurred, please refresh the page and try again.'

--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -91,7 +91,6 @@ class AssignmentRepo
     # as a collaborator.
     #
     # Returns true if successful, otherwise raises a Result::Error
-
     def add_user_to_repository!(github_repository_id)
       options = {}.tap { |opt| opt[:permission] = 'admin' if assignment.students_are_repo_admins? }
 

--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -69,6 +69,8 @@ class AssignmentRepo
         push_starter_code!(assignment_repo.github_repo_id)
       end
 
+      add_user_to_repo_watchlist(assignment_repo)
+
       begin
         assignment_repo.save!
       rescue ActiveRecord::RecordInvalid
@@ -85,10 +87,16 @@ class AssignmentRepo
 
     private
 
+    def add_user_to_repo_watchlist(repo)
+      options = { subscribed: true }
+      user.github_client.update_subscription(repo.github_repository.full_name, options)
+    end
+
     # Internal: Add the User to the GitHub repository
     # as a collaborator.
     #
     # Returns true if successful, otherwise raises a Result::Error
+
     def add_user_to_repository!(github_repository_id)
       options = {}.tap { |opt| opt[:permission] = 'admin' if assignment.students_are_repo_admins? }
 

--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -69,7 +69,7 @@ class AssignmentRepo
         push_starter_code!(assignment_repo.github_repo_id)
       end
 
-      add_user_to_repo_watchlist(assignment_repo)
+      user.github_user.watch_repository(assignment_repo)
 
       begin
         assignment_repo.save!
@@ -86,11 +86,6 @@ class AssignmentRepo
     # rubocop:enable MethodLength
 
     private
-
-    def add_user_to_repo_watchlist(repo)
-      options = { subscribed: true }
-      user.github_client.update_subscription(repo.github_repository.full_name, options)
-    end
 
     # Internal: Add the User to the GitHub repository
     # as a collaborator.

--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -63,13 +63,12 @@ class AssignmentRepo
         user: user
       )
 
+      user.github_user.watch_repository(assignment_repo)
       add_user_to_repository!(assignment_repo.github_repo_id)
 
       if assignment.starter_code?
         push_starter_code!(assignment_repo.github_repo_id)
       end
-
-      user.github_user.watch_repository(assignment_repo)
 
       begin
         assignment_repo.save!

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -12,8 +12,11 @@ class GitHubUser < GitHubResource
   end
 
   def watch_repository(repo)
-    options = { subscribed: true }
-    @client.update_subscription(repo.github_repository.full_name, options)
+    GitHub::Errors.with_error_handling do
+      @client.update_subscription(repo.github_repository.full_name, subscribed: true)
+    end
+  rescue GitHub::Error
+    false
   end
 
   def authorized_access_token?

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -11,6 +11,11 @@ class GitHubUser < GitHubResource
     end
   end
 
+  def watch_repository(repo)
+    options = { subscribed: true }
+    @client.update_subscription(repo.github_repository.full_name, options)
+  end
+
   def authorized_access_token?
     GitHub::Errors.with_error_handling do
       GitHubClassroom.github_client.check_application_authorization(


### PR DESCRIPTION
After accepting invitation user would be automatically added watchlist of created repo

Closes #775

@nwoodthorpe @tarebyte 

Will fix failing tests by recording cassettes once code to watch repos is approved.