### PR TITLE
Fix N+1 in calculating unlinked users

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -83,7 +83,10 @@ class AssignmentsController < ApplicationController
     return unless @organization.roster
 
     assignment_users = @assignment.users
-    roster_entry_users = @organization.roster.roster_entries.map(&:user).compact
+
+    roster_entries = @organization.roster.roster_entries
+    user_ids = roster_entries.map(&:user_id)
+    roster_entry_users = User.where(id: user_ids)
 
     @unlinked_users = assignment_users - roster_entry_users
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -84,9 +84,8 @@ class AssignmentsController < ApplicationController
 
     assignment_users = @assignment.users
 
-    roster_entries = @organization.roster.roster_entries
-    user_ids = roster_entries.map(&:user_id)
-    roster_entry_users = User.where(id: user_ids)
+    roster_entry_user_ids = @organization.roster.roster_entries.pluck(:user_id)
+    roster_entry_users = User.where(id: roster_entry_user_ids)
 
     @unlinked_users = assignment_users - roster_entry_users
   end


### PR DESCRIPTION
Me and @Kadaaran spent an hour or so yesterday picking apart the app trying to find inefficiencies causing long load times for large classrooms. The main issue ended up being an [Octokit bug](https://github.com/octokit/octokit.rb/issues/912), but we did come across another performance bug that affects large classrooms.

`.roster_entries.map(&:user)` loads the user records for each roster entry, but the way it's written, we make 1 SQL query per roster entry. Me and @Kadaaran tested this line of code against a classroom with 450 roster entries and it took `2.0s` to run.

The refactored logic makes a single batched query.

cc @tarebyte 