### PR TITLE
Fix styling on create team textbox

### DIFF
--- a/app/views/group_assignment_invitations/show.html.erb
+++ b/app/views/group_assignment_invitations/show.html.erb
@@ -51,8 +51,8 @@
   <%= form_tag({ controller: :group_assignment_invitations, action: :accept_invitation}, method: :patch) do %>
     <dl class="form">
       <dt><label><%= 'OR' if @groups.present? %> Create a new team</label></dt>
-      <dd>
-        <%= text_field_tag 'group[title]', nil, placeholder: 'Create a new team', class: 'textfield' %>
+      <dd class="d-flex">
+        <%= text_field_tag 'group[title]', nil, placeholder: 'Create a new team', class: 'form-control input-block' %>
         <%= button_tag(type: 'submit', class: 'btn btn-primary js-navigation js-form-submit') do %>
           <%= octicon 'plus' %> Create team
         <% end %>


### PR DESCRIPTION
Closes #974 

Fixes some outdated classes on a textbox.

<img width="1028" alt="screen shot 2017-08-08 at 3 43 06 pm" src="https://user-images.githubusercontent.com/4149056/29097777-75aa7df2-7c50-11e7-9e78-751d1e46d514.png">
