### PR TITLE
Add and configure Failbot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "connection_pool"
 
 gem "dalli"
 
+gem "failbot_rails", "~> 0.5.0"
 gem "faraday-http-cache"
 gem "flipper"
 gem "flipper-redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,10 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    failbot (2.0.1)
+    failbot_rails (0.5.0)
+      failbot (>= 0.9.2, < 3)
+      rails (>= 4)
     faker (1.7.3)
       i18n (~> 0.5)
     faraday (0.11.0)
@@ -453,6 +457,7 @@ DEPENDENCIES
   dogstatsd-ruby
   dotenv-rails
   factory_girl_rails
+  failbot_rails (~> 0.5.0)
   faker
   faraday-http-cache
   flipper
@@ -516,4 +521,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,12 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+ENV["FAILBOT_BACKEND"] ||= "memory"
+
+# report exceptions using Failbot
+require "failbot_rails"
+FailbotRails.setup("github-classroom#{'-staging' if Rails.env.staging?}")
+
 module GitHubClassroom
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
This adds the Failbot gem so that I can get some better reporting on Classroom in our internal tooling.

This shouldn't be an issue for non GitHub based instances.