### PR TITLE
Reduce poll interval to 1s instead of 3s

### DIFF
--- a/app/assets/javascripts/setupv2.js
+++ b/app/assets/javascripts/setupv2.js
@@ -1,5 +1,5 @@
 (function() {
-  var POLL_INTERVAL = 3000;
+  var POLL_INTERVAL = 1000;
   var check_progress,
     display_progress,
     get_status,


### PR DESCRIPTION
# What
The poll interval was previously 3 seconds and there is a large discrepancy between when a import actually finishes vs when classroom thinks it finishes.

I will do some investigating to why there is a large discrepancy but this should make the problem slightly worse for now.