### PR TITLE
Change group assignment show view to support rosters

### DIFF
--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -4,10 +4,11 @@ class GroupAssignmentsController < ApplicationController
   include OrganizationAuthorization
   include StarterCode
 
-  before_action :set_group_assignment, except: %i[new create]
-  before_action :set_groupings,        except: [:show]
-
+  before_action :set_group_assignment,      except: %i[new create]
+  before_action :set_groupings,             except: [:show]
   before_action :authorize_grouping_access, only: %i[create update]
+
+  before_action :set_group_assignment_repos, :set_students_not_on_team, only: [:show]
 
   def new
     @group_assignment = GroupAssignment.new
@@ -26,9 +27,7 @@ class GroupAssignmentsController < ApplicationController
     end
   end
 
-  def show
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:page])
-  end
+  def show; end
 
   def edit; end
 
@@ -95,6 +94,19 @@ class GroupAssignmentsController < ApplicationController
                         .group_assignments
                         .includes(:group_assignment_invitation)
                         .find_by!(slug: params[:id])
+  end
+
+  def set_group_assignment_repos
+    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:page])
+  end
+
+  def set_students_not_on_team
+    return unless @organization.roster.present?
+
+    students_on_team = @group_assignment_repos.map(&:repo_accesses).flatten.map(&:user).map(&:id).uniq
+    @students_not_on_team = @organization.roster.roster_entries.select do |entry|
+      !students_on_team.include?(entry.user.try(:id))
+    end
   end
 
   def deadline_param

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -101,11 +101,11 @@ class GroupAssignmentsController < ApplicationController
   end
 
   def set_students_not_on_team
-    return unless @organization.roster.present?
+    return if @organization.roster.blank?
 
     students_on_team = @group_assignment_repos.map(&:repo_accesses).flatten.map(&:user).map(&:id).uniq
-    @students_not_on_team = @organization.roster.roster_entries.select do |entry|
-      !students_on_team.include?(entry.user.try(:id))
+    @students_not_on_team = @organization.roster.roster_entries.reject do |entry|
+      students_on_team.include?(entry.user.try(:id))
     end
   end
 

--- a/app/controllers/roster_entries_controller.rb
+++ b/app/controllers/roster_entries_controller.rb
@@ -20,7 +20,11 @@ class RosterEntriesController < ApplicationController
   private
 
   def set_assignment
-    @assignment = Assignment.find_by!(slug: params[:assignment_id])
+    if(params[:assignment_id])
+      @assignment = Assignment.find_by!(slug: params[:assignment_id])
+    else
+      @assignment = GroupAssignment.find_by!(slug: params[:group_assignment_id])
+    end
   rescue ActiveRecord::ActiveRecordError
     not_found
   end
@@ -32,6 +36,12 @@ class RosterEntriesController < ApplicationController
   end
 
   def set_assignment_repo
-    @assignment_repo = @assignment.repos.select { |repo| repo.user == @roster_entry.user }.first
+    @assignment_repo = @assignment.repos.select do |repo|
+      if @assignment.is_a? Assignment
+        repo.user == @roster_entry.user
+      else
+        repo.repo_accesses.map(&:user).include? @roster_entry.user
+      end
+    end.first
   end
 end

--- a/app/controllers/roster_entries_controller.rb
+++ b/app/controllers/roster_entries_controller.rb
@@ -20,11 +20,11 @@ class RosterEntriesController < ApplicationController
   private
 
   def set_assignment
-    if(params[:assignment_id])
-      @assignment = Assignment.find_by!(slug: params[:assignment_id])
-    else
-      @assignment = GroupAssignment.find_by!(slug: params[:group_assignment_id])
-    end
+    @assignment = if params[:assignment_id]
+                    Assignment.find_by!(slug: params[:assignment_id])
+                  else
+                    GroupAssignment.find_by!(slug: params[:group_assignment_id])
+                  end
   rescue ActiveRecord::ActiveRecordError
     not_found
   end

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -35,26 +35,66 @@
       </div>
   </div>
 
-
   <div class="site-content-body">
     <div class="invitation-content">
       <%= render @group_assignment.group_assignment_invitation %>
     </div>
 
-    <% if @group_assignment_repos.present? %>
-      <div class="assignment-repo-list">
-        <% @group_assignment_repos.each do |group_assignment_repo| %>
-          <%= render partial: 'group_assignment_repos/group_assignment_repo', \
-            locals: { url: organization_group_assignment_group_assignment_repo_path(@organization, @group_assignment, group_assignment_repo) } %>
-        <% end %>
-      </div>
+    <% if @organization.roster %>
+      <div class="assignment-container">
+        <div class="tabnav-body clearfix ">
+          <div class="tabnav">
+            <nav class="tabnav-tabs">
+              <span id='students-tab' onclick="selectTab(this)" class="tabnav-tab selected tabnav-link" aria-current="page">Teams</span>
+              <span id='unlinked-tab' onclick="selectTab(this)" class="tabnav-tab tabnav-link">Students not on a team</span>
+            </nav>
+          </div>
+          <span id='students-span'>
+            <div class="assignment-repo-list">
+              <% if @group_assignment_repos.present? %>
+                <div class="assignment-repo-list">
+                  <% @group_assignment_repos.each do |group_assignment_repo| %>
+                    <%= render partial: 'group_assignment_repos/group_assignment_repo', \
+                      locals: { url: organization_group_assignment_group_assignment_repo_path(@organization, @group_assignment, group_assignment_repo) } %>
+                  <% end %>
+                </div>
 
-      <%= render partial: 'shared/pagination', locals: { collection: @group_assignment_repos } %>
-    <% else %>
-      <div class="blankslate">
-        <h3>"<%= @group_assignment.title %>" does not have any repositories.</h3>
-        <p>Share the invitation link with your students to get started.</p>
+                <%= render partial: 'shared/pagination', locals: { collection: @group_assignment_repos } %>
+              <% else %>
+                <div class="blankslate">
+                  <h3>"<%= @group_assignment.title %>" does not have any repositories.</h3>
+                  <p>Share the invitation link with your students to get started.</p>
+                </div>
+              <% end %>
+            </div>
+          </span>
+          <span id='unlinked-span' class='hidden-tab'>
+            <div class="assignment-repo-list">
+              <% @students_not_on_team.each do |entry| %>
+                <%= render partial: 'assignment_repos/assignment_repo', locals: {
+                  url: organization_group_assignment_roster_entry_path(@organization, @group_assignment, entry)
+                } %>
+              <% end %>
+            </div>
+          </span>
+        </div>
       </div>
+    <% else %>
+      <% if @group_assignment_repos.present? %>
+        <div class="assignment-repo-list">
+          <% @group_assignment_repos.each do |group_assignment_repo| %>
+            <%= render partial: 'group_assignment_repos/group_assignment_repo', \
+              locals: { url: organization_group_assignment_group_assignment_repo_path(@organization, @group_assignment, group_assignment_repo) } %>
+          <% end %>
+        </div>
+
+        <%= render partial: 'shared/pagination', locals: { collection: @group_assignment_repos } %>
+      <% else %>
+        <div class="blankslate">
+          <h3>"<%= @group_assignment.title %>" does not have any repositories.</h3>
+          <p>Share the invitation link with your students to get started.</p>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
 
       resources :group_assignments, path: "group-assignments" do
         resources :group_assignment_repos, only: [:show]
+        get "/roster_entries/:roster_entry_id", to: "roster_entries#show", as: "roster_entry"
       end
     end
   end


### PR DESCRIPTION
Closes #990 

This is the new view for group assignments with a roster. Only orgs with a roster will see the new view.

The first tab is identical to the old view. The second tab shows student that have not yet accepted the assignment. This includes students that haven't joined the classroom yet, or have just not joined a team yet.

~~TODO: Specs~~

Nevermind, there's no logic added in this PR.

<img width="1035" alt="screen shot 2017-07-26 at 2 07 24 pm" src="https://user-images.githubusercontent.com/4149056/28643898-3139e75a-720c-11e7-9c4f-6b47821da5b4.png">

<img width="1033" alt="screen shot 2017-07-26 at 2 07 51 pm" src="https://user-images.githubusercontent.com/4149056/28643903-384b385a-720c-11e7-90f2-9d6c619d408a.png">
