### PR TITLE
Make repo accesses optional for assignment repos

### DIFF
--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -4,7 +4,7 @@ class AssignmentRepo < ApplicationRecord
   update_index('stafftools#assignment_repo') { self }
 
   belongs_to :assignment
-  belongs_to :repo_access
+  belongs_to :repo_access, optional: true
   belongs_to :user
 
   has_one :organization, -> { unscope(where: :deleted_at) }, through: :assignment

--- a/spec/models/assignment_repo_spec.rb
+++ b/spec/models/assignment_repo_spec.rb
@@ -45,4 +45,13 @@ RSpec.describe AssignmentRepo, type: :model do
       end
     end
   end
+
+  describe 'belongs_to repo_access' do
+    it 'is optional' do
+      repo = build(:assignment_repo, assignment: assignment, github_repo_id: 42)
+      repo.repo_access = nil
+
+      expect(repo.valid?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Rails 5 enforces validations on `belongs_to` that the thing exists, but none of our new `AssignmentRepo`s have a `repo_access` (legacy reasons).

This was causing exceptions every time we tried to update an `AssignmentRepo`.

@tarebyte 