### PR TITLE
Migrations to remove identifier stuff

### DIFF
--- a/db/migrate/20170629200720_remove_identifier_tables.rb
+++ b/db/migrate/20170629200720_remove_identifier_tables.rb
@@ -1,0 +1,9 @@
+class RemoveIdentifierTables < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :assignments, :student_identifier_type_id
+    remove_column :group_assignments, :student_identifier_type_id
+
+    drop_table :student_identifier_types
+    drop_table :student_identifiers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620200357) do
+ActiveRecord::Schema.define(version: 20170629200720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,7 +52,6 @@ ActiveRecord::Schema.define(version: 20170620200357) do
     t.integer "creator_id"
     t.datetime "deleted_at"
     t.string "slug", null: false
-    t.integer "student_identifier_type_id"
     t.boolean "students_are_repo_admins", default: false, null: false
     t.index ["deleted_at"], name: "index_assignments_on_deleted_at"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
@@ -102,7 +101,6 @@ ActiveRecord::Schema.define(version: 20170620200357) do
     t.datetime "deleted_at"
     t.string "slug", null: false
     t.integer "max_members"
-    t.integer "student_identifier_type_id"
     t.boolean "students_are_repo_admins", default: false, null: false
     t.index ["deleted_at"], name: "index_group_assignments_on_deleted_at"
     t.index ["organization_id"], name: "index_group_assignments_on_organization_id"
@@ -166,30 +164,6 @@ ActiveRecord::Schema.define(version: 20170620200357) do
     t.index ["github_team_id"], name: "index_repo_accesses_on_github_team_id", unique: true
     t.index ["organization_id"], name: "index_repo_accesses_on_organization_id"
     t.index ["user_id"], name: "index_repo_accesses_on_user_id"
-  end
-
-  create_table "student_identifier_types", id: :serial, force: :cascade do |t|
-    t.integer "organization_id"
-    t.string "name", null: false
-    t.string "description", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.index ["organization_id"], name: "index_student_identifier_types_on_organization_id"
-  end
-
-  create_table "student_identifiers", id: :serial, force: :cascade do |t|
-    t.integer "organization_id"
-    t.integer "user_id"
-    t.integer "student_identifier_type_id"
-    t.string "value", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.index ["organization_id", "user_id", "student_identifier_type_id"], name: "index_student_identifiers_on_org_and_user_and_type", unique: true
-    t.index ["organization_id"], name: "index_student_identifiers_on_organization_id"
-    t.index ["student_identifier_type_id"], name: "index_student_identifiers_on_student_identifier_type_id"
-    t.index ["user_id"], name: "index_student_identifiers_on_user_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
A migration to remove the rows and tables in the schema related to the old implementation of identifiers.

The diff looks gnarly right now because this is based on #975, once that's merged, this'll look cleaner. The changes are in the latest commit. 