### PR TITLE
Fix styling on error partial

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -379,7 +379,6 @@ hr {
   }
 
   &.is-error {
-    height: 48px;
     background-color: rgba($red, 0.9);
     border-radius: 3px;
 


### PR DESCRIPTION
Closes #1011 

Before:
<img width="902" alt="screen shot 2017-07-12 at 10 35 00 am" src="https://user-images.githubusercontent.com/4149056/28131196-05a5a7e2-66ee-11e7-82fc-828a8e40bd4d.png">

After:
<img width="875" alt="screen shot 2017-07-12 at 10 34 13 am" src="https://user-images.githubusercontent.com/4149056/28131200-0c3634dc-66ee-11e7-87bd-f0372743fb8c.png">

