### PR TITLE
Change `help-wanted` link to reflect emoji label

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ ENV Variable | Description |
 `MOTD` | Show the message of the day banner at the top of the site
 
 ## Help wanted
-If you're interested in helping out with Classroom development and looking for a place to get started, check out the issues labeled [`help-wanted`](https://github.com/education/classroom/issues?q=is%3Aissue+is%3Aopen+label%3Ahelp-wanted) and feel free to ask any questions you have before diving into the code.
+If you're interested in helping out with Classroom development and looking for a place to get started, check out the issues labeled [`help-wanted`](https://github.com/education/classroom/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Ahand%3A+help-wanted%22) and feel free to ask any questions you have before diving into the code.
 
 ## Contributors
 Classroom is developed by these [contributors](https://github.com/education/classroom/graphs/contributors).


### PR DESCRIPTION
Hey 👋 

Saw that the `help-wanted` link was using referring to the old [`help-wanted`](https://github.com/education/classroom/issues?q=is%3Aissue+is%3Aopen+label%3Ahelp-wanted) label (without the emoji). 
The new [`help-wanted`](https://github.com/education/classroom/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Ahand%3A+help-wanted%22) link reflects the label that is being used (with the emoji).