### PR TITLE
[WIP] Synchronize users removed from teams

### DIFF
--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -9,14 +9,14 @@ class MembershipEventJob < ApplicationJob
 
     user_id = payload_body.dig("member", "id")
     team_id = payload_body.dig("team", "id")
+
     user = User.find_by(uid: user_id)
-    group_id = Group.find_by(github_team_id: team_id).id
+    return true unless user.present?
 
-    repo_accesses = GroupAssignmentRepo.find_by(group_id: group_id).repo_accesses
+    group = Group.find_by(github_team_id: team_id)
+    return true unless group.present?
 
-    repo_access = repo_accesses.find_by(user_id: user.id)
-    repo_access&.delete
-
-    # Do we remove github_repo as well ?
+    group.repo_accesses.find_by(user_id: user.id)
+    repo_access&.destroy
   end
 end

--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -11,10 +11,10 @@ class MembershipEventJob < ApplicationJob
     team_id = payload_body.dig("team", "id")
 
     user = User.find_by(uid: user_id)
-    return true unless user.present?
+    return true unless user.blank?
 
     group = Group.find_by(github_team_id: team_id)
-    return true unless group.present?
+    return true unless group.blank?
 
     group.repo_accesses.find_by(user_id: user.id)
     repo_access&.destroy

--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Documentation: https://developer.github.com/v3/activity/events/types/#membershipevent
+class MembershipEventJob < ApplicationJob
+  queue_as :github_event
+
+  def perform(payload_body)
+    return true unless payload_body.dig("action") == "removed"
+
+    user_id = payload_body.dig("member", "id")
+    team_id = payload_body.dig("team", "id")
+    user = User.find_by(uid: user_id)
+    group_id = Group.find_by(github_team_id: team_id).id
+
+    repo_accesses = GroupAssignmentRepo.find_by(group_id: group_id).repo_accesses
+
+    repo_access = repo_accesses.find_by(user_id: user.id)
+    repo_access.delete if repo_access
+
+    # Do we remove github_repo as well ?
+  end
+end

--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -15,7 +15,7 @@ class MembershipEventJob < ApplicationJob
     repo_accesses = GroupAssignmentRepo.find_by(group_id: group_id).repo_accesses
 
     repo_access = repo_accesses.find_by(user_id: user.id)
-    repo_access.delete if repo_access
+    repo_access&.delete
 
     # Do we remove github_repo as well ?
   end

--- a/lib/github/web_hook.rb
+++ b/lib/github/web_hook.rb
@@ -2,7 +2,7 @@
 
 module GitHub
   class WebHook
-    ACCEPTED_EVENTS = %w[ping repository].freeze
+    ACCEPTED_EVENTS = %w[ping repository membership].freeze
 
     class << self
       # Public: Generate the [HMAC](https://tools.ietf.org/html/rfc2104)


### PR DESCRIPTION
Hi folks ! 👋 

First fix for the issue #1216 / #1215 
TODO:
- [ ] Write tests
- [ ] Removed from organization as well ?

It seems Classroom does not accept some events, especially when a user is removed from an organization or leaves a team in GitHub.
The thing is that in Classroom the number of members was wrong all this time (the informations were not updated at all).

I found a way to fix it. Not sure if it's a good way to do it but it works.

Next step would be to do the same when someone leaves an organization or is removed by an admin. 
I realized after I've finished it that someone was already working on the organization/teams issue #1174 🙈 

<img width="1017" alt="screen shot 2018-01-25 at 15 13 51" src="https://user-images.githubusercontent.com/11220823/35402000-7faac1aa-01fb-11e8-804d-4606498a9e7a.png">
<img width="1020" alt="screen shot 2018-01-25 at 18 10 57" src="https://user-images.githubusercontent.com/11220823/35402001-7fe0fcc0-01fb-11e8-935c-ececee039496.png">

Happy to hear your comments about it ✨ 