### PR TITLE
Default deadline datepicker time to next hour

### DIFF
--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -10,6 +10,13 @@ function leftpad(val){
   return ("0" + val).slice(-2);
 }
 
+function timeRoundedUp() {
+  var currentDateTime = new Date();
+  var nextHour = currentDateTime.getHours() + 1;
+
+  return (leftpad(nextHour) + ':00');
+}
+
 function initializePicker(picker){
   if($(picker).val() !== ""){
     var d = new Date($(picker).val() + " UTC");
@@ -29,7 +36,8 @@ function initializePicker(picker){
   }
 
   $(picker).datetimepicker({
-    format: 'm/d/Y H:i O'
+    format: 'm/d/Y H:i O',
+    defaultTime: timeRoundedUp()
   });
 }
 


### PR DESCRIPTION
Thanks @mozzadrella for doing user testing and finding this UX issue ✨ 

Currently when you don't have a deadline, the datepicker time defaults to the current hour and 0 minutes, which means the default deadline is always in the past and is invalid.

In most cases, the teacher will be selecting a deadline from the datepicker, but if someone just accepts the default deadline (maybe to see how the deadlines feature works), we shouldn't error.

We now default to the NEXT hour.

<img width="638" alt="screen shot 2017-07-14 at 10 18 47 am" src="https://user-images.githubusercontent.com/4149056/28222944-5649f54a-687e-11e7-94f4-be8678456d36.png">

Also: This is the last fix before everything has been addressed. After that, we should be 🍏 to full ship. 
