### PR TITLE
Remove automatic retries in repo creation process

### DIFF
--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -7,7 +7,6 @@ class AssignmentRepo
     IMPORT_STARTER_CODE = "Importing starter code"
 
     queue_as :create_repository
-    retry_on Creator::Result::Error, wait: :exponentially_longer, queue: :create_repository
 
     # Create an AssignmentRepo
     #
@@ -79,7 +78,6 @@ class AssignmentRepo
         status: assignment.invitation&.status
       )
       GitHubClassroom.statsd.increment("v2_exercise_repo.create.fail")
-      raise err
     end
     # rubocop:enable MethodLength
     # rubocop:enable AbcSize


### PR DESCRIPTION
## What
This PR removes automatic retries from `CreateGitHubRepositoryJob`

## Why
Retries are funneling up to our error reporting software even when they aren't necessarily errors.

We have a manual retry button on the setupv2 page so it would reduce complexity and do away with automatic retries in place of manual retries.

---


Closes #1416 