### PR TITLE
Different hover color for delete roster entry button

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -934,7 +934,12 @@ div.site-content-body.tabnav-body.join-box {
 
 .remove-roster-entry-button {
   margin-left: 10px;
-  fill: #d73a49;
+  fill: #333;
+  opacity: 0.25;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 
 .clickable {


### PR DESCRIPTION
The current delete button is sort of bugging me: Way too much red.

<img width="767" alt="screen shot 2017-07-27 at 8 31 31 am" src="https://user-images.githubusercontent.com/4149056/28679031-d0aa3598-72a6-11e7-9348-0d025c70e751.png">

Idea 1:

<img width="771" alt="screen shot 2017-07-27 at 8 29 03 am" src="https://user-images.githubusercontent.com/4149056/28679039-d6a8adda-72a6-11e7-9358-bc662c2eb806.png">

Idea 2 (taken from the GitHub modal styles)

<img width="769" alt="screen shot 2017-07-27 at 8 35 06 am" src="https://user-images.githubusercontent.com/4149056/28679058-e2455d5a-72a6-11e7-8c0c-e1039caf6cfe.png">

Preferences? I'm leaning towards 2, especially since it's what we use right now in our modals.

/cc @mozzadrella 