### PR TITLE
Memoize disabled? to save a ton of API requests

### DIFF
--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -24,7 +24,7 @@ class AssignmentRepo < ApplicationRecord
   # This should really be in a view model
   # but it'll live here for now.
   def disabled?
-    !github_repository.on_github? || !github_user.on_github?
+    @disabled ||= !github_repository.on_github? || !github_user.on_github?
   end
 
   def private?

--- a/app/models/group_assignment_repo.rb
+++ b/app/models/group_assignment_repo.rb
@@ -39,7 +39,7 @@ class GroupAssignmentRepo < ApplicationRecord
 
   # TODO: Move to a view model
   def disabled?
-    !github_repository.on_github? || !github_team.on_github?
+    @disabled ||= !github_repository.on_github? || !github_team.on_github?
   end
 
   def github_repository


### PR DESCRIPTION
While doing some profiling last week, I noticed that our calls to `disabled?` are causing a TON of API requests on `group_assignment/show` and `assignment/show`, coming from the `group_assignment_repo/show` and `assignment_repo/show` partials.

On an assignment repo, we make 3 `disabled?` calls, which equals 6 API requests.

On a group assignment repo, we make between 3 and 8 `disabled?` calls depending on the number of team members, which equals 6 - 16 API requests.

The value of `disabled?` shouldn't change during the time we're rendering these partials, so memoizing won't have any visible impact. It will, though, bring both of these partials down to only 2 API requests.

@tarebyte @johndbritton 