### PR TITLE
Log response times to statsd

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -16,8 +16,8 @@ module GitHubClassroom
   end
 end
 
-ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, start_time, finish_time, _id, payload|
-  next if payload[:path] =~ /\A\/peek/
+ActiveSupport::Notifications.subscribe("process_action.action_controller") do |_, start_time, finish_time, _id, payload|
+  next if payload[:path].match? %r{\A\/peek/}
 
   total_time = finish_time - start_time
 

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -15,3 +15,11 @@ module GitHubClassroom
                 end
   end
 end
+
+ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, start_time, finish_time, _id, payload|
+  next if payload[:path] =~ /\A\/peek/
+
+  total_time = finish_time - start_time
+
+  GitHubClassroom.statsd.timing("request.response_time", total_time)
+end


### PR DESCRIPTION
Start logging response times to statsd

We filter out peek requests because they're almost instant and not interesting at all.