### PR TITLE
Fix concurrency issue with CreateGitHubRepositoryJob

### DIFF
--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -19,6 +19,9 @@ class AssignmentRepo
     def perform(assignment, user)
       start = Time.zone.now
 
+      invitation_status = assignment.invitation&.status
+      return if %w[unaccepted creating_repo importing_starter_code completed].include?(invitation_status)
+
       assignment.invitation&.creating_repo!
 
       creator = Creator.new(assignment: assignment, user: user)


### PR DESCRIPTION
## What
The concurrency problem with `CreateGitHubRepositoryJob` is that you could kick off two jobs that could create two repos. We want `CreateGitHubRepositoryJob` to only create one repo always.

## How

We do this by short circuiting the job and returning early if the invitation status is:
* `unaccepted` (if the invitation wasn't accepted)
* `creating_repo` (if a job is already creating a repo)
* `importing_starter_code`(if starter code is being imported already)
* `completed` (if a repo already exists)

Closes #1392 