### PR TITLE
Fix accept assignment view

### DIFF
--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,7 +4,7 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
-  before_action :check_repository_already_created_on_github, :check_user_not_previous_acceptee,
+  before_action :check_repo_already_on_github, :check_user_not_previous_acceptee,
   :check_should_redirect_to_roster_page, only: [:show]
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
@@ -54,9 +54,8 @@ class AssignmentInvitationsController < ApplicationController
     create_submission
   end
 
-  def check_repository_already_created_on_github
+  def check_repo_already_on_github
     return if current_submission.nil? || !current_submission.github_repository.on_github?
-
     if current_submission.assignment.starter_code?
       import_status = current_submission.github_repository.import_progress.status
       return redirect_to setup_assignment_invitation_path if import_status != "complete"

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,8 +4,7 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
-  before_action :check_repo_already_on_github, :check_user_not_previous_acceptee,
-  :check_should_redirect_to_roster_page, only: [:show]
+  before_action :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: :show
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
 
@@ -28,7 +27,9 @@ class AssignmentInvitationsController < ApplicationController
     render json: setup_status(current_submission)
   end
 
-  def show; end
+  def show
+    return unless check_repo_already_on_github
+  end
 
   def success; end
 

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,6 +4,7 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
+  before_action :check_already_on_github, only: [:show]
   before_action :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: [:show]
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
@@ -51,6 +52,14 @@ class AssignmentInvitationsController < ApplicationController
     remove_instance_variable(:@current_submission)
 
     create_submission
+  end
+
+  def check_already_on_github
+    return if current_submission.nil?
+    import_status = current_submission.github_repository.import_progress.status
+    if current_submission.github_repository.on_github? && import_status == "complete"
+      return redirect_to success_assignment_invitation_path
+    end
   end
 
   def check_user_not_previous_acceptee

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,7 +4,8 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
-  before_action :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: :show
+  before_action :check_repository_on_github, :check_user_not_previous_acceptee,
+                :check_should_redirect_to_roster_page, only: [:show]
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
 
@@ -27,9 +28,7 @@ class AssignmentInvitationsController < ApplicationController
     render json: setup_status(current_submission)
   end
 
-  def show
-    return unless check_repo_already_on_github
-  end
+  def show; end
 
   def success; end
 
@@ -55,17 +54,22 @@ class AssignmentInvitationsController < ApplicationController
     create_submission
   end
 
-  def check_repo_already_on_github
-    return if current_submission.nil? || !current_submission.github_repository.on_github?
+  # rubocop:disable Metrics/AbcSize
+  def check_repository_on_github
+    return if current_submission.nil?
+    return unless current_submission.github_repository.on_github?
+
     if current_submission.assignment.starter_code?
       import_status = current_submission.github_repository.import_progress.status
       return redirect_to setup_assignment_invitation_path if import_status != "complete"
     end
     redirect_to success_assignment_invitation_path
   end
+  # rubocop:enable Metrics/AbcSize
 
   def check_user_not_previous_acceptee
     return if current_submission.nil?
+
     if repo_setup_enabled? && setup_status(current_submission)[:status] != :complete
       return redirect_to setup_assignment_invitation_path
     end

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,7 +4,8 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
-  before_action :check_repository_already_created_on_github, :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: [:show]
+  before_action :check_repository_already_created_on_github, :check_user_not_previous_acceptee,
+  :check_should_redirect_to_roster_page, only: [:show]
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
 
@@ -54,16 +55,13 @@ class AssignmentInvitationsController < ApplicationController
   end
 
   def check_repository_already_created_on_github
-    return if current_submission.nil?
-
-    return unless current_submission.github_repository.on_github?
+    return if current_submission.nil? || !current_submission.github_repository.on_github?
 
     if current_submission.assignment.starter_code?
       import_status = current_submission.github_repository.import_progress.status
       return redirect_to setup_assignment_invitation_path if import_status != "complete"
     end
-
-    return redirect_to success_assignment_invitation_path
+    redirect_to success_assignment_invitation_path
   end
 
   def check_user_not_previous_acceptee

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -4,8 +4,7 @@ class AssignmentInvitationsController < ApplicationController
   include InvitationsControllerMethods
   include RepoSetup
 
-  before_action :check_already_on_github, only: [:show]
-  before_action :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: [:show]
+  before_action :check_repository_already_created_on_github, :check_user_not_previous_acceptee, :check_should_redirect_to_roster_page, only: [:show]
   before_action :ensure_submission_repository_exists, only: %i[setup setup_progress success]
   before_action :ensure_authorized_repo_setup, only: %i[setup setup_progress]
 
@@ -54,12 +53,17 @@ class AssignmentInvitationsController < ApplicationController
     create_submission
   end
 
-  def check_already_on_github
+  def check_repository_already_created_on_github
     return if current_submission.nil?
-    import_status = current_submission.github_repository.import_progress.status
-    if current_submission.github_repository.on_github? && import_status == "complete"
-      return redirect_to success_assignment_invitation_path
+
+    return unless current_submission.github_repository.on_github?
+
+    if current_submission.assignment.starter_code?
+      import_status = current_submission.github_repository.import_progress.status
+      return redirect_to setup_assignment_invitation_path if import_status != "complete"
     end
+
+    return redirect_to success_assignment_invitation_path
   end
 
   def check_user_not_previous_acceptee

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -7,6 +7,7 @@ class GroupAssignmentInvitationsController < ApplicationController
 
   layout "layouts/invitations"
 
+  before_action :check_user_already_on_team,           only: [:show]
   before_action :check_group_not_previous_acceptee,    only: [:show]
   before_action :check_user_not_group_member,          only: [:show]
   before_action :check_should_redirect_to_roster_page, only: [:show]
@@ -156,6 +157,14 @@ class GroupAssignmentInvitationsController < ApplicationController
     repo             = group_assignment_repo.github_repository
     classroom_branch = repo.branch_present?("github-classroom")
     repo.imported? && classroom_branch && group_assignment_repo.not_configured?
+  end
+
+  def check_user_already_on_team
+    return unless group.present? && group_assignment_repo.present?
+
+    if group.repo_accesses.find_by(user_id: current_user.id)
+      redirect_to successful_invitation_group_assignment_invitation_path
+    end
   end
 
   def check_group_not_previous_acceptee

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -161,8 +161,8 @@ class GroupAssignmentInvitationsController < ApplicationController
 
   def check_user_already_on_team
     return unless group.present? && group_assignment_repo.present?
-
-    redirect_to successful_invitation_group_assignment_invitation_path if group.repo_accesses.find_by(user_id: current_user.id)
+    user_in_group = group.repo_accesses.find_by(user_id: current_user.id)
+    redirect_to successful_invitation_group_assignment_invitation_path if user_in_group
   end
 
   def check_group_not_previous_acceptee

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -162,9 +162,7 @@ class GroupAssignmentInvitationsController < ApplicationController
   def check_user_already_on_team
     return unless group.present? && group_assignment_repo.present?
 
-    if group.repo_accesses.find_by(user_id: current_user.id)
-      redirect_to successful_invitation_group_assignment_invitation_path
-    end
+    redirect_to successful_invitation_group_assignment_invitation_path if group.repo_accesses.find_by(user_id: current_user.id)
   end
 
   def check_group_not_previous_acceptee


### PR DESCRIPTION
Hi there 👋 

> Based on user bug reported by our support team. 

I found out that if the assignment was already accepted and a user goes on the invitation link:
- the user is redirected to the setup view even though the repository already existed on GitHub and the assignment was already accepted.

<img width="500" alt="screen shot 2018-02-22 at 17 53 30" src="https://user-images.githubusercontent.com/11220823/36552629-9882e8c8-17fa-11e8-8fa0-4a9a8f46dd97.png">

- If the assignment had no starter code it returns this view, even if the repository exists (404 because we check the import status on an assignment that was not imported because there is no starter code to import)

<img width="500" alt="screen shot 2018-02-22 at 11 59 58" src="https://user-images.githubusercontent.com/11220823/36552642-a0461698-17fa-11e8-872e-db206bff634f.png">

I added a few methods to check if the repository exists on GitHub and added a check for starter-code if there is one.
I applied it for `Assignment` and `GroupAssignment` as well even if the logic is different.
The user is now redirected to the success view if the repo is already created on GH and if the starter code is imported if there is one.

<img width="500" alt="screen shot 2018-02-22 at 14 50 40" src="https://user-images.githubusercontent.com/11220823/36552778-ffe555dc-17fa-11e8-92dd-a228917292cc.png">

Also I could really use the community help to test this new feature because I can reproduce this bug in dev mode but not in production anymore 😞
