### PR TITLE
Fix permissions error

### DIFF
--- a/app/controllers/short_url_controller.rb
+++ b/app/controllers/short_url_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ShortUrlController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def assignment_invitation
     invitation = AssignmentInvitation.find_by(short_key: key)
 

--- a/spec/controllers/short_url_controller_spec.rb
+++ b/spec/controllers/short_url_controller_spec.rb
@@ -3,12 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ShortUrlController, type: :controller do
-  describe "authenticated request" do
-    let(:user) { classroom_student }
-
-    before do
-      sign_in_as(user)
-    end
+  describe "unauthenticated request" do
 
     describe "GET #accept_assignment", :vcr do
       let(:invitation) { create(:assignment_invitation) }

--- a/spec/controllers/short_url_controller_spec.rb
+++ b/spec/controllers/short_url_controller_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe ShortUrlController, type: :controller do
   describe "unauthenticated request" do
-
     describe "GET #accept_assignment", :vcr do
       let(:invitation) { create(:assignment_invitation) }
 


### PR DESCRIPTION
When a user hits the short_url controller, the before action in `application_controller` asks for full teacher scopes. 

We should skip and authenticate after we redirect.

@tarebyte @johndbritton