### PR TITLE
Migration to add tables for new roster models, + roster_id on org

### DIFF
--- a/db/migrate/20170629203747_add_new_identifier_tables.rb
+++ b/db/migrate/20170629203747_add_new_identifier_tables.rb
@@ -1,12 +1,12 @@
 class AddNewIdentifierTables < ActiveRecord::Migration[5.1]
   def change
-    create_table :roster do |t|
+    create_table :rosters do |t|
       t.string :identifier_name, null: false
 
       t.timestamps null: false
     end
 
-    create_table :roster_entry do |t|
+    create_table :roster_entries do |t|
       t.string :identifier, null: false
       t.references :roster, null: false
       t.references :user

--- a/db/migrate/20170629203747_add_new_identifier_tables.rb
+++ b/db/migrate/20170629203747_add_new_identifier_tables.rb
@@ -1,0 +1,20 @@
+class AddNewIdentifierTables < ActiveRecord::Migration[5.1]
+  def change
+    create_table :roster do |t|
+      t.string :identifier_name, null: false
+
+      t.timestamps null: false
+    end
+
+    create_table :roster_entry do |t|
+      t.string :identifier, null: false
+      t.references :roster, null: false
+      t.references :user
+
+      t.timestamps null: false
+    end
+
+    add_column :organizations, :roster_id, :integer
+    add_index :organizations, :roster_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170629200720) do
+ActiveRecord::Schema.define(version: 20170629203747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,8 +143,10 @@ ActiveRecord::Schema.define(version: 20170629200720) do
     t.string "slug", null: false
     t.integer "webhook_id"
     t.boolean "is_webhook_active", default: false
+    t.integer "roster_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
     t.index ["github_id"], name: "index_organizations_on_github_id", unique: true
+    t.index ["roster_id"], name: "index_organizations_on_roster_id"
     t.index ["slug"], name: "index_organizations_on_slug"
   end
 
@@ -164,6 +166,22 @@ ActiveRecord::Schema.define(version: 20170629200720) do
     t.index ["github_team_id"], name: "index_repo_accesses_on_github_team_id", unique: true
     t.index ["organization_id"], name: "index_repo_accesses_on_organization_id"
     t.index ["user_id"], name: "index_repo_accesses_on_user_id"
+  end
+
+  create_table "roster", force: :cascade do |t|
+    t.string "identifier_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "roster_entry", force: :cascade do |t|
+    t.string "identifier", null: false
+    t.bigint "roster_id", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["roster_id"], name: "index_roster_entry_on_roster_id"
+    t.index ["user_id"], name: "index_roster_entry_on_user_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,20 +168,20 @@ ActiveRecord::Schema.define(version: 20170629203747) do
     t.index ["user_id"], name: "index_repo_accesses_on_user_id"
   end
 
-  create_table "roster", force: :cascade do |t|
-    t.string "identifier_name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "roster_entry", force: :cascade do |t|
+  create_table "roster_entries", force: :cascade do |t|
     t.string "identifier", null: false
     t.bigint "roster_id", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["roster_id"], name: "index_roster_entry_on_roster_id"
-    t.index ["user_id"], name: "index_roster_entry_on_user_id"
+    t.index ["roster_id"], name: "index_roster_entries_on_roster_id"
+    t.index ["user_id"], name: "index_roster_entries_on_user_id"
+  end
+
+  create_table "rosters", force: :cascade do |t|
+    t.string "identifier_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Works towards #986 

As discussed here: https://github.com/education/classroom/issues/448#issuecomment-311786419

These are the new tables for rosters. Since an organization belongs to a roster, the organization now has a `roster_id` column