### PR TITLE
Fix for pagination bug

### DIFF
--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -16,7 +16,7 @@ class RosterEntry < ApplicationRecord
   # with a secondary sort on ID to ensure ties are always handled in the same way
   def self.order_for_view(assignment)
     users_with_repo = assignment.repos.pluck(:user_id)
-    sql_formatted_users = "(#{users_with_repo.join(',')})"
+    sql_formatted_users = users_with_repo.empty? ? "(NULL)" : "(#{users_with_repo.join(',')})"
 
     order <<~SQL
       CASE
@@ -31,7 +31,7 @@ class RosterEntry < ApplicationRecord
   # Restrict relation to only entries that have not joined a team
   def self.students_not_on_team(group_assignment)
     students_on_team = group_assignment.repos.map(&:repo_accesses).flatten.map(&:user).map(&:id).uniq
-    sql_formatted_students_on_team = "(#{students_on_team.join(',')})"
+    sql_formatted_students_on_team = students_on_team.empty? ? "(NULL)" : "(#{students_on_team.join(',')})"
 
     where <<~SQL
       roster_entries.user_id IS NULL OR

--- a/spec/models/roster_entry_spec.rb
+++ b/spec/models/roster_entry_spec.rb
@@ -47,5 +47,15 @@ RSpec.describe RosterEntry, type: :model do
 
       expect(RosterEntry.where(roster: roster).order_for_view(assignment).to_a).to eq(expected_ordering)
     end
+
+    it "orders correctly, even with no accepted students" do
+      roster.roster_entries.first.destroy # Ignore the default entry here
+      assignment_repo.delete
+      linked_accepted_entry.destroy
+
+      expected_ordering = [linked_not_accepted_entry, not_linked_entry]
+
+      expect(RosterEntry.where(roster: roster).order_for_view(assignment).to_a).to eq(expected_ordering)
+    end
   end
 end


### PR DESCRIPTION
Apparently `IN ()` is invalid syntax in postgres and none of my specs caught that -_-

Instead of `()`, we use `(NULL)` as the empty collection, which works in both cases.

I also added a regression test.

@tarebyte 