### PR TITLE
Add missing association on user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   has_many :assignment_repos
   has_many :repo_accesses, dependent: :destroy
+  has_one :roster_entry
 
   has_and_belongs_to_many :organizations
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   has_many :assignment_repos
   has_many :repo_accesses, dependent: :destroy
-  has_one :roster_entry
+  has_many :roster_entries
 
   has_and_belongs_to_many :organizations
 


### PR DESCRIPTION
Forgot this association in my last PR. A RosterEntry belongs_to a User, so a User should has_many RosterEntry.

