### PR TITLE
Render ActionCable errors

### DIFF
--- a/app/assets/javascripts/setupv2.js
+++ b/app/assets/javascripts/setupv2.js
@@ -1,6 +1,9 @@
 (function() {
   var POLL_INTERVAL = 1000;
   var display_progress,
+    flash_error,
+    flash_progress,
+    flash_text,
     get_status,
     hide_border_and_background,
     hide_indicator_image,
@@ -133,6 +136,27 @@
         setTimeout(show_success, 500);
         break;
     }
+    flash_progress(progress);
+  };
+
+  flash_progress = function(progress) {
+    if (progress.error) {
+      flash_error(progress.error);
+    } else if (progress.text) {
+      flash_text(progress.text);
+    } else {
+      $("#flash-messages").empty();
+    }
+  };
+
+  flash_error = function(error) {
+    $("#flash-messages")
+      .html("<div class='flash-application container-lg'><div class='flash flash-error'>" + error + "</div></div>");
+  };
+
+  flash_text = function(text) {
+    $("#flash-messages")
+      .html("<div class='flash-application container-lg'><div class='flash flash-success'>" + text + "</div></div>");
   };
 
   success_path = function () {

--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -72,7 +72,7 @@ class AssignmentRepo
       invite_status.errored_creating_repo!
       ActionCable.server.broadcast(
         RepositoryCreationStatusChannel.channel(user_id: user.id),
-        text: err,
+        error: err,
         status: invite_status.status
       )
       logger.warn(err.message)

--- a/app/jobs/assignment_repo/porter_status_job.rb
+++ b/app/jobs/assignment_repo/porter_status_job.rb
@@ -36,7 +36,7 @@ class AssignmentRepo
           invite_status&.errored_importing_starter_code!
           ActionCable.server.broadcast(
             RepositoryCreationStatusChannel.channel(user_id: user.id),
-            text: result,
+            error: result,
             status: invite_status&.status
           )
           logger.warn result.to_s

--- a/app/views/assignment_invitations/setupv2.html.erb
+++ b/app/views/assignment_invitations/setupv2.html.erb
@@ -1,5 +1,7 @@
 <%= render 'organizations/organization_invitation_banner' %>
 
+<div id="flash-messages" class="flash-messages"></div>
+
 <div class="site-content">
   <div class="site-content-cap">
     <h2 class="site-content-heading">

--- a/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           status: "creating_repo"
         )
         .with(
-          text: AssignmentRepo::Creator::REPOSITORY_CREATION_FAILED,
+          error: AssignmentRepo::Creator::REPOSITORY_CREATION_FAILED,
           status: "errored_creating_repo"
         )
     end
@@ -188,7 +188,7 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             status: "creating_repo"
           )
           .with(
-            text: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
+            error: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
             status: "errored_creating_repo"
           )
       end
@@ -227,7 +227,7 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             status: "creating_repo"
           )
           .with(
-            text: AssignmentRepo::Creator::REPOSITORY_COLLABORATOR_ADDITION_FAILED,
+            error: AssignmentRepo::Creator::REPOSITORY_COLLABORATOR_ADDITION_FAILED,
             status: "errored_creating_repo"
           )
       end
@@ -264,7 +264,7 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             status: "creating_repo"
           )
           .with(
-            text: AssignmentRepo::Creator::DEFAULT_ERROR_MESSAGE,
+            error: AssignmentRepo::Creator::DEFAULT_ERROR_MESSAGE,
             status: "errored_creating_repo"
           )
       end

--- a/spec/jobs/assignment_repo/porter_status_job_spec.rb
+++ b/spec/jobs/assignment_repo/porter_status_job_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe AssignmentRepo::PorterStatusJob, type: :job do
         expect { subject.perform_now(@assignment_repo, student) }
           .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
           .with(
-            text: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
+            error: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
             status: "errored_importing_starter_code"
           )
       end
@@ -238,7 +238,7 @@ RSpec.describe AssignmentRepo::PorterStatusJob, type: :job do
         expect { subject.perform_now(@assignment_repo, student) }
           .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
           .with(
-            text: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
+            error: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
             status: "errored_importing_starter_code"
           )
       end


### PR DESCRIPTION
## What
This PR adds a JS function to take `ActionCable` messages and render their `error` and `text` fields.
This allows us to funnel up errors to the user (where we previously couldn't).

## What does it look like?
![error-flashes](https://user-images.githubusercontent.com/11095731/43414707-6a7b36e6-93e8-11e8-8205-cd40c4b80927.gif)

closes #1443