### PR TITLE
Update Nokogiri to mitigate CVE-2017-9050

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     msgpack (1.1.0)
     multi_json (1.12.1)
@@ -235,8 +235,8 @@ GEM
     nenv (0.3.0)
     newrelic_rpm (4.4.0.336)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -520,4 +520,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
I got a notification for https://github.com/education/classroom/network/dependencies#35074859

This updates bumps Nokogiri to 1.8.2