### PR TITLE
Put back java as ElasticSearch now supports Java9

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,7 +5,7 @@ tap "caskroom/cask"
 tap "homebrew/versions"
 tap "github/bootstrap"
 
-cask "java8"
+cask "java"
 cask "ngrok"
 
 brew "nodejs"


### PR DESCRIPTION
Fix to #1297 

It appears that ElasticSearch finally supports Java9 🎉
We're going to put back `Java` and remove `Java8` from the Brewfile.

I uninstalled `java8` and I'm running with `java9` and all is good for now ✨ 
> ➜  classroom git:(update_Brewfile_java) brew cask info java
java: 9.0.4,11:c2514751926b4512b076cc82f959763f