### PR TITLE
Make OAuth Scope tree descendent finder work for arbitrarily deep trees

### DIFF
--- a/lib/github/token.rb
+++ b/lib/github/token.rb
@@ -61,17 +61,19 @@ module GitHub
 
       def descendents(scope, scope_tree = SCOPE_TREE)
         if scope_tree.key?(scope)
-          if scope_tree[scope].empty?
-            return []
-          else
-            children = scope_tree[scope].keys.map { |key| descendents(key, scope_tree) }
-            return [scope_tree[scope].keys, children].flatten
-          end
+          return [] if scope_tree[scope].empty?
+          top_level_recurse(scope, scope_tree)
         else
-            return scope_tree.keys.map do |key|
-              descendents(scope, scope_tree[key])
-            end.flatten
+          mid_level_recurse(scope, scope_tree)
         end
+      end
+
+      def top_level_recurse(scope, scope_tree)
+        [scope_tree[scope].keys, scope_tree[scope].keys.map { |key| descendents(key, scope_tree) }].flatten
+      end
+
+      def mid_level_recurse(scope, scope_tree)
+        scope_tree.keys.map { |key| descendents(scope, scope_tree[key]) }.flatten
       end
     end
   end

--- a/lib/github/token.rb
+++ b/lib/github/token.rb
@@ -64,14 +64,14 @@ module GitHub
       #
       # Since I don't think OAuth scopes will ever get that deep YOLO
       # - <3 @tarebyte
-      def descendents(scope)
-        if parent_scope?(scope)
-          return SCOPE_TREE[scope].keys.map do |child|
+      def descendents(scope, scope_tree = SCOPE_TREE)
+        if parent_scope?(scope, scope_tree)
+          return scope_tree[scope].keys.map do |child|
             [child, descendents(child)]
           end.flatten
         else
-          parent_scopes.each do |top|
-            return SCOPE_TREE[top][scope].keys if SCOPE_TREE[top].key?(scope)
+          parent_scopes(scope_tree).each do |top|
+            return scope_tree[top][scope].keys if scope_tree[top].key?(scope)
           end
         end
 
@@ -80,13 +80,13 @@ module GitHub
 
       private
 
-      def parent_scopes
+      def parent_scopes(scope_tree)
         return @parent_scopes if defined?(@parent_scopes)
-        @parent_scopes = SCOPE_TREE.keys
+        @parent_scopes = scope_tree.keys
       end
 
-      def parent_scope?(scope)
-        !SCOPE_TREE[scope].nil?
+      def parent_scope?(scope, scope_tree)
+        !scope_tree[scope].nil?
       end
     end
   end

--- a/lib/github/token.rb
+++ b/lib/github/token.rb
@@ -59,34 +59,19 @@ module GitHub
         end.flatten.uniq.sort
       end
 
-      # Note that this will only work for a scope that is _at MAX_
-      # three children deep.
-      #
-      # Since I don't think OAuth scopes will ever get that deep YOLO
-      # - <3 @tarebyte
       def descendents(scope, scope_tree = SCOPE_TREE)
-        if parent_scope?(scope, scope_tree)
-          return scope_tree[scope].keys.map do |child|
-            [child, descendents(child)]
-          end.flatten
-        else
-          parent_scopes(scope_tree).each do |top|
-            return scope_tree[top][scope].keys if scope_tree[top].key?(scope)
+        if scope_tree.key?(scope)
+          if scope_tree[scope].empty?
+            return []
+          else
+            children = scope_tree[scope].keys.map { |key| descendents(key, scope_tree) }
+            return [scope_tree[scope].keys, children].flatten
           end
+        else
+            return scope_tree.keys.map do |key|
+              descendents(scope, scope_tree[key])
+            end.flatten
         end
-
-        []
-      end
-
-      private
-
-      def parent_scopes(scope_tree)
-        return @parent_scopes if defined?(@parent_scopes)
-        @parent_scopes = scope_tree.keys
-      end
-
-      def parent_scope?(scope, scope_tree)
-        !scope_tree[scope].nil?
       end
     end
   end

--- a/spec/lib/github/token_spec.rb
+++ b/spec/lib/github/token_spec.rb
@@ -27,7 +27,6 @@ describe GitHub::Token do
   end
 
   describe "descendents" do
-
     scope_tree = {
       "admin:org" => {
         "write:org" => {

--- a/spec/lib/github/token_spec.rb
+++ b/spec/lib/github/token_spec.rb
@@ -37,6 +37,13 @@ describe GitHub::Token do
       "admin:public_key" => {
         "write:public_key" => {
           "read:public_key" => {}
+        },
+        "admin:obscure_key" => {
+          "write:obscure_key" => {
+            "read:obscure_key" => {
+              "execute:obscure_key" => {}
+            }
+          }
         }
       },
       "gist" => {}
@@ -56,6 +63,14 @@ describe GitHub::Token do
 
     it "returns [] when the scope is childless" do
       expect(subject.descendents("gist", scope_tree)).to eq([])
+    end
+
+    it "returns children when the scope is a grandchild" do
+      expect(subject.descendents("read:obscure_key", scope_tree)).to eq(["execute:obscure_key"])
+    end
+
+    it "returns grandchildren when the scope is a child" do
+      expect(subject.descendents("write:obscure_key", scope_tree)).to eq(["read:obscure_key", "execute:obscure_key"])
     end
   end
 end

--- a/spec/lib/github/token_spec.rb
+++ b/spec/lib/github/token_spec.rb
@@ -27,20 +27,35 @@ describe GitHub::Token do
   end
 
   describe "descendents" do
+
+    scope_tree = {
+      "admin:org" => {
+        "write:org" => {
+          "read:org" => {}
+        }
+      },
+      "admin:public_key" => {
+        "write:public_key" => {
+          "read:public_key" => {}
+        }
+      },
+      "gist" => {}
+    }.freeze
+
     it "returns [] when the scope is the last child" do
-      expect(subject.descendents("read:org")).to eq([])
+      expect(subject.descendents("read:org", scope_tree)).to eq([])
     end
 
     it "returns a list of children when it is a middle child" do
-      expect(subject.descendents("write:org")).to eq(["read:org"])
+      expect(subject.descendents("write:org", scope_tree)).to eq(["read:org"])
     end
 
     it "returns a list of children when it is a parent" do
-      expect(subject.descendents("admin:org")).to eq(["write:org", "read:org"])
+      expect(subject.descendents("admin:org", scope_tree)).to eq(["write:org", "read:org"])
     end
 
     it "returns [] when the scope is childless" do
-      expect(subject.descendents("gist")).to eq([])
+      expect(subject.descendents("gist", scope_tree)).to eq([])
     end
   end
 end


### PR DESCRIPTION
This addresses the comments on the `descendents` function within `token.rb` which explains that there is an assumption that OAuth scopes will never exceed three levels deep. It introduces some complexity into the code because it has to recursively traverse the tree, where the old version essentially just finds its place in the tree from three available levels.