### PR TITLE
Show failure text if we error when trying to get branch

### DIFF
--- a/app/view_models/shared_assignment_repo_view.rb
+++ b/app/view_models/shared_assignment_repo_view.rb
@@ -17,11 +17,15 @@ class SharedAssignmentRepoView < ViewModel
 
   def commit_text
     pluralize(number_of_github_commits, 'commit')
+  rescue GitHub::Error
+    'Failed to fetch commit data'
   end
 
   def github_commits_url
     branch = github_repository.default_branch
     github_repository.commits_url(branch)
+  rescue GitHub::Error
+    ''
   end
 
   def disabled_class


### PR DESCRIPTION
Right now, if `default_branch` errors, it bubbles all the way to ActionView and then we crash.

This PR adds handling in the view model. Also, because of the way the detail partials work, by returning `''` as the `url` in the error case, the partial is rendered as a `span` instead of a `a`.

@tarebyte 