### PR TITLE
Including GitHub IDs in downloaded rosters

### DIFF
--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -9,14 +9,14 @@ class RosterEntry < ApplicationRecord
 
   def self.to_csv
     CSV.generate(headers: true, col_sep: ",", force_quotes: true) do |csv|
-      csv << %i[github_id identifier github_username name]
+      csv << %i[identifier github_username github_id name]
 
       all.sort_by(&:identifier).each do |entry|
         github_user = entry.user.try(:github_user)
         github_id = github_user.try(:id) || ""
         login = github_user.try(:login) || ""
         name = github_user.try(:name) || ""
-        csv << [github_id, entry.identifier, login, name]
+        csv << [entry.identifier, login, github_id, name]
       end
     end
   end

--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -9,13 +9,14 @@ class RosterEntry < ApplicationRecord
 
   def self.to_csv
     CSV.generate(headers: true, col_sep: ",", force_quotes: true) do |csv|
-      csv << %i[identifier github_username name]
+      csv << %i[github_id identifier github_username name]
 
       all.sort_by(&:identifier).each do |entry|
         github_user = entry.user.try(:github_user)
+        github_id = github_user.try(:id) || ""
         login = github_user.try(:login) || ""
         name = github_user.try(:name) || ""
-        csv << [entry.identifier, login, name]
+        csv << [github_id, entry.identifier, login, name]
       end
     end
   end


### PR DESCRIPTION
This PR address https://github.com/education/classroom/issues/1310
The downloaded roster now include a student's GitHub ID (if the account is linked)

Let me know if there needs to be changes!

## Roster
<img width="1109" alt="screen shot 2018-03-18 at 12 04 24 pm" src="https://user-images.githubusercontent.com/11889765/37568045-2a6c1896-2aa6-11e8-9381-93544bea9b7f.png">

## Downloaded Roster
<img width="289" alt="screen shot 2018-03-18 at 12 14 36 pm" src="https://user-images.githubusercontent.com/11889765/37568044-22403a76-2aa6-11e8-8ed0-86a0623748b1.png">
