### PR TITLE
Fix errors on deadlines

### DIFF
--- a/app/models/assignment/editor.rb
+++ b/app/models/assignment/editor.rb
@@ -74,7 +74,7 @@ class Assignment
     def new_deadline(deadline)
       new_deadline = Deadline::Factory.build_from_string(deadline_at: deadline)
       unless new_deadline.valid?
-        @assignment.errors.add(:deadline, new_deadline.errors[:deadline_at].join("\n") )
+        @assignment.errors.add(:deadline, new_deadline.errors[:deadline_at].join("\n"))
         raise Result::Error
       end
 

--- a/app/models/assignment/editor.rb
+++ b/app/models/assignment/editor.rb
@@ -73,7 +73,10 @@ class Assignment
 
     def new_deadline(deadline)
       new_deadline = Deadline::Factory.build_from_string(deadline_at: deadline)
-      raise Result::Error, new_deadline.errors.full_messages.join("\n") unless new_deadline.valid?
+      unless new_deadline.valid?
+        @assignment.errors.add(:deadline, new_deadline.errors[:deadline_at].join("\n") )
+        raise Result::Error
+      end
 
       @assignment.deadline = new_deadline
       @assignment.deadline.create_job

--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -39,9 +39,10 @@
 </dl>
 
 <% if current_user.feature_enabled?(:deadlines) %>
-  <dl class="form">
+  <dl class="<%= view.form_class_for(:deadline) %>">
     <dt><label>Deadline <small>(optional)</small></label></dt>
     <dd><%= f.text_field :deadline, class: 'jquery-datetimepicker form-control input-contrast input-block', value: DeadlineFormatHelper.convert(f.object.deadline) %></dd>
+    <%= render('shared/form_error', errors: view.error_message_for(:deadline)) if view.errors_for?(:deadline) %>
     <span class="note">After the deadline, GitHub Classroom will save the latest commit from each repo as a submission. Submission commits are viewable on the assignment page.</span>
   </dl>
 <% end %>

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -45,9 +45,10 @@
 </dl>
 
 <% if current_user.feature_enabled?(:deadlines) %>
-  <dl class="form">
+  <dl class="<%= view.form_class_for(:deadline) %>">
     <dt><label>Deadline <small>(optional)</small></label></dt>
     <dd><%= f.text_field :deadline, class: 'jquery-datetimepicker form-control input-contrast input-block', value: DeadlineFormatHelper.convert(f.object.deadline) %></dd>
+    <%= render('shared/form_error', errors: view.error_message_for(:deadline)) if view.errors_for?(:deadline) %>
     <span class="note">After the deadline, GitHub Classroom will save the latest commit from each repo as a submission. Submission commits are viewable on the assignment page.</span>
   </dl>
 <% end %>


### PR DESCRIPTION
Since we didn't add errors on the `@assignment` object, the view had no idea something had gone wrong with the deadline. Also, we didn't have the FormView tooltip logic in the view.

@tarebyte 