### PR TITLE
Don't run uniqueness validation for invitations with nil short keys

### DIFF
--- a/app/models/assignment_invitation.rb
+++ b/app/models/assignment_invitation.rb
@@ -16,7 +16,7 @@ class AssignmentInvitation < ApplicationRecord
   validates :key, presence:   true
   validates :key, uniqueness: true
 
-  validates :short_key, uniqueness: true
+  validates :short_key, uniqueness: true, allow_nil: true
 
   after_initialize :assign_key
 

--- a/app/models/group_assignment_invitation.rb
+++ b/app/models/group_assignment_invitation.rb
@@ -19,7 +19,7 @@ class GroupAssignmentInvitation < ApplicationRecord
   validates :key, presence:   true
   validates :key, uniqueness: true
 
-  validates :short_key, uniqueness: true
+  validates :short_key, uniqueness: true, allow_nil: true
 
   after_initialize :assign_key
 

--- a/spec/models/assignment_invitation_spec.rb
+++ b/spec/models/assignment_invitation_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe AssignmentInvitation, type: :model do
     expect(assignment_invitation.key).to_not be_nil
   end
 
+  describe 'short_key' do
+    it 'allows multiple invitations with nil short_key' do
+      first_inv, second_inv = create(:assignment_invitation), create(:assignment_invitation)
+
+      first_inv.update_attributes!(short_key: nil)
+      second_inv.short_key = nil
+
+      expect(second_inv.save).to be_truthy
+    end
+  end
+
   describe '#redeem_for' do
     let(:student) { create(:user) }
 

--- a/spec/models/assignment_invitation_spec.rb
+++ b/spec/models/assignment_invitation_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe AssignmentInvitation, type: :model do
 
   describe 'short_key' do
     it 'allows multiple invitations with nil short_key' do
-      first_inv, second_inv = create(:assignment_invitation), create(:assignment_invitation)
+      first_inv = create(:assignment_invitation)
+      second_inv = create(:assignment_invitation)
 
       first_inv.update_attributes!(short_key: nil)
       second_inv.short_key = nil

--- a/spec/models/group_assignment_invitation_spec.rb
+++ b/spec/models/group_assignment_invitation_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
 
   describe 'short_key' do
     it 'allows multiple invitations with nil short_key' do
-      first_inv, second_inv = create(:group_assignment_invitation), create(:group_assignment_invitation)
+      first_inv = create(:group_assignment_invitation)
+      second_inv = create(:group_assignment_invitation)
 
       first_inv.update_attributes!(short_key: nil)
       second_inv.short_key = nil

--- a/spec/models/group_assignment_invitation_spec.rb
+++ b/spec/models/group_assignment_invitation_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
     expect(group_assignment_invitation.key).to_not be_nil
   end
 
+  describe 'short_key' do
+    it 'allows multiple invitations with nil short_key' do
+      first_inv, second_inv = create(:group_assignment_invitation), create(:group_assignment_invitation)
+
+      first_inv.update_attributes!(short_key: nil)
+      second_inv.short_key = nil
+
+      expect(second_inv.save).to be_truthy
+    end
+  end
+
   describe '#redeem_for', :vcr do
     let(:student)       { classroom_student }
     let(:organization)  { classroom_org     }


### PR DESCRIPTION
We should not be running uniqueness checks for invitations with nil short_keys (e.g. all existing invitations).

Also wrote regression specs for assignment and group assignment invitation.