### PR TITLE
Remove homebrew/versions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,7 +2,6 @@
 
 # Helpers
 tap "caskroom/cask"
-tap "homebrew/versions"
 tap "github/bootstrap"
 
 cask "java8"


### PR DESCRIPTION
`homebrew/versions`[here](https://github.com/Homebrew/homebrew-versions) is now deprecated (it's now part of homebrew/core) and might cause troubles during the `./server/setup`


This PR is the same than @talsafran 's ( 👋) one for the education's website 👍 

