### PR TITLE
Octopoller.try 

### DIFF
--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -2,17 +2,18 @@
 
 module Octopoller
   class TimeoutError < StandardError; end
+  class TooManyAttemptsError < StandardError; end
 
   # Polls until success
-  # Re-runs when an error is caught
+  # Re-runs when the block returns `:re_poll`
   #
-  # wait - The time delay in seconds between polls (default is 1 second)
+  # wait    - The time delay in seconds between polls (default is 1 second)
   # timeout - The maximum number of seconds the poller will run (default is 15 seconds)
-  # error_handler - A proc that will run with each instance of an error
-  # yield - A block that will execute, and if it raises an error it will re-run until success or the timeout is reached
-  # raise - Raises an Octopoller::TimeoutError if the timeout is reached
+  # yield   - A block that will execute, and if `:re_poll` is returned it will re-run
+  #         - Re-runs until success or the timeout is reached
+  # raise   - Raises an Octopoller::TimeoutError if the timeout is reached
   def poll(wait: 1.second, timeout: 15.seconds)
-    raise ArgumentError, "Cannot poll backwards in time" if wait.negative?
+    raise ArgumentError, "Cannot wait backwards in time" if wait.negative?
     raise ArgumentError, "Timed out without even being able to try" if timeout.negative?
 
     start = Time.now.utc
@@ -24,5 +25,38 @@ module Octopoller
     raise TimeoutError, "Polling timed out paitently"
   end
 
+  # Tries until success
+  # Re-runs when the block returns `:retry`
+  #
+  # wait      - The time delay in seconds between attempts (default is 1 second)
+  #           - When given the argument `:exponentially` the action will be retried with exponetial backoff
+  # attempts  - The maximum number of attempts the action will be performed (default is 15)
+  # yield     - A block that will execute, and if `:retry` is returned it will re-run the action
+  #           - re-run the action until success or the max number of attempts is reached
+  # raise     - Raises an Octopoller::TooManyTriesError if the max number of attempts is reached
+  #
+  # rubocop:disable MethodLength
+  # rubocop:disable CyclomaticComplexity
+  # rubocop:disable PerceivedComplexity
+  def try(wait: 1.second, attempts: 15)
+    exponential_backoff = wait == :exponentially
+    raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
+    raise ArgumentError, "Cannot try something a negative number of attempts" if attempts.negative?
+    raise ArgumentError, "Cannot try something zero attempts" if attempts.zero?
+
+    wait = 0.5.seconds if exponential_backoff
+    attempts.times do
+      block_value = yield
+      return block_value unless block_value == :retry
+      sleep wait
+      wait *= 2 if exponential_backoff
+    end
+    raise TooManyAttemptsError, "Tried maximum number of attempts"
+  end
+  # rubocop:enable MethodLength
+  # rubocop:enable CyclomaticComplexity
+  # rubocop:enable PerceivedComplexity
+
   module_function :poll
+  module_function :try
 end

--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -7,56 +7,58 @@ module Octopoller
   # Polls until success
   # Re-runs when the block returns `:re_poll`
   #
-  # wait    - The time delay in seconds between polls (default is 1 second)
-  # timeout - The maximum number of seconds the poller will run (default is 15 seconds)
-  # yield   - A block that will execute, and if `:re_poll` is returned it will re-run
-  #         - Re-runs until success or the timeout is reached
-  # raise   - Raises an Octopoller::TimeoutError if the timeout is reached
-  def poll(wait: 1.second, timeout: 15.seconds)
-    raise ArgumentError, "Cannot wait backwards in time" if wait.negative?
-    raise ArgumentError, "Timed out without even being able to try" if timeout.negative?
-
-    start = Time.now.utc
-    while Time.now.utc < start + timeout
-      block_value = yield
-      return block_value unless block_value == :re_poll
-      sleep wait
-    end
-    raise TimeoutError, "Polling timed out paitently"
-  end
-
-  # Tries until success
-  # Re-runs when the block returns `:retry`
-  #
-  # wait      - The time delay in seconds between attempts (default is 1 second)
+  # wait      - The time delay in seconds between polls (default is 1 second)
   #           - When given the argument `:exponentially` the action will be retried with exponetial backoff
+  # timeout   - The maximum number of seconds the poller will run (default is 15 seconds)
   # attempts  - The maximum number of attempts the action will be performed (default is 15)
-  # yield     - A block that will execute, and if `:retry` is returned it will re-run the action
-  #           - re-run the action until success or the max number of attempts is reached
-  # raise     - Raises an Octopoller::TooManyTriesError if the max number of attempts is reached
+  # yield     - A block that will execute, and if `:re_poll` is returned it will re-run
+  #           - Re-runs until success or the timeout is reached
+  # raise     - Raises an Octopoller::TimeoutError if the timeout is reached
   #
   # rubocop:disable MethodLength
   # rubocop:disable CyclomaticComplexity
   # rubocop:disable PerceivedComplexity
-  def try(wait: 1.second, attempts: 15)
+  def poll(wait: 1.second, timeout: nil, retries: nil)
+    Octopoller.validate_arguments(wait, timeout, retries)
     exponential_backoff = wait == :exponentially
-    raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
-    raise ArgumentError, "Cannot try something a negative number of attempts" if attempts.negative?
-    raise ArgumentError, "Cannot try something zero attempts" if attempts.zero?
 
     wait = 0.5.seconds if exponential_backoff
-    attempts.times do
-      block_value = yield
-      return block_value unless block_value == :retry
-      sleep wait
-      wait *= 2 if exponential_backoff
+    if timeout
+      start = Time.now.utc
+      while Time.now.utc < start + timeout
+        block_value = yield
+        return block_value unless block_value == :re_poll
+        sleep wait
+        wait *= 2 if exponential_backoff
+      end
+      raise TimeoutError, "Polling timed out paitently"
+    else
+      (retries + 1).times do
+        block_value = yield
+        return block_value unless block_value == :re_poll
+        sleep wait
+        wait *= 2 if exponential_backoff
+      end
+      raise TooManyAttemptsError, "Polled maximum number of attempts"
     end
-    raise TooManyAttemptsError, "Tried maximum number of attempts"
   end
   # rubocop:enable MethodLength
   # rubocop:enable CyclomaticComplexity
   # rubocop:enable PerceivedComplexity
 
+  def self.validate_arguments(wait, timeout, retries)
+    if (timeout.nil? && retries.nil?) || (timeout && retries)
+      raise ArgumentError, "Must pass an argument to either `timeout` or `retries`"
+    end
+    exponential_backoff = wait == :exponentially
+    raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
+    if timeout
+      raise ArgumentError, "Timed out without even being able to try" if timeout.negative?
+    end
+    if retries
+      raise ArgumentError, "Cannot retry something a negative number of times" if retries.negative?
+    end
+  end
+
   module_function :poll
-  module_function :try
 end

--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -18,6 +18,7 @@ module Octopoller
   # rubocop:disable MethodLength
   # rubocop:disable CyclomaticComplexity
   # rubocop:disable PerceivedComplexity
+  # rubocop:disable AbcSize
   def poll(wait: 1.second, timeout: nil, retries: nil)
     Octopoller.validate_arguments(wait, timeout, retries)
     exponential_backoff = wait == :exponentially
@@ -45,20 +46,21 @@ module Octopoller
   # rubocop:enable MethodLength
   # rubocop:enable CyclomaticComplexity
   # rubocop:enable PerceivedComplexity
+  # rubocop:enable AbcSize
 
+  # rubocop:disable CyclomaticComplexity
+  # rubocop:disable PerceivedComplexity
   def self.validate_arguments(wait, timeout, retries)
     if (timeout.nil? && retries.nil?) || (timeout && retries)
       raise ArgumentError, "Must pass an argument to either `timeout` or `retries`"
     end
     exponential_backoff = wait == :exponentially
     raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
-    if timeout
-      raise ArgumentError, "Timed out without even being able to try" if timeout.negative?
-    end
-    if retries
-      raise ArgumentError, "Cannot retry something a negative number of times" if retries.negative?
-    end
+    raise ArgumentError, "Timed out without even being able to try" if timeout && timeout.negative?
+    raise ArgumentError, "Cannot retry something a negative number of times" if retries && retries.negative?
   end
+  # rubocop:enable CyclomaticComplexity
+  # rubocop:enable PerceivedComplexity
 
   module_function :poll
 end

--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -56,8 +56,8 @@ module Octopoller
     end
     exponential_backoff = wait == :exponentially
     raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
-    raise ArgumentError, "Timed out without even being able to try" if timeout && timeout.negative?
-    raise ArgumentError, "Cannot retry something a negative number of times" if retries && retries.negative?
+    raise ArgumentError, "Timed out without even being able to try" if timeout&.negative?
+    raise ArgumentError, "Cannot retry something a negative number of times" if retries&.negative?
   end
   # rubocop:enable CyclomaticComplexity
   # rubocop:enable PerceivedComplexity

--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -21,7 +21,7 @@ module Octopoller
   # rubocop:disable AbcSize
   def poll(wait: 1.second, timeout: nil, retries: nil)
     Octopoller.validate_arguments(wait, timeout, retries)
-    exponential_backoff = wait == :exponentially
+    exponential_backoff = (wait == :exponentially)
 
     wait = 0.5.seconds if exponential_backoff
     if timeout

--- a/spec/lib/octopoller_spec.rb
+++ b/spec/lib/octopoller_spec.rb
@@ -3,47 +3,128 @@
 require "rails_helper"
 
 RSpec.describe Octopoller do
-  it "does not accept negative wait time" do
-    expect { Octopoller.poll(wait: -(1.second)) {} }
-      .to raise_error(ArgumentError, "Cannot poll backwards in time")
-  end
+  describe "poll" do
+    it "does not accept negative wait time" do
+      expect { Octopoller.poll(wait: -(1.second)) {} }
+        .to raise_error(ArgumentError, "Cannot wait backwards in time")
+    end
 
-  it "does not accept negative timeout" do
-    expect { Octopoller.poll(timeout: -(1.second)) {} }
-      .to raise_error(ArgumentError, "Timed out without even being able to try")
-  end
+    it "does not accept negative timeout" do
+      expect { Octopoller.poll(timeout: -(1.second)) {} }
+        .to raise_error(ArgumentError, "Timed out without even being able to try")
+    end
 
-  it "polls until timeout" do
-    expect do
-      Octopoller.poll(wait: 0.1.seconds, timeout: 0.5.seconds) do
-        :re_poll
+    it "polls until timeout" do
+      expect do
+        Octopoller.poll(wait: 0.01.seconds, timeout: 0.05.seconds) do
+          :re_poll
+        end
+      end.to raise_error(Octopoller::TimeoutError, "Polling timed out paitently")
+    end
+
+    it "exits on successful return" do
+      result = Octopoller.poll { "Success!" }
+      expect(result).to eq("Success!")
+    end
+
+    it "polls until successful return" do
+      polled = false
+      result = Octopoller.poll(wait: 0.01.seconds) do
+        if polled
+          "Success!"
+        else
+          polled = true
+          :re_poll
+        end
       end
-    end.to raise_error(Octopoller::TimeoutError, "Polling timed out paitently")
+      expect(result).to eq("Success!")
+    end
+
+    it "doesn't swallow a raised error" do
+      expect do
+        Octopoller.poll(wait: 0.01.seconds) do
+          raise StandardError, "An error occuered"
+        end
+      end.to raise_error(StandardError, "An error occuered")
+    end
   end
 
-  it "exits on successful return" do
-    result = Octopoller.poll { "Success!" }
-    expect(result).to eq("Success!")
-  end
+  describe "try" do
+    it "does not accept negative wait time" do
+      expect { Octopoller.try(wait: -(1.second)) {} }
+        .to raise_error(ArgumentError, "Cannot wait backwards in time")
+    end
 
-  it "polls until successful return" do
-    polled = false
-    result = Octopoller.poll(wait: 0.1.seconds) do
-      if polled
-        "Success!"
-      else
-        polled = true
-        :re_poll
+    it "does not accept negative attempts" do
+      expect { Octopoller.try(attempts: -1) {} }
+        .to raise_error(ArgumentError, "Cannot try something a negative number of attempts")
+    end
+
+    it "does not accept negative attempts" do
+      expect { Octopoller.try(attempts: 0) {} }
+        .to raise_error(ArgumentError, "Cannot try something zero attempts")
+    end
+
+    it "try until max attempts reached" do
+      expect do
+        Octopoller.try(wait: 0.01.seconds, attempts: 2) do
+          :retry
+        end
+      end.to raise_error(Octopoller::TooManyAttemptsError, "Tried maximum number of attempts")
+    end
+
+    it "tries exactly the number of attempts" do
+      attempts = 0
+      expect do
+        Octopoller.try(wait: 0.01.seconds, attempts: 4) do
+          attempts += 1
+          :retry
+        end
+      end.to raise_error(Octopoller::TooManyAttemptsError, "Tried maximum number of attempts")
+      expect(attempts).to eq(4)
+    end
+
+    describe "tries with expoential back off" do
+      before(:all) do
+        start = Time.now.utc
+        @times = []
+        Octopoller.try(wait: :exponentially, attempts: 3) do
+          @times << Time.now.utc
+          :retry if @times.count < 3
+        end
+        @times = @times.map { |time| time - start }
+      end
+
+      it "attempts double in wait time" do
+        expect(@times[1]).to be > @times[0] * 2
+        expect(@times[2]).to be > @times[1] * 2
       end
     end
-    expect(result).to eq("Success!")
-  end
 
-  it "doesn't swallow a raised error" do
-    expect do
-      Octopoller.poll(wait: 0.1.seconds) do
-        raise StandardError, "An error occuered"
+    it "exits on successful return" do
+      result = Octopoller.try { "Success!" }
+      expect(result).to eq("Success!")
+    end
+
+    it "try until successful return" do
+      tried = false
+      result = Octopoller.try(wait: 0.01.seconds) do
+        if tried
+          "Success!"
+        else
+          tried = true
+          :retry
+        end
       end
-    end.to raise_error(StandardError, "An error occuered")
+      expect(result).to eq("Success!")
+    end
+
+    it "doesn't swallow a raised error" do
+      expect do
+        Octopoller.try(wait: 0.01.seconds) do
+          raise StandardError, "An error occuered"
+        end
+      end.to raise_error(StandardError, "An error occuered")
+    end
   end
 end

--- a/spec/lib/octopoller_spec.rb
+++ b/spec/lib/octopoller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Octopoller do
     end
 
     it "accepts 0 retries" do
-      expect { Octopoller.poll(wait: 0.01.seconds, retries: 0) { } }.to_not raise_error(ArgumentError)
+      expect { Octopoller.poll(wait: 0.01.seconds, retries: 0) {} }.to_not raise_error(ArgumentError)
     end
 
     it "poll until max retries reached" do

--- a/spec/lib/octopoller_spec.rb
+++ b/spec/lib/octopoller_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Octopoller do
-  describe "poll" do
+  describe "poll with timeout" do
     it "does not accept negative wait time" do
-      expect { Octopoller.poll(wait: -(1.second)) {} }
+      expect { Octopoller.poll(wait: -(1.second), timeout: 1.second) {} }
         .to raise_error(ArgumentError, "Cannot wait backwards in time")
     end
 
@@ -23,13 +23,13 @@ RSpec.describe Octopoller do
     end
 
     it "exits on successful return" do
-      result = Octopoller.poll { "Success!" }
+      result = Octopoller.poll(timeout: 1.second) { "Success!" }
       expect(result).to eq("Success!")
     end
 
     it "polls until successful return" do
       polled = false
-      result = Octopoller.poll(wait: 0.01.seconds) do
+      result = Octopoller.poll(wait: 0.01.seconds, timeout: 1.second) do
         if polled
           "Success!"
         else
@@ -42,45 +42,44 @@ RSpec.describe Octopoller do
 
     it "doesn't swallow a raised error" do
       expect do
-        Octopoller.poll(wait: 0.01.seconds) do
+        Octopoller.poll(wait: 0.01.seconds, timeout: 0.01) do
           raise StandardError, "An error occuered"
         end
       end.to raise_error(StandardError, "An error occuered")
     end
   end
 
-  describe "try" do
+  describe "poll with retries" do
     it "does not accept negative wait time" do
-      expect { Octopoller.try(wait: -(1.second)) {} }
+      expect { Octopoller.poll(wait: -(1.second), retries: 1) {} }
         .to raise_error(ArgumentError, "Cannot wait backwards in time")
     end
 
-    it "does not accept negative attempts" do
-      expect { Octopoller.try(attempts: -1) {} }
-        .to raise_error(ArgumentError, "Cannot try something a negative number of attempts")
+    it "does not accept negative retries" do
+      expect { Octopoller.poll(retries: -1) {} }
+        .to raise_error(ArgumentError, "Cannot retry something a negative number of times")
     end
 
-    it "does not accept negative attempts" do
-      expect { Octopoller.try(attempts: 0) {} }
-        .to raise_error(ArgumentError, "Cannot try something zero attempts")
+    it "accepts 0 retries" do
+      expect { Octopoller.poll(wait: 0.01.seconds, retries: 0) { } }.to_not raise_error(ArgumentError)
     end
 
-    it "try until max attempts reached" do
+    it "poll until max retries reached" do
       expect do
-        Octopoller.try(wait: 0.01.seconds, attempts: 2) do
-          :retry
+        Octopoller.poll(wait: 0.01.seconds, retries: 2) do
+          :re_poll
         end
-      end.to raise_error(Octopoller::TooManyAttemptsError, "Tried maximum number of attempts")
+      end.to raise_error(Octopoller::TooManyAttemptsError, "Polled maximum number of attempts")
     end
 
-    it "tries exactly the number of attempts" do
+    it "tries exactly the number of retries" do
       attempts = 0
       expect do
-        Octopoller.try(wait: 0.01.seconds, attempts: 4) do
+        Octopoller.poll(wait: 0.01.seconds, retries: 3) do
           attempts += 1
-          :retry
+          :re_poll
         end
-      end.to raise_error(Octopoller::TooManyAttemptsError, "Tried maximum number of attempts")
+      end.to raise_error(Octopoller::TooManyAttemptsError, "Polled maximum number of attempts")
       expect(attempts).to eq(4)
     end
 
@@ -88,32 +87,32 @@ RSpec.describe Octopoller do
       before(:all) do
         start = Time.now.utc
         @times = []
-        Octopoller.try(wait: :exponentially, attempts: 3) do
+        Octopoller.poll(wait: :exponentially, retries: 3) do
           @times << Time.now.utc
-          :retry if @times.count < 3
+          :re_poll if @times.count < 3
         end
         @times = @times.map { |time| time - start }
       end
 
-      it "attempts double in wait time" do
+      it "retries double in wait time" do
         expect(@times[1]).to be > @times[0] * 2
         expect(@times[2]).to be > @times[1] * 2
       end
     end
 
     it "exits on successful return" do
-      result = Octopoller.try { "Success!" }
+      result = Octopoller.poll(retries: 1) { "Success!" }
       expect(result).to eq("Success!")
     end
 
     it "try until successful return" do
       tried = false
-      result = Octopoller.try(wait: 0.01.seconds) do
+      result = Octopoller.poll(wait: 0.01.seconds, retries: 1) do
         if tried
           "Success!"
         else
           tried = true
-          :retry
+          :re_poll
         end
       end
       expect(result).to eq("Success!")
@@ -121,7 +120,7 @@ RSpec.describe Octopoller do
 
     it "doesn't swallow a raised error" do
       expect do
-        Octopoller.try(wait: 0.01.seconds) do
+        Octopoller.poll(wait: 0.01.seconds, retries: 0) do
           raise StandardError, "An error occuered"
         end
       end.to raise_error(StandardError, "An error occuered")


### PR DESCRIPTION
## What
@d12 [said](https://github.com/education/classroom/pull/1400#discussion_r203068588) that it would be nice to have a a function that attempts a action given a # of attempts. This PR proposes a new Octopoller function `try`.

It's API is very similar to the `poll` API:
```ruby
Octopoller.try(wait: 1.second, attempts: 2) do
  result = put_in_usb_stick()
  :retry if result.success?
end
```

There is also an exponential backoff retry:
```ruby
start = Time.now
Octopoller.try(wait: :exponentially) do
  puts (Time.now - start).seconds
end

# => 0 seconds
# => 0.5 seconds
# => 1 second
# => 2 seconds
# => 4 seconds
# ....
# Tried maximum number of attempts (Octopoller::TooManyAttemptsError)
```

What are your thoughts and ideas about the API? Can it be improved? Is this what you hoped it would look like?
