### PR TITLE
Drop unique index on github_id for Organizations

### DIFF
--- a/db/migrate/20180131020132_drop_unique_github_id_index_on_organizations.rb
+++ b/db/migrate/20180131020132_drop_unique_github_id_index_on_organizations.rb
@@ -1,0 +1,6 @@
+class DropUniqueGitHubIdIndexOnOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :organizations, :github_id
+    add_index :organizations, :github_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170802170240) do
+ActiveRecord::Schema.define(version: 20180131020132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 20170802170240) do
     t.boolean "is_webhook_active", default: false
     t.integer "roster_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
-    t.index ["github_id"], name: "index_organizations_on_github_id", unique: true
+    t.index ["github_id"], name: "index_organizations_on_github_id"
     t.index ["roster_id"], name: "index_organizations_on_roster_id"
     t.index ["slug"], name: "index_organizations_on_slug"
   end


### PR DESCRIPTION
Working towards https://github.com/education/classroom/issues/595

This removes the unique index on `github_id` at the database level for the `organizations` table.

Until the feature is complete we need to keep the unique index at the model level, but this is a good first start.