### PR TITLE
Fix pagination for non rosters orgs

### DIFF
--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -29,10 +29,11 @@ class GroupAssignmentsController < ApplicationController
   end
 
   def show
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:teams_page])
+    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:page])
 
     return unless @organization.roster
 
+    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:teams_page])
     @students_not_on_team = @organization.roster.roster_entries
                                          .students_not_on_team(@group_assignment)
                                          .page(params[:students_page])

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -30,7 +30,8 @@ class GroupAssignmentsController < ApplicationController
 
   def show
     pagination_key = @organization.roster ? :teams_page : :page
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[pagination_key])
+    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment)
+                                                 .page(params[pagination_key])
 
     return unless @organization.roster
     @students_not_on_team = @organization.roster.roster_entries

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -29,11 +29,10 @@ class GroupAssignmentsController < ApplicationController
   end
 
   def show
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:page])
+    pagination_key = @organization.roster ? :teams_page : :page
+    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[pagination_key])
 
     return unless @organization.roster
-
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).page(params[:teams_page])
     @students_not_on_team = @organization.roster.roster_entries
                                          .students_not_on_team(@group_assignment)
                                          .page(params[:students_page])


### PR DESCRIPTION
Fix to #1303 
Found out that the bug is linked to #1228 @d12 🙏 

This issue occurs in a particular situation: in the group_assignment page for organizations without roster.
This line was sending to the partial another page parameter than the regular one we should have.

https://github.com/education/classroom/blob/3b01242b9c5f769a1fa12234c83723713851f8fd/app/controllers/group_assignments_controller.rb#L32
https://github.com/education/classroom/blob/3b01242b9c5f769a1fa12234c83723713851f8fd/app/views/group_assignments/show.html.erb#L99

**TODO**:  Write test (which are not overkill) for pagination