### PR TITLE
Configure Redis adapter for ActionCable

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,12 @@
+default: &default
+  adapter: redis
+  url: <%= GitHubClassroom::REDIS_URL %>
+
 development:
-  adapter: async
+  <<: *default
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: redis://localhost:6379/1
-  channel_prefix: git_hub_classroom_production
+  <<: *default


### PR DESCRIPTION
Looks like there was a lot of `Redis::CannotConnectError`. This is because ActionCable wasn't configured properly. Good news is that this didn't affect any teachers/students flows but caused a firehose of `Redis::CannotConnectError` and `5xx` on `/cable`.

Originally part of #1385 but being pulled out.