### PR TITLE
Fix deadline regression

### DIFF
--- a/app/models/assignment/editor.rb
+++ b/app/models/assignment/editor.rb
@@ -49,7 +49,7 @@ class Assignment
 
     # rubocop:disable AbcSize
     def perform
-      recreate_deadline(@options[:deadline]) if deadline_updated?
+      recreate_deadline(@options[:deadline]) if deadline_updated_and_valid?
 
       @assignment.update_attributes(@options.except(:deadline))
       raise Result::Error, @assignment.errors.full_messages.join("\n") unless @assignment.valid?
@@ -90,10 +90,13 @@ class Assignment
       end
     end
 
-    def deadline_updated?
-      return false unless @options[:deadline]
+    def deadline_updated_and_valid?
+      return true unless @options[:deadline].present?
+
       new_deadline_at = DateTime.strptime(@options[:deadline], Deadline::Factory::DATETIME_FORMAT).utc
       new_deadline_at != @assignment.deadline&.deadline_at
+    rescue ArgumentError
+      false
     end
   end
 end

--- a/app/models/assignment/editor.rb
+++ b/app/models/assignment/editor.rb
@@ -91,7 +91,7 @@ class Assignment
     end
 
     def deadline_updated_and_valid?
-      return true unless @options[:deadline].present?
+      return true if @options[:deadline].blank?
 
       new_deadline_at = DateTime.strptime(@options[:deadline], Deadline::Factory::DATETIME_FORMAT).utc
       new_deadline_at != @assignment.deadline&.deadline_at


### PR DESCRIPTION
Introduced in #976 :/

Right now, we can't clear deadlines because we try to `strptime` the empty string.

Side note: We really need a spec for the editor, it's getting really complex. See #1016 