### PR TITLE
Add bootsnap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "rails", "~> 5.1", ">= 5.1.2"
 
 gem "autoprefixer-rails"
 
+gem "bootsnap", ">= 1.1.0", require: false
+
 gem "chewy", "~> 0.9.0"
 gem "connection_pool"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       execjs
     awesome_print (1.7.0)
     bindex (0.5.0)
+    bootsnap (1.1.2)
+      msgpack (~> 1.0)
     builder (3.2.3)
     bullet (5.5.1)
       activesupport (>= 3.0.0)
@@ -222,6 +224,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -440,6 +443,7 @@ DEPENDENCIES
   airbrake
   autoprefixer-rails
   awesome_print
+  bootsnap (>= 1.1.0)
   bullet
   chewy (~> 0.9.0)
   connection_pool

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,3 +3,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
[Bootsnap](https://github.com/Shopify/bootsnap) by Shopify was just added to [Rails core](https://github.com/rails/rails/pull/29313), so I figured what the heck why not ¯\\_(ツ)_/¯