### PR TITLE
Remove custom components from Classroom

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,10 +3,10 @@
 
 @import "variables";
 @import "primer-css/index";
+@import "primer-overrides/*";
 
 @import "include-fragment-element/include-fragment-element";
 @import "components/*";
-
 
 @import "layout";
 @import "stafftools";

--- a/app/assets/stylesheets/components/pagination.scss
+++ b/app/assets/stylesheets/components/pagination.scss
@@ -1,6 +1,5 @@
 .paginate-container {
   margin-top: 3rem;
-  text-align: center;
 }
 
 .pagination {

--- a/app/assets/stylesheets/components/pagination.scss
+++ b/app/assets/stylesheets/components/pagination.scss
@@ -19,12 +19,12 @@
   a,
   em,
   span {
-    background-color: #fff;
     padding: 7px 12px;
     margin-right: -4px;
     font-size: 13px;
     font-style: normal;
     font-weight: bold;
+    background-color: #fff;
     border-top: 1px solid #e5e5e5;
     border-bottom: 1px solid #e5e5e5;
     border-left: 1px solid #e5e5e5;

--- a/app/assets/stylesheets/components/pagination.scss
+++ b/app/assets/stylesheets/components/pagination.scss
@@ -4,7 +4,7 @@
 }
 
 .pagination {
-  background-color: #fff;
+  background-color: inherit;
 
   .disabled {
     color: #d3d3d3;
@@ -20,6 +20,7 @@
   a,
   em,
   span {
+    background-color: #fff;
     padding: 7px 12px;
     margin-right: -4px;
     font-size: 13px;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -3,7 +3,6 @@
 }
 
 body {
-  font: 13px/1.4 Helvetica, arial, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
   background-color: #f3f4f6;
 
   &.site {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -264,23 +264,6 @@ main {
   background-color: #555;
 }
 
-.assignment-list-items {
-  .assignment-list-item:not(:first-child) {
-    padding-top: 1rem;
-    margin-top: 1rem;
-    border-top: 1px solid #e3e3e3;
-
-    @media screen and (max-width: 40em) {
-      padding-top: 1rem;
-      margin-top: 0.5rem;
-    }
-  }
-
-  .assignment-list-item:not(:last-child) {
-    margin-bottom: 1rem;
-  }
-}
-
 .assignment-name-link {
   padding-top: 0.4rem;
   margin-top: 0;
@@ -431,19 +414,6 @@ hr {
 
   @media screen and (max-width: 40em) {
     margin-left: 15px;
-  }
-}
-
-.organization-list-items {
-  .organization-list-item:not(:first-child) {
-    padding-top: 2rem;
-    margin-top: 2rem;
-    border-top: 1px solid #e3e3e3;
-
-    @media screen and (max-width: 40em) {
-      padding-top: 1rem;
-      margin-top: 1rem;
-    }
   }
 }
 

--- a/app/assets/stylesheets/primer-overrides/box.scss
+++ b/app/assets/stylesheets/primer-overrides/box.scss
@@ -1,0 +1,19 @@
+// Overridden from https://github.com/primer/primer-css/blob/293d832cc638a0aeeaa64da0b1dc3389f37d40da/modules/primer-box/lib/box.scss
+
+.Box {
+  border: $border-width $border-style #e3e3e3;
+}
+
+.Box-header {
+  background-color: #fbfbfb;
+  border-color: #e3e3e3;
+}
+
+.Box-title {
+  font-weight: $font-weight-normal;
+  color: #5d666f;
+}
+
+.Box-row {
+  border-top: $border-width $border-style #e3e3e3;
+}

--- a/app/assets/stylesheets/primer-overrides/box.scss
+++ b/app/assets/stylesheets/primer-overrides/box.scss
@@ -4,6 +4,41 @@
   border: $border-width $border-style #e3e3e3;
 }
 
+.Box--stafftools {
+  &.Box--condensed {
+    .Box-header {
+      background-color: #f5f5f5;
+      background-image: linear-gradient(
+        -45deg,
+        rgba(192, 192, 192, 0.1) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(192, 192, 192, 0.1) 50%,
+        rgba(192, 192, 192, 0.1) 75%,
+        transparent 75%,
+        transparent
+      );
+      background-size: 50px 50px;
+    }
+  }
+
+  &.Box--danger {
+    .Box-header {
+      background-color: #df3e3e;
+
+      .Box-title {
+        color: #fff;
+        text-shadow: 0 -1px 0 #900;
+      }
+    }
+  }
+
+  .Box-title {
+    font-weight: $font-weight-bold;
+    color: #24292e;
+  }
+}
+
 .Box-header {
   background-color: #fbfbfb;
   border-color: #e3e3e3;

--- a/app/views/assignments/_assignment.html.erb
+++ b/app/views/assignments/_assignment.html.erb
@@ -1,4 +1,4 @@
-<div class="assignment-list-item container-lg clearfix">
+<div class="Box-row d-flex flex-wrap flex-content-center">
   <div class="float-left col-sm-6 d-flex">
     <div class="d-flex flex-column flex-justify-center flex-items-center flex-md-items-start">
       <span class="assignment-icon assignment-icon-individual left">
@@ -16,7 +16,7 @@
   </div>
 
   <div class="float-right col-sm-6 d-flex clipboard-form">
-    <div class="flex-self-center input-group assignment-invite-link">
+    <div class="flex-self-center input-group">
       <%= render partial: "shared/invitations/clipboard_form", locals: InvitationHelper.attributes(assignment.invitation, request.base_url) %>
     </div>
   </div>

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -1,29 +1,29 @@
 <%= render 'organizations/organization_banner' %>
 
-<div class="site-content">
-  <div class="site-content-cap">
-    <h2 class="site-content-heading">
+<div class="Box Box--spacious">
+  <div class="Box-header">
+    <h3 class="Box-title">
       <span class="assignment-icon assignment-icon-individual">
         <%= octicon 'person', height: 22 %>
       </span>
       New individual assignment
-    </h2>
+    </h3>
   </div>
-</div>
 
-<div class="site-content-body">
-  <%= form_for [@organization, @assignment] do |f| %>
-    <div class="columns">
-      <div class="two-thirds column">
-        <%= render partial: 'assignments/assignment_form_options', locals: { f: f } %>
+  <div class="Box-body">
+    <%= form_for [@organization, @assignment] do |f| %>
+      <div class="columns">
+        <div class="two-thirds column">
+          <%= render partial: 'assignments/assignment_form_options', locals: { f: f } %>
+        </div>
+
+        <%= render partial: 'shared/unlimited_free_private_repositories_banner' %>
       </div>
 
-      <%= render partial: 'shared/unlimited_free_private_repositories_banner' %>
-    </div>
-
-    <div class="form-actions">
-      <%= f.submit 'Create Assignment', class: 'btn btn-primary', id: 'assignment_submit' %>
-      <%= link_to 'Cancel', organization_path(@organization), class: 'btn', role: 'button' %>
-    </div>
-  <% end %>
+      <div class="form-actions">
+        <%= f.submit 'Create Assignment', class: 'btn btn-primary', id: 'assignment_submit' %>
+        <%= link_to 'Cancel', organization_path(@organization), class: 'btn', role: 'button' %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/group_assignments/_group_assignment.html.erb
+++ b/app/views/group_assignments/_group_assignment.html.erb
@@ -1,4 +1,4 @@
-<div class="assignment-list-item container-lg clearfix">
+<div class="Box-row d-flex flex-wrap flex-content-center">
   <div class="float-left col-sm-6 d-flex">
     <div class="d-flex flex-column flex-justify-center flex-items-center flex-md-items-start">
       <span class="group-assignment-icon assignment-icon-group left">
@@ -15,7 +15,7 @@
   </div>
 
   <div class="float-left col-sm-6 d-flex clipboard-form">
-    <div class="flex-self-center input-group assignment-invite-link">
+    <div class="flex-self-center input-group">
       <%= render partial: "shared/invitations/clipboard_form", locals: InvitationHelper.attributes(group_assignment.invitation, request.base_url) %>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <div class="loading-indicator" style="display: none;"></div>
 
     <%= render 'peek/bar' %>
+
     <main>
       <%= render 'shared/message_of_the_day' %>
       <%= render 'shared/header' %>
@@ -26,8 +27,8 @@
         <%= render 'shared/flash_messages' %>
       </div>
 
-      <div class="container-lg">
-          <%= yield %>
+      <div class="site-content container-lg">
+        <%= yield %>
       </div>
     </main>
 

--- a/app/views/layouts/stafftools.html.erb
+++ b/app/views/layouts/stafftools.html.erb
@@ -24,10 +24,10 @@
 
       <div class="site-content">
         <div class="container-lg">
-          <div class="one-fourth column">
+          <div class="col-3 pr-4 float-left">
             <%= render 'stafftools/navigation' %>
           </div>
-          <div class="three-fourths column">
+          <div class="col-9 float-left">
             <%= yield %>
           </div>
         </div>

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -1,4 +1,4 @@
-<div class="clearfix organization-list-item">
+<div class="Box-row clearfix organization-list-item">
   <div class="float-left mr-2">
     <%= image_tag organization.github_organization.github_avatar_url(120), class: 'avatar left', height: 60, width: 60, alt: "@#{organization.github_organization.login}" %>
   </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,27 +1,26 @@
-<div class="site-content">
-
-  <div class="site-content-cap clearfix">
+<div class="Box Box--spacious">
+  <div class="Box-header d-flex flex-items-center">
+    <h3 class="Box-title overflow-hidden flex-auto">Classrooms</h3>
     <% if @organizations.present? %>
-      <%= link_to new_organization_path, class: 'btn btn-primary float-right', role: 'button' do %>
+      <%= link_to new_organization_path, class: 'btn btn-primary', role: 'button' do %>
         New classroom
       <% end %>
     <% end %>
-    <h2 class="site-content-heading float-left">Classrooms</h2>
   </div>
+  <% if @organizations.present? %>
+    <div><%= render @organizations %></div>
+  <% else %>
+    <div class="blankslate blankslate-clean-background blankslate-spacious">
+      <h3>You’re not managing any classrooms yet.</h3>
+      <p>You can begin creating assignments once you have at least one classroom.</p>
 
-  <div class="site-content-body organization-list-items">
-    <% if @organizations.present? %>
-      <%= render @organizations %>
-      <%= render partial: 'shared/pagination', locals: { collection: @organizations } %>
-    <% else %>
-      <div class="blankslate large-format spacious clean-background">
-        <h3>You’re not managing any classrooms yet.</h3>
-        <p>You can begin creating assignments once you have at least one classroom.</p>
-
-        <%= link_to new_organization_path, class: 'btn btn-primary btn-big', role: 'button' do %>
-          Create your first classroom
-        <% end %>
-      </div>
-    <% end %>
-  </div>
+      <%= link_to new_organization_path, class: 'btn btn-primary btn-big', role: 'button' do %>
+        Create your first classroom
+      <% end %>
+    </div>
+  <% end %>
 </div>
+
+<% if @organizations.present? %>
+  <%= render partial: 'shared/pagination', locals: { collection: @organizations } %>
+<% end %>

--- a/app/views/organizations/new_assignment.html.erb
+++ b/app/views/organizations/new_assignment.html.erb
@@ -1,11 +1,11 @@
 <%= render 'organizations/organization_banner' %>
 
-<div class="site-content">
-  <div class="site-content-cap">
-    <h2 class="site-content-heading">New Assignment</h2>
+<div class="Box Box--spacious">
+  <div class="Box-header">
+    <h3 class="Box-title">New assignment</h3>
   </div>
 
-  <div class="site-content-body">
+  <div class="Box-body">
     <div class="columns d-table col-12 clearfix  d-flex flex-wrap flex-content-between">
       <div class="col-md-6 float-left mx-auto  text-center p-2  d-sm-block">
         <span class="assignment-icon assignment-icon-individual">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,29 +1,23 @@
 <%= render 'organizations/organization_banner' %>
 
-<div class="site-content">
-
-  <div class="site-content-cap container-lg clearfix">
-      <h2 class="col-6 float-left text-left pr-2 site-content-heading">Assignments</h2>
-
-        <div class="col-6 float-right text-right pl-2">
-          <% if @assignments.present? %>
-            <%= link_to 'New assignment', new_assignment_organization_path(@organization), class: 'btn btn-primary right', role: 'button'%>
-          <% end %>
-        </div>
-  </div>
-
-
-  <div class="site-content-body assignment-list-items">
+<div class="Box Box--spacious">
+  <div class="Box-header d-flex flex-items-center">
+    <h3 class="Box-title overflow-hidden flex-auto">Assignments</h3>
     <% if @assignments.present? %>
-      <%= render @assignments %>
-      <%= render partial: 'shared/pagination', locals: { collection: @assignments } %>
-    <% else %>
-      <div class="blankslate blankslate-spacious blankslate-clean-background">
-        <h3>This organization doesn’t have any assignments yet.</h3>
-        <%= link_to new_assignment_organization_path(@organization), class: 'btn btn-large btn-primary f3 mt-3', role: 'button' do %>
-          Create your first assignment
-        <% end %>
-      </div>
+      <%= link_to 'New assignment', new_assignment_organization_path(@organization), class: 'btn btn-primary right', role: 'button'%>
     <% end %>
   </div>
+
+  <% if @assignments.present? %>
+    <div><%= render @assignments %></div>
+  <% else %>
+    <div class="blankslate blankslate-spacious blankslate-clean-background">
+      <h3>This organization doesn’t have any assignments yet.</h3>
+      <%= link_to new_assignment_organization_path(@organization), class: 'btn btn-large btn-primary f3 mt-3', role: 'button' do %>
+        Create your first assignment
+      <% end %>
+    </div>
+  <% end %>
 </div>
+
+<%= render partial: 'shared/pagination', locals: { collection: @assignments } %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,5 +1,5 @@
 <% if collection.next_page || collection.prev_page %>
-  <div class="paginate-container container">
+  <div class="paginate-container d-flex flex-justify-center">
     <%= paginate collection %>
   </div>
 <% end %>

--- a/app/views/stafftools/assignments/_assignment_repo.html.erb
+++ b/app/views/stafftools/assignments/_assignment_repo.html.erb
@@ -1,4 +1,4 @@
-<li class="clearfix">
-  <%= octicon 'repo' %>
+<li class="Box-row clearfix">
+  <%= octicon 'repo', class: 'mr-2' %>
   <strong><%= link_to assignment_repo.github_repository.full_name, stafftools_assignment_repo_path(assignment_repo.id) %></strong>
 </li>

--- a/app/views/stafftools/assignments/show.html.erb
+++ b/app/views/stafftools/assignments/show.html.erb
@@ -1,69 +1,67 @@
-<div class="site-content">
-
-  <div class="d-flex flex-column flex-md-row flex-items-center flex-md-items-center stafftools-page-header clearfix">
-    <div class="col-1 d-flex">
-      <span class="assignment-icon assignment-icon-group">
-        <%= octicon 'person', height: 22 %>
-      </span>
-    </div>
-
-    <div class="col-10 col-md-10 d-flex flex-column">
-      <h2 class="stafftools-heading">
-        <%= @assignment.title %>
-      </h2>
-
-      <p class="assignment-type text-gray"><%= t('views.stafftools.assignments.assignment_type') %></p>
-    </div>
+<div class="d-flex flex-column flex-md-row flex-items-center flex-md-items-center stafftools-page-header clearfix mt-2">
+  <div class="col-1 d-flex">
+    <span class="assignment-icon assignment-icon-group">
+      <%= octicon 'person', height: 22 %>
+    </span>
   </div>
 
-  <div class="boxed-group">
-    <h3><%= t('views.stafftools.assignments.assignment_info') %></h3>
+  <div class="col-10 col-md-10 d-flex flex-column">
+    <h2 class="stafftools-heading">
+      <%= @assignment.title %>
+    </h2>
 
-    <div class="boxed-group-inner">
-      <table>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.id') %></td>
-          <td><%= @assignment.id %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.owned_by') %></td>
-          <td><%= link_to @assignment.organization.title, stafftools_organization_path(@assignment.organization.id) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.created_by') %></td>
-          <td><%= link_to @assignment.creator.github_user.login, stafftools_user_path(@assignment.creator) %></td>
-        </tr>
-        <% if @assignment.starter_code? %>
+    <p class="assignment-type text-gray"><%= t('views.stafftools.assignments.assignment_type') %></p>
+  </div>
+</div>
+
+<div class="Box Box--stafftools Box--condensed">
+  <div class="Box-header">
+    <h3 class="Box-title"><%= t('views.stafftools.assignments.assignment_info') %></h3>
+  </div>
+
+  <div class="Box-body">
+    <table>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.id') %></td>
+        <td><%= @assignment.id %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.owned_by') %></td>
+        <td><%= link_to @assignment.organization.title, stafftools_organization_path(@assignment.organization.id) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.created_by') %></td>
+        <td><%= link_to @assignment.creator.github_user.login, stafftools_user_path(@assignment.creator) %></td>
+      </tr>
+      <% if @assignment.starter_code? %>
         <tr>
           <td class="text-emphasized"><%= t('views.stafftools.assignments.starter_code') %></td>
           <td><%= link_to @assignment.starter_code_repository.html_url, @assignment.starter_code_repository.html_url %></td>
         </tr>
-        <% end %>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.invitation') %></td>
-          <td><%= link_to @assignment.assignment_invitation.key, stafftools_assignment_invitation_path(@assignment.assignment_invitation.id) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.created_on') %></td>
-          <td><%= local_time(@assignment.created_at) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.assignments.last_updated') %></td>
-          <td><%= local_time(@assignment.created_at) %></td>
-        </tr>
-      </table>
-    </div>
+      <% end %>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.invitation') %></td>
+        <td><%= link_to @assignment.assignment_invitation.key, stafftools_assignment_invitation_path(@assignment.assignment_invitation.id) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.created_on') %></td>
+        <td><%= local_time(@assignment.created_at) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.assignments.last_updated') %></td>
+        <td><%= local_time(@assignment.created_at) %></td>
+      </tr>
+    </table>
   </div>
-
-  <% if @assignment.assignment_repos.present? %>
-    <div class="boxed-group">
-      <h3><%= t('views.stafftools.assignments.assignment_repo') %></h3>
-
-      <div class="boxed-group-inner">
-        <ul class="boxed-group-list standalone">
-          <%= render partial: 'stafftools/assignments/assignment_repo', collection: @assignment.assignment_repos %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
 </div>
+
+<% if @assignment.assignment_repos.present? %>
+  <div class="Box Box--stafftools Box--condensed mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title"><%= t('views.stafftools.assignments.assignment_repo') %></h3>
+    </div>
+    <ul>
+      <%= render partial: 'stafftools/assignments/assignment_repo', collection: @assignment.assignment_repos %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/stafftools/organizations/_assignment.html.erb
+++ b/app/views/stafftools/organizations/_assignment.html.erb
@@ -1,4 +1,4 @@
-<li class="clearfix">
-  <%= octicon 'person' %>
+<li class="Box-row clearfix">
+  <%= octicon 'person', class: 'mr-2' %>
   <strong><%= link_to assignment.title, stafftools_assignment_path(assignment.id) %></strong>
 </li>

--- a/app/views/stafftools/organizations/_group_assignment.html.erb
+++ b/app/views/stafftools/organizations/_group_assignment.html.erb
@@ -1,4 +1,4 @@
-<li class="clearfix">
-  <%= octicon 'organization' %>
+<li class="Box-row clearfix">
+  <%= octicon 'organization', class: 'mr-1' %>
   <strong><%= link_to group_assignment.title, stafftools_group_assignment_path(group_assignment.id) %></strong>
 </li>

--- a/app/views/stafftools/organizations/_grouping.html.erb
+++ b/app/views/stafftools/organizations/_grouping.html.erb
@@ -1,4 +1,4 @@
-<li class="clearfix">
-  <%= octicon 'organization' %>
+<li class="Box-row clearfix">
+  <%= octicon 'organization', class: 'mr-1' %>
   <strong><%= link_to grouping.title, stafftools_grouping_path(grouping.id) %></strong>
 </li>

--- a/app/views/stafftools/organizations/_user.html.erb
+++ b/app/views/stafftools/organizations/_user.html.erb
@@ -1,2 +1,2 @@
-<%= image_tag user.github_user.github_avatar_url(40), height: 20, width: 20, alt: "@#{user.github_user.login}" %>
+<%= image_tag user.github_user.github_avatar_url(40), height: 20, width: 20, alt: "@#{user.github_user.login}", class: 'avatar mr-2' %>
 <strong><%= link_to user.github_user.login, stafftools_user_path(user.id) %></strong>

--- a/app/views/stafftools/organizations/show.html.erb
+++ b/app/views/stafftools/organizations/show.html.erb
@@ -1,114 +1,119 @@
-<div class="site-content">
-  <div class="d-flex flex-md-row flex-items-center stafftools-page-header">
-    <div class="col-1 assignment-icon assignment-icon-group">
-      <%= image_tag @organization.github_organization.github_avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{@organization.github_organization.login}" %>
-    </div>
-
-    <div class="col-10 col-md-10 d-flex flex-column">
-      <h2 class="stafftools-heading">
-        <%= @organization.title %>
-      </h2>
-
-      <p class="assignment-type text-gray"><%= t('views.stafftools.organizations.classroom') %></p>
-    </div>
+<div class="d-flex flex-md-row flex-items-center stafftools-page-header mt-2">
+  <div class="col-1 assignment-icon assignment-icon-group">
+    <%= image_tag @organization.github_organization.github_avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{@organization.github_organization.login}" %>
   </div>
 
-  <div class="boxed-group">
-    <h3><%= t('views.stafftools.organizations.classroom') %></h3>
+  <div class="col-10 col-md-10 d-flex flex-column">
+    <h2 class="stafftools-heading">
+      <%= @organization.title %>
+    </h2>
 
-    <div class="boxed-group-inner">
-      <table>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.id') %></td>
-          <td><%= @organization.id %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.classroom') %></td>
-          <td><%= link_to organization_url(@organization), organization_url(@organization) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.joined_on') %></td>
-          <td><%= local_time(@organization.created_at) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.last_updated') %></td>
-          <td><%= local_time(@organization.updated_at) %></td>
-        </tr>
-      </table>
-    </div>
+    <p class="assignment-type text-gray"><%= t('views.stafftools.organizations.classroom') %></p>
   </div>
-
-  <div class="boxed-group">
-    <h3><%= t('views.stafftools.organizations.github_organization') %></h3>
-
-    <div class="boxed-group-inner">
-      <table>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.id') %></td>
-          <td><%= @organization.github_id %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized"><%= t('views.stafftools.organizations.homepage') %></td>
-          <td><%= link_to @organization.github_organization.html_url, @organization.github_organization.html_url %></td>
-        </tr>
-        <% if @organization.webhook_id.present? %>
-          <tr>
-            <td class="text-emphasized"><%= t('views.stafftools.organizations.webhook_url') %></td>
-            <% url = "https://github.com/organizations/#{@organization.github_organization.login}/settings/hooks/#{@organization.webhook_id}" %>
-            <td><%= link_to url, url %></td>
-          </tr>
-          <tr>
-            <td class="text-emphasized"><%= t('views.stafftools.organizations.webhook_enabled_check') %></td>
-            <td><%= @organization.is_webhook_active? %></td>
-          </tr>
-        <% end %>
-      </table>
-    </div>
-  </div>
-
-  <div class="boxed-group">
-    <h3><%= t('views.stafftools.organizations.owners') %></h3>
-
-    <div class="boxed-group-inner">
-      <ul class="boxed-group-list standalone">
-        <% @organization.users.each do |user| %>
-          <li class="stafftools-button-li clearfix">
-            <%= render partial: 'stafftools/organizations/user', locals: { user: user } %>
-            <a data-remodal-target="remove-user-from-organization-<%= user.id %>" class="btn btn-danger stafftools-small-button<%= ' disabled' if @organization.users.count < 2 %>">Remove</a>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-
-  <% @organization.users.each do |user| %>
-    <%= render partial: 'stafftools/organizations/remove_user_from_organization_modal', locals: { user: user } %>
-  <% end %>
-
-  <% if @organization.all_assignments.present? %>
-    <div class="boxed-group">
-      <h3><%= t('views.stafftools.organizations.assignments') %></h3>
-
-      <div class="boxed-group-inner">
-        <ul class="boxed-group-list standalone">
-          <% @organization.all_assignments.each do |assignment| %>
-            <% type = assignment.class.to_s.underscore %>
-            <%= render partial: "stafftools/organizations/#{type}", locals: { :"#{type}" => assignment } %>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @organization.groupings.present? %>
-    <div class="boxed-group">
-      <h3><%= t('views.stafftools.organizations.groupings') %></h3>
-
-      <div class="boxed-group-inner">
-        <ul class="boxed-group-list standalone">
-          <%= render partial: "stafftools/organizations/grouping", collection: @organization.groupings %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
 </div>
+
+<div class="Box Box--stafftools Box--condensed">
+  <div class="Box-header">
+    <h3 class="Box-title"><%= t('views.stafftools.organizations.classroom') %></h3>
+  </div>
+
+  <div class="Box-body">
+    <table>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.id') %></td>
+        <td><%= @organization.id %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.classroom') %></td>
+        <td><%= link_to organization_url(@organization), organization_url(@organization) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.joined_on') %></td>
+        <td><%= local_time(@organization.created_at) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.last_updated') %></td>
+        <td><%= local_time(@organization.updated_at) %></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="Box Box--stafftools Box--condensed mt-3">
+  <div class="Box-header">
+    <h3 class="Box-title"><%= t('views.stafftools.organizations.github_organization') %></h3>
+  </div>
+
+  <div class="Box-body">
+    <table>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.id') %></td>
+        <td><%= @organization.github_id %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized"><%= t('views.stafftools.organizations.homepage') %></td>
+        <td><%= link_to @organization.github_organization.html_url, @organization.github_organization.html_url %></td>
+      </tr>
+      <% if @organization.webhook_id.present? %>
+        <tr>
+          <td class="text-emphasized"><%= t('views.stafftools.organizations.webhook_url') %></td>
+          <% url = "https://github.com/organizations/#{@organization.github_organization.login}/settings/hooks/#{@organization.webhook_id}" %>
+          <td><%= link_to url, url %></td>
+        </tr>
+        <tr>
+          <td class="text-emphasized"><%= t('views.stafftools.organizations.webhook_enabled_check') %></td>
+          <td><%= @organization.is_webhook_active? %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+
+<div class="Box Box--stafftools Box--condensed mt-3">
+  <div class="Box-header">
+    <h3 class="Box-title"><%= t('views.stafftools.organizations.owners') %></h3>
+  </div>
+
+  <ul>
+    <% @organization.users.each do |user| %>
+      <li class="Box-row d-flex flex-items-center">
+        <div class="flex-auto">
+          <%= render partial: 'stafftools/organizations/user', locals: { user: user } %>
+        </div>
+
+        <a data-remodal-target="remove-user-from-organization-<%= user.id %>" class="btn btn-danger stafftools-small-button<%= ' disabled' if @organization.users.count < 2 %>">Remove</a>
+      </li>
+    <% end %>
+  </ul>
+</div>
+
+<% @organization.users.each do |user| %>
+  <%= render partial: 'stafftools/organizations/remove_user_from_organization_modal', locals: { user: user } %>
+<% end %>
+
+<% if @organization.all_assignments.present? %>
+  <div class="Box Box--stafftools Box--condensed mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title"><%= t('views.stafftools.organizations.assignments') %></h3>
+    </div>
+
+    <ul>
+      <% @organization.all_assignments.each do |assignment| %>
+        <% type = assignment.class.to_s.underscore %>
+        <%= render partial: "stafftools/organizations/#{type}", locals: { :"#{type}" => assignment } %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if @organization.groupings.present? %>
+  <div class="Box Box--stafftools Box--condensed mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title"><%= t('views.stafftools.organizations.groupings') %></h3>
+    </div>
+
+    <ul>
+      <%= render partial: "stafftools/organizations/grouping", collection: @organization.groupings %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/stafftools/users/_organization.html.erb
+++ b/app/views/stafftools/users/_organization.html.erb
@@ -1,4 +1,4 @@
-<li class="clearfix">
-  <%= image_tag organization.github_organization.github_avatar_url(40), height: 20, width: 20, alt: "@#{organization.github_organization.login}" %>
+<li class="Box-row d-flex flex-items-start">
+  <%= image_tag organization.github_organization.github_avatar_url(40), height: 20, width: 20, alt: "@#{organization.github_organization.login}", class: 'avatar mr-2' %>
   <strong><%= link_to organization.slug, stafftools_organization_path(organization.id) %></strong>
 </li>

--- a/app/views/stafftools/users/show.html.erb
+++ b/app/views/stafftools/users/show.html.erb
@@ -1,96 +1,101 @@
-<div class="site-content">
-  <div class="d-flex flex-md-row flex-items-center stafftools-page-header">
-    <div class="col-1 d-flexp">
-      <span class="assignment-icon assignment-icon-individual left">
-        <%= image_tag @user.github_user.github_avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{@user.github_user.login}" %>
-      </span>
-    </div>
-
-    <div class="col-10 col-md-10 d-flex flex-column">
-      <h2 class="stafftools-heading">
-        <%= @user.github_user.login %>
-      </h2>
-
-      <p class="assignment-type text-gray">
-        <%= content_tag(:span, 'Staff', class: 'staff-badge') if @user.staff? %> User
-      </p>
-    </div>
+<div class="d-flex flex-md-row flex-items-center stafftools-page-header mt-2">
+  <div class="col-1 d-flexp">
+    <span class="assignment-icon assignment-icon-individual left">
+      <%= image_tag @user.github_user.github_avatar_url(96), height: 48, width: 48, class: 'avatar left', alt: "@#{@user.github_user.login}" %>
+    </span>
   </div>
 
-  <div class="boxed-group">
-    <h3>User information</h3>
+  <div class="col-10 col-md-10 d-flex flex-column">
+    <h2 class="stafftools-heading">
+      <%= @user.github_user.login %>
+    </h2>
 
-    <div class="boxed-group-inner">
-      <table>
-        <tr>
-          <td class="text-emphasized">ID</td>
-          <td><%= @user.id %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized">GitHub ID</td>
-          <td><%= @user.uid %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized">GitHub profile</td>
-          <td><%= link_to @user.github_user.html_url, @user.github_user.html_url %></td>
-        </tr>
-        <tr>
-         <td class="text-emphasized">Joined on</td>
-         <td><%= local_time(@user.created_at) %></td>
-        </tr>
-        <tr>
-         <td class="text-emphasized">Last active</td>
-         <td><%= local_time(@user.last_active_at) %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized">Access token</td>
-          <td><%= @user.authorized_access_token? ? 'Authorized' : 'Rejected' %></td>
-        </tr>
-        <tr>
-          <td class="text-emphasized">Scopes</td>
-          <td><%= @user.github_client_scopes.join(', ') %></td>
-        </tr>
-      </table>
-    </div>
+    <p class="assignment-type text-gray">
+      <%= content_tag(:span, 'Staff', class: 'staff-badge') if @user.staff? %> User
+    </p>
   </div>
-
-  <% if @user.organizations.present? %>
-    <div class="boxed-group">
-      <h3>Classrooms</h3>
-
-      <div class="boxed-group-inner">
-        <ul class="boxed-group-list standalone">
-          <%= render partial: 'stafftools/users/organization', collection: @user.organizations %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @user.repo_accesses.present? %>
-    <div class="boxed-group">
-      <h3>Organization Memberships</h3>
-
-      <div class="boxed-group-inner">
-        <ul class="boxed-group-list standalone">
-          <% @user.repo_accesses.each do |repo_access| %>
-            <%= render partial: 'stafftools/users/organization', locals: { organization: repo_access.organization } %>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @user.id != current_user.id %>
-    <div class="boxed-group dangerzone">
-      <h3>Dangerzone</h3>
-
-      <div class="boxed-group-inner">
-        <h4>Impersonate <%= "@#{@user.github_user.login}" %></h4>
-        <a data-remodal-target="impersonate-user" class="btn btn-danger boxed-action">Impersonate <%= "@#{@user.github_user.login}" %></a>
-        <p>This will send you to <strong><%= @user.github_user.login %></strong>'s Classroom dashboard as <strong><%= @user.github_user.login %></strong>.</p>
-
-        <%= render partial: 'stafftools/users/impersonate_user_confirmation_modal', locals: { user: @user } %>
-      </div>
-    </div>
-  <% end %>
 </div>
+
+<div class="Box Box--stafftools Box--condensed">
+  <div class="Box-header">
+    <h3 class="Box-title">User information</h3>
+  </div>
+
+  <div class="Box-body">
+    <table>
+      <tr>
+        <td class="text-emphasized">ID</td>
+        <td><%= @user.id %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">GitHub ID</td>
+        <td><%= @user.uid %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">GitHub profile</td>
+        <td><%= link_to @user.github_user.html_url, @user.github_user.html_url %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">Joined on</td>
+        <td><%= local_time(@user.created_at) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">Last active</td>
+        <td><%= local_time(@user.last_active_at) %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">Access token</td>
+        <td><%= @user.authorized_access_token? ? 'Authorized' : 'Rejected' %></td>
+      </tr>
+      <tr>
+        <td class="text-emphasized">Scopes</td>
+        <td><%= @user.github_client_scopes.join(', ') %></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<% if @user.organizations.present? %>
+  <div class="Box Box--stafftools Box--condensed mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title">Classrooms</h3>
+    </div>
+
+    <ul><%= render partial: 'stafftools/users/organization', collection: @user.organizations %></ul>
+  </div>
+<% end %>
+
+<% if @user.repo_accesses.present? %>
+  <div class="Box Box--stafftools Box--condensed mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title">Organization memberships</h3>
+    </div>
+
+    <ul>
+      <% @user.repo_accesses.each do |repo_access| %>
+        <%= render partial: 'stafftools/users/organization', locals: { organization: repo_access.organization } %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if @user.id != current_user.id %>
+  <div class="Box Box--stafftools Box--condensed Box--danger mt-3">
+    <div class="Box-header">
+      <h3 class="Box-title">Dangerzone</h3>
+    </div>
+
+    <div class="Box-row d-flex flex-items-center">
+      <div class="flex-auto">
+        <strong>Impersonate <%= "@#{@user.github_user.login}" %></strong>
+        <div class="text-small text-gray-light">
+          This will send you to <strong><%= @user.github_user.login %></strong>'s Classroom dashboard as <strong><%= @user.github_user.login %></strong>.
+        </div>
+      </div>
+
+      <a data-remodal-target="impersonate-user" class="btn btn-danger">Impersonate <%= "@#{@user.github_user.login}" %></a>
+
+      <%= render partial: 'stafftools/users/impersonate_user_confirmation_modal', locals: { user: @user } %>
+    </div>
+  </div>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jquery-readyselector": "git+https://git@github.com/Verba/jquery-readyselector.git",
     "jquery-ujs": " ~1.2.2",
     "jquery.turbolinks": "git+https://git@github.com/kossnocorp/jquery.turbolinks#2.1.0",
-    "primer-css": "^8.0.0",
+    "primer-css": "^9.0.0",
     "rails-ujs": "^5.1.1",
     "remodal": "^1.1.1",
     "transliteration": "^1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,225 +302,225 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-primer-alerts@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/primer-alerts/-/primer-alerts-1.1.7.tgz#22585d938fdff02b6d22ce603ddfb1967329a88a"
+primer-alerts@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/primer-alerts/-/primer-alerts-1.1.8.tgz#c1cd665180210448b11c46a79e11b851df246873"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-avatars@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-avatars/-/primer-avatars-1.0.1.tgz#33d6670eb656a46716aec2b49079eca1d2a1ff93"
+primer-avatars@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-avatars/-/primer-avatars-1.0.2.tgz#3d879cd05c8b57315510b2ca5d84361df3355708"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-base@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/primer-base/-/primer-base-0.4.2.tgz#10bea7bdd454c447b1ed6e801595f3888b30f01f"
-  dependencies:
-    primer-support "*"
-
-primer-blankslate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-blankslate/-/primer-blankslate-1.0.1.tgz#7de263f82eeb432d108d441fbf2324d7624041bc"
-  dependencies:
-    primer-support "^4.0.6"
-
-primer-box@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/primer-box/-/primer-box-2.1.7.tgz#04b719d5ebe6a7080f59581bf7bf754c94d57342"
-  dependencies:
-    primer-support "^4.0.6"
-
-primer-breadcrumb@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-breadcrumb/-/primer-breadcrumb-1.0.1.tgz#d0ef69d2f1de4ce9d4dd93c7c059954506dc0ee4"
-  dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
-
-primer-buttons@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/primer-buttons/-/primer-buttons-2.0.5.tgz#0bdec1f102dffb23eff112971f29e0d836a30288"
-  dependencies:
-    primer-support "^4.0.6"
-
-primer-cards@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/primer-cards/-/primer-cards-0.1.7.tgz#9a6eac6d53bd3de2b45f3956a012b3f637fb2b7a"
-  dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
-
-primer-core@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/primer-core/-/primer-core-5.0.1.tgz#4d9abf5ae477b3b049afbfe51bbf18a4003fd0cb"
-  dependencies:
-    primer-base "^0.4.0"
-    primer-box "^2.1.7"
-    primer-buttons "^2.0.5"
-    primer-forms "^1.0.12"
-    primer-layout "^1.0.4"
-    primer-navigation "^1.0.5"
-    primer-support "^4.0.6"
-    primer-table-object "^1.0.8"
-    primer-tooltips "^1.0.1"
-    primer-truncate "^1.0.1"
-    primer-utilities "^4.3.4"
-
-primer-css@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/primer-css/-/primer-css-8.0.0.tgz#e5762dabf7fad925f30978bbbc588f3bd466ae5f"
-  dependencies:
-    primer-alerts "^1.1.7"
-    primer-avatars "^1.0.1"
-    primer-base "^0.4.0"
-    primer-blankslate "^1.0.1"
-    primer-box "^2.1.7"
-    primer-breadcrumb "^1.0.1"
-    primer-buttons "^2.0.5"
-    primer-cards "^0.1.7"
-    primer-core "^5.0.1"
-    primer-forms "^1.0.12"
-    primer-labels "^1.1.5"
-    primer-layout "^1.0.4"
-    primer-markdown "^3.3.12"
-    primer-marketing "^5.0.1"
-    primer-marketing-support "^1.0.1"
-    primer-marketing-type "^1.0.1"
-    primer-marketing-utilities "^1.0.1"
-    primer-navigation "^1.0.5"
-    primer-page-headers "^1.0.1"
-    primer-page-sections "^1.0.1"
-    primer-product "^5.0.1"
-    primer-support "^4.0.6"
-    primer-table-object "^1.0.8"
-    primer-tables "^1.0.1"
-    primer-tooltips "^1.0.1"
-    primer-truncate "^1.0.1"
-    primer-utilities "^4.3.4"
-
-primer-forms@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/primer-forms/-/primer-forms-1.0.12.tgz#01b98f50885272fa8b787e204337983e57f7f015"
-  dependencies:
-    primer-support "^4.0.6"
-
-primer-labels@^1.1.5:
+primer-base@^1.1.5:
   version "1.1.5"
-  resolved "https://registry.yarnpkg.com/primer-labels/-/primer-labels-1.1.5.tgz#1752b9dfa952ee66276046e221dd5e10a0f8be99"
+  resolved "https://registry.yarnpkg.com/primer-base/-/primer-base-1.1.5.tgz#1d67e8eb54370b850629d483097d19306cc75ecc"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-layout@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/primer-layout/-/primer-layout-1.0.4.tgz#ef7d277fed5b4e4ee37584ab67a4a0b8b661cdd2"
+primer-blankslate@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-blankslate/-/primer-blankslate-1.0.2.tgz#341441d2e6013272b3c5808f478c7b2b678c352c"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-markdown@^3.3.12:
-  version "3.3.12"
-  resolved "https://registry.yarnpkg.com/primer-markdown/-/primer-markdown-3.3.12.tgz#68de88600edc49d28727afeee32e0effc1ca2afe"
+primer-box@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/primer-box/-/primer-box-2.1.8.tgz#c453bfceb00a959211fb23a1246dc337a5265b5f"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-marketing-support@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-marketing-support/-/primer-marketing-support-1.0.1.tgz#68bd8d11636f7342483590e4ea65eef5ee74370e"
-
-primer-marketing-type@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-marketing-type/-/primer-marketing-type-1.0.1.tgz#58c57fba54de27a2912b79821cb29d52cc94a55d"
+primer-breadcrumb@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-breadcrumb/-/primer-breadcrumb-1.0.2.tgz#5958bc0db10957f641417007cab7c9c9b4a493ff"
   dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-marketing-utilities@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-marketing-utilities/-/primer-marketing-utilities-1.0.1.tgz#482fbcf19f9b81f7d289b26ee43bcc94d563856e"
+primer-buttons@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/primer-buttons/-/primer-buttons-2.0.6.tgz#1bc62b651de1013bb9d3bc085db7f8868fad31a9"
   dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-marketing@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/primer-marketing/-/primer-marketing-5.0.1.tgz#27eaf4ebb279c755e8642de1be1bbe189a683e7a"
+primer-cards@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/primer-cards/-/primer-cards-0.1.8.tgz#240657a16b4b579fe984d2f5688d09bfe9c70b1d"
   dependencies:
-    primer-breadcrumb "^1.0.1"
-    primer-cards "^0.1.7"
-    primer-marketing-support "^1.0.1"
-    primer-marketing-type "^1.0.1"
-    primer-marketing-utilities "^1.0.1"
-    primer-page-headers "^1.0.1"
-    primer-page-sections "^1.0.1"
-    primer-support "^4.0.6"
-    primer-tables "^1.0.1"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-navigation@^1.0.5:
+primer-core@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/primer-core/-/primer-core-6.0.0.tgz#474f2acafdf5ab31c34dae8bebded7b80799ea17"
+  dependencies:
+    primer-base "^1.1.5"
+    primer-box "^2.1.8"
+    primer-buttons "^2.0.6"
+    primer-forms "^1.0.13"
+    primer-layout "^1.0.5"
+    primer-navigation "^1.0.6"
+    primer-support "^4.0.7"
+    primer-table-object "^1.0.9"
+    primer-tooltips "^1.0.2"
+    primer-truncate "^1.0.2"
+    primer-utilities "^4.3.5"
+
+primer-css@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/primer-css/-/primer-css-9.0.0.tgz#aac7e2c57134f26d76cd895e7e986cbd530fbedd"
+  dependencies:
+    primer-alerts "^1.1.8"
+    primer-avatars "^1.0.2"
+    primer-base "^1.1.5"
+    primer-blankslate "^1.0.2"
+    primer-box "^2.1.8"
+    primer-breadcrumb "^1.0.2"
+    primer-buttons "^2.0.6"
+    primer-cards "^0.1.8"
+    primer-core "^6.0.0"
+    primer-forms "^1.0.13"
+    primer-labels "^1.1.6"
+    primer-layout "^1.0.5"
+    primer-markdown "^3.3.13"
+    primer-marketing "^5.0.2"
+    primer-marketing-support "^1.0.2"
+    primer-marketing-type "^1.0.2"
+    primer-marketing-utilities "^1.0.2"
+    primer-navigation "^1.0.6"
+    primer-page-headers "^1.0.2"
+    primer-page-sections "^1.0.2"
+    primer-product "^5.0.2"
+    primer-support "^4.0.7"
+    primer-table-object "^1.0.9"
+    primer-tables "^1.0.2"
+    primer-tooltips "^1.0.2"
+    primer-truncate "^1.0.2"
+    primer-utilities "^4.3.5"
+
+primer-forms@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/primer-forms/-/primer-forms-1.0.13.tgz#5ddc008cb083b625871dcb4b0e394cdb3dc44991"
+  dependencies:
+    primer-support "^4.0.7"
+
+primer-labels@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/primer-labels/-/primer-labels-1.1.6.tgz#0c65080e94b18561a031d242e9f04e915b1e44f9"
+  dependencies:
+    primer-support "^4.0.7"
+
+primer-layout@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/primer-navigation/-/primer-navigation-1.0.5.tgz#e87b0386f1636624d275bd55650b3b1d476b050f"
+  resolved "https://registry.yarnpkg.com/primer-layout/-/primer-layout-1.0.5.tgz#266f7a8c2c8b1a49efe6773c10685fb99e588530"
   dependencies:
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-page-headers@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-page-headers/-/primer-page-headers-1.0.1.tgz#e32e15cfb6a2c49bb99f1cd71c3ca04e817a0f77"
+primer-markdown@^3.3.13:
+  version "3.3.13"
+  resolved "https://registry.yarnpkg.com/primer-markdown/-/primer-markdown-3.3.13.tgz#45f0e11b4c7924214ffd47839409cf890d6c2727"
   dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-page-sections@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-page-sections/-/primer-page-sections-1.0.1.tgz#0f42a7c9ce8fe12ac8abd21d4d3a1321414359e9"
+primer-marketing-support@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-marketing-support/-/primer-marketing-support-1.0.2.tgz#2f888949b709d277973639930699783df988d63a"
+
+primer-marketing-type@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-marketing-type/-/primer-marketing-type-1.0.2.tgz#10b8b664c41ea0385b795a00d9edbedf9f5eabb2"
   dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-product@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/primer-product/-/primer-product-5.0.1.tgz#a9c79500830abef2a9e40260e15b52d7e3ea86e4"
+primer-marketing-utilities@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-marketing-utilities/-/primer-marketing-utilities-1.0.2.tgz#bd4321d787b145b6c12fa2b8815e15f1d9bba324"
   dependencies:
-    primer-alerts "^1.1.7"
-    primer-avatars "^1.0.1"
-    primer-blankslate "^1.0.1"
-    primer-labels "^1.1.5"
-    primer-markdown "^3.3.12"
-    primer-support "^4.0.6"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-support@*, primer-support@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/primer-support/-/primer-support-4.0.6.tgz#80f3bf1ceb63fda1cf2fdbcea09b632c812e1d54"
-
-primer-table-object@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/primer-table-object/-/primer-table-object-1.0.8.tgz#1c1614bd68f6ad872e5d344470fb34d8382db15f"
+primer-marketing@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/primer-marketing/-/primer-marketing-5.0.2.tgz#c7a0e0e9bc7625221b4dabf1c992ff35e7449c63"
   dependencies:
-    primer-support "^4.0.6"
+    primer-breadcrumb "^1.0.2"
+    primer-cards "^0.1.8"
+    primer-marketing-support "^1.0.2"
+    primer-marketing-type "^1.0.2"
+    primer-marketing-utilities "^1.0.2"
+    primer-page-headers "^1.0.2"
+    primer-page-sections "^1.0.2"
+    primer-support "^4.0.7"
+    primer-tables "^1.0.2"
 
-primer-tables@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-tables/-/primer-tables-1.0.1.tgz#cd2364576b3a7b13534804f124536e61fc078464"
+primer-navigation@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/primer-navigation/-/primer-navigation-1.0.6.tgz#458e19709bcf8e9fc2a615d5a1b0d7d1c5d57e6a"
   dependencies:
-    primer-marketing-support "^1.0.1"
-    primer-support "^4.0.6"
+    primer-support "^4.0.7"
 
-primer-tooltips@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-tooltips/-/primer-tooltips-1.0.1.tgz#0692af6ac2aa17346421bedc2832014b267754df"
+primer-page-headers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-page-headers/-/primer-page-headers-1.0.2.tgz#835c611875fb1c253b19491bf08ff37d5a8b513f"
   dependencies:
-    primer-support "^4.0.6"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-truncate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-truncate/-/primer-truncate-1.0.1.tgz#36b96206b11bc90d4428b8ea90f9a53b1a92abcf"
+primer-page-sections@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-page-sections/-/primer-page-sections-1.0.2.tgz#cf89a15bfb65a45eaf164f3f66bb34b7d63012db"
   dependencies:
-    primer-support "^4.0.6"
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
 
-primer-utilities@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/primer-utilities/-/primer-utilities-4.3.4.tgz#ffc89bd99eaf6924d5904fe30081170c6c855008"
+primer-product@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/primer-product/-/primer-product-5.0.2.tgz#d8e76636512fa1ee43d326ad7e57177b3950a157"
   dependencies:
-    primer-support "^4.0.6"
+    primer-alerts "^1.1.8"
+    primer-avatars "^1.0.2"
+    primer-blankslate "^1.0.2"
+    primer-labels "^1.1.6"
+    primer-markdown "^3.3.13"
+    primer-support "^4.0.7"
+
+primer-support@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/primer-support/-/primer-support-4.0.7.tgz#c9c433c5a597a78226870ea3d18c4bf0e96eeab4"
+
+primer-table-object@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/primer-table-object/-/primer-table-object-1.0.9.tgz#dcaa07cdc806d3f87ecea1ae10717c4c18686281"
+  dependencies:
+    primer-support "^4.0.7"
+
+primer-tables@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-tables/-/primer-tables-1.0.2.tgz#d9a346c3555bb54e7f6898a3cc60aa2d44b59d86"
+  dependencies:
+    primer-marketing-support "^1.0.2"
+    primer-support "^4.0.7"
+
+primer-tooltips@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-tooltips/-/primer-tooltips-1.0.2.tgz#057297397bb450382fc736a3b9b7c776e888a67f"
+  dependencies:
+    primer-support "^4.0.7"
+
+primer-truncate@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/primer-truncate/-/primer-truncate-1.0.2.tgz#dcbfa49c6953f264b6ff7c6af0ff75a58581d671"
+  dependencies:
+    primer-support "^4.0.7"
+
+primer-utilities@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/primer-utilities/-/primer-utilities-4.3.5.tgz#42c58e681459493fe99f2956c4b3bf7c04005d67"
+  dependencies:
+    primer-support "^4.0.7"
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Instead of relying on custom components we should lean on the already created Primer ones.