### PR TITLE
Allow staff to add users to feature preview group

### DIFF
--- a/app/assets/stylesheets/components/boxed-group.scss
+++ b/app/assets/stylesheets/components/boxed-group.scss
@@ -1,3 +1,15 @@
+.Box--dangerzone {
+  .Box-header {
+    background-color: #df3e3e;
+    border: 1px solid #a00;
+
+    .Box-title {
+      color: #fff;
+      text-shadow: 0 -1px 0 #900;
+    }
+  }
+}
+
 .boxed-group {
   position: relative;
   margin-top: 1rem;

--- a/app/assets/stylesheets/stafftools.scss
+++ b/app/assets/stylesheets/stafftools.scss
@@ -1,7 +1,11 @@
 .stafftools {
   background: #fff;
 
-  .boxed-group > h3 {
+  .Box {
+    margin-top: 1rem;
+  }
+
+  .Box > .Box-header, .boxed-group > h3 {
     background-image: linear-gradient(
       -45deg,
       rgba(192, 192, 192, 0.1) 25%,

--- a/app/assets/stylesheets/stafftools.scss
+++ b/app/assets/stylesheets/stafftools.scss
@@ -5,7 +5,8 @@
     margin-top: 1rem;
   }
 
-  .Box > .Box-header, .boxed-group > h3 {
+  .Box > .Box-header,
+  .boxed-group > h3 {
     background-image: linear-gradient(
       -45deg,
       rgba(192, 192, 192, 0.1) 25%,

--- a/app/controllers/stafftools/users_controller.rb
+++ b/app/controllers/stafftools/users_controller.rb
@@ -20,6 +20,26 @@ module Stafftools
       redirect_to stafftools_root_path
     end
 
+    def enable_feature_previewing
+      if @user.update_attributes(feature_previewer: true)
+        flash[:success] = "#{@user.github_user.login} can now see select preview features"
+      else
+        flash[:error] = "We weren't able to enable seeing preview features for #{@user.github_user.login}"
+      end
+
+      redirect_to stafftools_user_path(@user)
+    end
+
+    def disable_feature_previewing
+      if @user.update_attributes(feature_previewer: false)
+        flash[:success] = "#{@user.github_user.login} can no longer see select preview features"
+      else
+        flash[:error] = "We weren't able to remove #{@user.github_user.login} from seeing preview features"
+      end
+
+      redirect_to stafftools_user_path(@user)
+    end
+
     private
 
     def set_user

--- a/app/views/stafftools/users/show.html.erb
+++ b/app/views/stafftools/users/show.html.erb
@@ -97,6 +97,28 @@
           <a data-remodal-target="impersonate-user" class="btn btn-danger">Impersonate</a>
         </div>
 
+        <div class="Box-row d-flex flex-items-center">
+          <% if @user.feature_previewer? %>
+            <div class="flex-auto">
+              <strong>Disable <%= "@#{@user.github_user.login}" %> from previewing features</strong>
+              <div class="text-small text-gray-light">
+                <strong><%= @user.github_user.login %></strong> will no longer be able to see any feature we have enabled for the features preview group.
+              </div>
+            </div>
+
+            <%= link_to 'Disable', disable_feature_previewing_stafftools_user_path(@user), class: 'btn btn-danger', method: :delete %>
+          <% else %>
+            <div class="flex-auto">
+              <strong>Enable <%= "@#{@user.github_user.login}" %> to preview features</strong>
+              <div class="text-small text-gray-light">
+                This will allow <strong><%= @user.github_user.login %></strong> to see any feature we have enabled for the features preview group.
+              </div>
+            </div>
+
+            <%= link_to 'Enable', enable_feature_previewing_stafftools_user_path(@user), class: 'btn btn-danger', method: :patch %>
+          <% end %>
+        </div>
+      </ul>
     </div>
   <% end %>
 </div>

--- a/app/views/stafftools/users/show.html.erb
+++ b/app/views/stafftools/users/show.html.erb
@@ -81,16 +81,22 @@
   <% end %>
 
   <% if @user.id != current_user.id %>
-    <div class="boxed-group dangerzone">
-      <h3>Dangerzone</h3>
-
-      <div class="boxed-group-inner">
-        <h4>Impersonate <%= "@#{@user.github_user.login}" %></h4>
-        <a data-remodal-target="impersonate-user" class="btn btn-danger boxed-action">Impersonate <%= "@#{@user.github_user.login}" %></a>
-        <p>This will send you to <strong><%= @user.github_user.login %></strong>'s Classroom dashboard as <strong><%= @user.github_user.login %></strong>.</p>
-
-        <%= render partial: 'stafftools/users/impersonate_user_confirmation_modal', locals: { user: @user } %>
+    <div class="Box Box--condensed Box--dangerzone">
+      <div class="Box-header">
+        <h3 class="Box-title">Dangerzone</h3>
       </div>
+      <ul>
+        <div class="Box-row d-flex flex-items-center">
+          <div class="flex-auto">
+            <strong>Impersonate <%= "@#{@user.github_user.login}" %></strong>
+            <div class="text-small text-gray-light">
+              This will send you to <strong><%= @user.github_user.login %></strong>'s Classroom dashboard as <strong><%= @user.github_user.login %></strong>.
+            </div>
+          </div>
+
+          <a data-remodal-target="impersonate-user" class="btn btn-danger">Impersonate</a>
+        </div>
+
     </div>
   <% end %>
 </div>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -18,7 +18,5 @@ module GitHubClassroom
   end
 end
 
-# Flipper group for staff
-Flipper.register(:staff) do |user|
-  user.respond_to?(:staff?) && user.staff?
-end
+Flipper.register(:staff)              { |user| user.respond_to?(:staff?) && user.staff?                         }
+Flipper.register(:feature_previewers) { |user| user.respond_to?(:feature_previewer?) && user.feature_previewer? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,9 @@ Rails.application.routes.draw do
       member do
         post :impersonate
         delete :stop_impersonating
+
+        patch  :preview_features, to: 'users#enable_feature_previewing',  as: :enable_feature_previewing
+        delete :preview_features, to: 'users#disable_feature_previewing', as: :disable_feature_previewing
       end
     end
 

--- a/db/migrate/20170622032909_add_feature_previewers_to_user.rb
+++ b/db/migrate/20170622032909_add_feature_previewers_to_user.rb
@@ -1,0 +1,5 @@
+class AddFeaturePreviewersToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :feature_previewer, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620200357) do
+ActiveRecord::Schema.define(version: 20170622032909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 20170620200357) do
     t.datetime "updated_at", null: false
     t.boolean "site_admin", default: false
     t.datetime "last_active_at", null: false
+    t.boolean "feature_previewer", default: false
     t.index ["token"], name: "index_users_on_token", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#feature_previewer?' do
+    it 'returns if the User is can preview features' do
+      expect(subject.feature_previewer?).to be(false)
+      subject.update_attributes(feature_previewer: true)
+      expect(subject.feature_previewer?).to be(true)
+    end
+  end
+
   describe '#github_client_scopes', :vcr do
     it 'returns an Array of scopes' do
       subject.assign_from_auth_hash(github_omniauth_hash)


### PR DESCRIPTION
This is one implementation for allowing us to keep a group of "feature previewers" that we can add when we're ready for beta testing.

## Demo in stafftools 
![enabling feature](https://user-images.githubusercontent.com/564113/27418700-b1e83434-56d1-11e7-8b65-f6ffd0053879.gif)

## Todo
- [ ] Feedback
- [ ] Controller tests
- [ ] Extract migration into another PR to ship and run

/cc @mozzadrella as you may want this to look differently