### PR TITLE
Add I18n support for stafftools navigation and resources

### DIFF
--- a/app/views/stafftools/_navigation.html.erb
+++ b/app/views/stafftools/_navigation.html.erb
@@ -1,9 +1,9 @@
 <nav class="menu">
-  <span class="menu-heading"><%= octicon 'rocket' %> Site Admin</span>
-  <%= link_to 'Search', stafftools_root_path, class: 'menu-item selected' %>
+  <span class="menu-heading"><%= octicon 'rocket' %> <%= t('views.stafftools.site_admin') %></span>
+  <%= link_to t('views.stafftools.search'), stafftools_root_path, class: 'menu-item selected' %>
 </nav>
 
 <nav class="menu">
-  <span class="menu-heading"><%= octicon 'code' %> Developer Tools</span>
-  <%= link_to 'Features', stafftools_flipper_path, class: 'menu-item' %>
+  <span class="menu-heading"><%= octicon 'code' %> <%= t('views.stafftools.developer_tools') %></span>
+  <%= link_to t('views.stafftools.features'), stafftools_flipper_path, class: 'menu-item' %>
 </nav>

--- a/app/views/stafftools/resources/_search_results.html.erb
+++ b/app/views/stafftools/resources/_search_results.html.erb
@@ -16,7 +16,7 @@
   <% else %>
     <div class="blankslate">
       <%= octicon 'search', height: 22 %>
-      <h3>We couldn't find any matching resources</h3>
+      <h3><%= t('views.stafftools.resources.resource_not_found') %></h3>
     </div>
   <% end %>
 <% end %>

--- a/app/views/stafftools/resources/index.html.erb
+++ b/app/views/stafftools/resources/index.html.erb
@@ -1,11 +1,11 @@
 <div class="site-content">
   <div class="site-content-cap">
-    <h2 class="site-content-heading">Search</h2>
+    <h2 class="site-content-heading"><%= t('views.stafftools.resources.search') %></h2>
   </div>
 
   <div class="site-content-body">
     <%= form_tag stafftools_resource_search_path, id: 'js-search-form', method: :get, remote: true do %>
-      <%= text_field_tag :query, params[:query], class: 'input-block form-control', placeholder: 'Search Classroom...', autofocus: true %>
+      <%= text_field_tag :query, params[:query], class: 'input-block form-control', placeholder: t('views.stafftools.resources.search_classroom'), autofocus: true %>
     <% end %>
 
     <div class="search-results" id="js-search-results">

--- a/config/locales/views/stafftools/en.yml
+++ b/config/locales/views/stafftools/en.yml
@@ -1,0 +1,7 @@
+en:
+  views:
+    stafftools:
+      site_admin: 'Site Admin'
+      developer_tools: 'Developer Tools'
+      search: 'Search'
+      features: 'Features'

--- a/config/locales/views/stafftools/resources/en.yml
+++ b/config/locales/views/stafftools/resources/en.yml
@@ -1,0 +1,7 @@
+en:
+  views:
+    stafftools:
+      resources:
+        resource_not_found: "We couldn't find any matching resources"
+        search_classroom: 'Search Classroom...'
+        search: 'Search'


### PR DESCRIPTION
Convert static text to symbol in stafftools/resources and stafftools/navigation views