### PR TITLE
Capitalize the letter in wilfriede's handle for CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners
 # -----------
 
-*               @tarebyte @nwoodthorpe @wilfriede
+*               @tarebyte @nwoodthorpe @wilfriedE
 
 README.md       @mozzadrella
 ROADMAP.md      @mozzadrella


### PR DESCRIPTION
@wilfriedE isn't getting set as a codeowner. I guess codeowners is case sensitive.