### PR TITLE
Use new current_invitation_status

### DIFF
--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -109,7 +109,7 @@ class AssignmentInvitationsController < ApplicationController
 
   def check_user_not_previous_acceptee
     return if current_submission.nil?
-    return unless current_invitation&.completed?
+    return unless current_invitation_status.completed?
     redirect_to success_assignment_invitation_path
   end
 


### PR DESCRIPTION
Looks like there was case where it was using the `status` on `AssignmentInvitation` which must have been a bad patch from before #1425 