### PR TITLE
Don't hit the cache on polling progress

### DIFF
--- a/app/models/github_repository/import_dependency.rb
+++ b/app/models/github_repository/import_dependency.rb
@@ -20,7 +20,8 @@ class GitHubRepository
 
   def import_progress(**options)
     GitHub::Errors.with_error_handling do
-      options[:accept] = "application/vnd.github.barred-rock-preview"
+      options[:accept] = Octokit::Preview::PREVIEW_TYPES[:source_imports]
+      options[:headers] = GitHub::APIHeaders.no_cache_no_store
       @client.source_import_progress(full_name, options)
     end
   end


### PR DESCRIPTION
## What
Possibly why there is a discrepancy between the time of import completion and when the UI presents completion is that the `client.source_import_progress` is hitting the cache and thus is not necessarily up to date.

This PR proposes that we include the header in our import progress request: 
```ruby
{ "Cache-Control" => "no-cache, no-store" }
``` 

