### PR TITLE
Sort roster entries based on identifier

### DIFF
--- a/app/views/shared/_shared_join_roster.html.erb
+++ b/app/views/shared/_shared_join_roster.html.erb
@@ -22,7 +22,7 @@
     <h3><%= roster.identifier_name %></h3>
       <div class="site-content-body tabnav-body clearfix join-box">
         <div class="remodal-user-list">
-        <% roster.unlinked_entries.each do |entry| %>
+        <% roster.unlinked_entries.sort_by { |entry| entry.identifier }.each do |entry| %>
           <div class="remodal-user">
             <%= form_tag({ controller: view.controller_name, action: :join_roster }, method: :patch) do %>
               <%= hidden_field_tag 'roster_entry_id', entry.id %>

--- a/app/views/shared/_shared_join_roster.html.erb
+++ b/app/views/shared/_shared_join_roster.html.erb
@@ -22,7 +22,7 @@
     <h3><%= roster.identifier_name %></h3>
       <div class="site-content-body tabnav-body clearfix join-box">
         <div class="remodal-user-list">
-        <% roster.unlinked_entries.sort_by { |entry| entry.identifier }.each do |entry| %>
+        <% roster.unlinked_entries.sort_by(&:identifier).each do |entry| %>
           <div class="remodal-user">
             <%= form_tag({ controller: view.controller_name, action: :join_roster }, method: :patch) do %>
               <%= hidden_field_tag 'roster_entry_id', entry.id %>


### PR DESCRIPTION
Based on this: https://github.com/education/classroom/issues/1239

The roster shown to a student when they first log in to choose their IDs is now **sorted** ✨ !

<img width="1038" alt="screen shot 2018-01-25 at 8 21 58 pm" src="https://user-images.githubusercontent.com/11889765/35421420-269cf9aa-0211-11e8-84cd-fb659d9b8ef6.png">
