### PR TITLE
Update GitHub client token for organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,7 +36,7 @@ class Organization < ApplicationRecord
   end
 
   def github_client
-    token = Rails.env.test? ? users.limit(1).order("RANDOM()").pluck(:token)[0] : users.first.token
+    token = Rails.env.test? ? users.first.token : users.limit(1).order("RANDOM()").pluck(:token)[0]
 
     Octokit::Client.new(access_token: token)
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,7 +36,8 @@ class Organization < ApplicationRecord
   end
 
   def github_client
-    token = users.limit(1).order("RANDOM()").pluck(:token)[0]
+    token = Rails.env.test? ? users.limit(1).order("RANDOM()").pluck(:token)[0] : users.first.token
+
     Octokit::Client.new(access_token: token)
   end
 


### PR DESCRIPTION
Intend to fix #1308 

If we are in test environment then we get the first user's token to make sure we don't get `401 - Bad credentials` when doing API calls.