### PR TITLE
Rosters should optionally belong to an organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,7 +13,7 @@ class Organization < ApplicationRecord
   has_many :group_assignments,        dependent: :destroy
   has_many :repo_accesses,            dependent: :destroy
 
-  belongs_to :roster
+  belongs_to :roster, optional: true
 
   has_and_belongs_to_many :users
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -5,6 +5,19 @@ require 'rails_helper'
 RSpec.describe Organization, type: :model do
   subject { create(:organization, github_id: 12_345) }
 
+  describe 'roster' do
+    it 'can have a roster' do
+      subject.roster = create(:roster)
+      expect(subject.save).to be_truthy
+    end
+
+    it 'can have no roster' do
+      subject.roster = nil
+
+      expect(subject.save).to be_truthy
+    end
+  end
+
   describe 'when title is changed' do
     it 'updates the slug' do
       subject.update_attributes(title: 'New Title')

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Organization, type: :model do
   subject { create(:organization, github_id: 12_345) }
 
-  describe 'roster' do
+  describe 'roster association' do
     it 'can have a roster' do
       subject.roster = create(:roster)
       expect(subject.save).to be_truthy


### PR DESCRIPTION
This is only being triggered by `PingJob`s right now, but it's throwing exceptions. Orgs without a Roster should not be invalid.

