### PR TITLE
Remove pagination for download

### DIFF
--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -110,6 +110,7 @@ module Orgs
     end
 
     def download_roster
+      @roster_entries = @current_roster.roster_entries.includes(:user).order(:identifier)
       respond_to do |format|
         format.csv { send_data @roster_entries.to_csv, filename: "classroom_roster.csv", disposition: "attachment" }
       end

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -210,11 +210,9 @@ RSpec.describe Orgs::RostersController, type: :controller do
         before do
           roster.roster_entries.destroy_all
 
-          identifiers = 24.times.map { |e| "ID-#{e}" }
-          identifiers.each do |identifier|
-            roster.roster_entries << RosterEntry.new(identifier: identifier)
+          Array.new(24) do |e|
+            roster.roster_entries << RosterEntry.new(identifier: "ID-#{e}")
           end
-
           @all_entries = roster.roster_entries
         end
 

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -206,6 +206,25 @@ RSpec.describe Orgs::RostersController, type: :controller do
         end
       end
 
+      context "download roster" do
+        before do
+          roster.roster_entries.destroy_all
+
+          identifiers = 24.times.map { |e| "ID-#{e}" }
+          identifiers.each do |identifier|
+            roster.roster_entries << RosterEntry.new(identifier: identifier)
+          end
+
+          @all_entries = roster.roster_entries
+        end
+
+        it "exports CSV with all entries" do
+          roster_csv = @all_entries.to_csv
+
+          expect(roster_csv.split("\n").size - 1).to eq(@all_entries.count)
+        end
+      end
+
       after do
         GitHubClassroom.flipper[:student_identifier].disable
       end

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Orgs::RostersController, type: :controller do
         end
       end
 
-      context "download roster" do
+      context "download roster button" do
         before do
           roster.roster_entries.destroy_all
 
@@ -216,9 +216,11 @@ RSpec.describe Orgs::RostersController, type: :controller do
           @all_entries = roster.roster_entries
         end
 
-        it "exports CSV with all entries" do
+        it "should exports CSV with all entries" do
           roster_csv = @all_entries.to_csv
+          paginated_roster_csv = @all_entries.first(20).to_csv
 
+          expect(paginated_roster_csv.split("\n").size - 1).not_to eq(@all_entries.count)
           expect(roster_csv.split("\n").size - 1).to eq(@all_entries.count)
         end
       end


### PR DESCRIPTION
Fix for #1291 
I forgot to remove pagination for the download button on my last PR 🙈 
The download button returned only the first 20 students not all of them as it should have.

I removed pagination so it returns now all of the students from the roster.

TODO: 
- [x] Tests for all entries
- [x] Tests with pagination