### PR TITLE
Better progress indication

### DIFF
--- a/app/assets/javascripts/setupv2.js
+++ b/app/assets/javascripts/setupv2.js
@@ -1,6 +1,7 @@
 (function() {
   var POLL_INTERVAL = 1000;
   var display_progress,
+    display_text,
     flash_error,
     flash_progress,
     flash_text,
@@ -16,6 +17,9 @@
     is_hidden,
     progress_path,
     ready,
+    set_progress,
+    set_progress_green,
+    set_progress_red,
     setup_retry_button,
     setup_cable,
     show_retry_button,
@@ -53,51 +57,56 @@
     }
   };
 
-  hide_indicator_image = function(step_indicator) {
-    var status = step_indicator.find(".status");
-    status.find(".complete-indicator").hide();
-    status.find(".failure-indicator").hide();
-    status.find(".spinner").hide();
+  set_progress_green = function(step_indicator) {
+    var progress = step_indicator.find(".progress");
+    if (progress.hasClass("bg-red")) {
+      progress.removeClass("bg-red");
+    }
+    if (!progress.hasClass("bg-green")) {
+      progress.addClass("bg-green");
+    }
   };
 
-  get_status = function(step_indicator) {
-    var status = step_indicator.find(".status");
-    if (is_hidden(status)) {
-      status.removeClass("d-none");
+  set_progress_red = function(step_indicator) {
+    var progress = step_indicator.find(".progress");
+    if (progress.hasClass("bg-green")) {
+      progress.removeClass("bg-green");
     }
-    return status;
+    if (!progress.hasClass("bg-red")) {
+      progress.addClass("bg-red");
+    }
+  }
+
+  set_progress = function(step_indicator, percent) {
+    step_indicator.find(".progress").width(percent + "%");
   };
 
   indicate_waiting = function(step_indicator) {
     hide_border_and_background(step_indicator);
-    hide_indicator_image(step_indicator);
+    set_progress_green(step_indicator);
   };
 
   indicate_completion = function(step_indicator) {
     hide_border_and_background(step_indicator);
-    hide_indicator_image(step_indicator);
     step_indicator.addClass("border-green bg-green-light");
-    var status = get_status(step_indicator);
-
-    status.find(".complete-indicator").show();
+    set_progress_green(step_indicator);
   };
 
   indicate_failure = function(step_indicator) {
     hide_border_and_background(step_indicator);
-    hide_indicator_image(step_indicator);
     step_indicator.addClass("border-red bg-red-light");
-    var status = get_status(step_indicator);
-
-    status.find(".failure-indicator").show();
+    set_progress_red(step_indicator);
   };
 
   indicate_in_progress = function(step_indicator) {
     hide_border_and_background(step_indicator);
-    hide_indicator_image(step_indicator);
     step_indicator.addClass("border-green bg-white");
-    var status = get_status(step_indicator);
+    set_progress_green(step_indicator);
+  };
 
-    status.find(".spinner").show();
+  display_text = function(step_indicator, text) {
+    var paragraph = step_indicator.find(".alt-text-small");
+    paragraph.text(text);
   };
 
   display_progress = function(progress) {
@@ -107,31 +116,51 @@
       case "waiting":
         indicate_waiting(create_repo_progress_indicator);
         indicate_waiting(import_repo_progress_indicator);
+        set_progress(create_repo_progress_indicator, 0);
+        set_progress(import_repo_progress_indicator, 0);
+        display_text(create_repo_progress_indicator, "Waiting...");
+        display_text(import_repo_progress_indicator, "Waiting...");
         hide_retry_button();
         break;
       case "creating_repo":
         indicate_in_progress(create_repo_progress_indicator);
         indicate_waiting(import_repo_progress_indicator);
+        set_progress(create_repo_progress_indicator, 50);
+        set_progress(import_repo_progress_indicator, 0);
+        display_text(create_repo_progress_indicator, "Creating GitHub repository...");
+        display_text(import_repo_progress_indicator, "Waiting...");
         hide_retry_button();
         break;
       case "importing_starter_code":
         indicate_completion(create_repo_progress_indicator);
         indicate_in_progress(import_repo_progress_indicator);
+        set_progress(create_repo_progress_indicator, 100);
+        set_progress(import_repo_progress_indicator, progress.percent);
+        display_text(create_repo_progress_indicator, "Done");
+        display_text(import_repo_progress_indicator, progress.status_text);
         hide_retry_button();
         break;
       case "errored_creating_repo":
         indicate_failure(create_repo_progress_indicator);
         indicate_failure(import_repo_progress_indicator);
+        display_text(create_repo_progress_indicator, "Errored");
+        display_text(import_repo_progress_indicator, "Errored");
         show_retry_button();
         break;
       case "errored_importing_starter_code":
         indicate_completion(create_repo_progress_indicator);
         indicate_failure(import_repo_progress_indicator);
+        display_text(create_repo_progress_indicator, "Done");
+        display_text(import_repo_progress_indicator, "Errored");
         show_retry_button();
         break;
       case "completed":
         indicate_completion(create_repo_progress_indicator);
         indicate_completion(import_repo_progress_indicator);
+        set_progress(create_repo_progress_indicator, 100);
+        set_progress(import_repo_progress_indicator, 100);
+        display_text(create_repo_progress_indicator, "Done");
+        display_text(import_repo_progress_indicator, "Done");
         hide_retry_button();
         setTimeout(show_success, 500);
         break;

--- a/app/assets/javascripts/setupv2.js
+++ b/app/assets/javascripts/setupv2.js
@@ -75,7 +75,7 @@
     if (!progress.hasClass("bg-red")) {
       progress.addClass("bg-red");
     }
-  }
+  };
 
   set_progress = function(step_indicator, percent) {
     step_indicator.find(".progress").width(percent + "%");

--- a/app/assets/stylesheets/components/progress-bar.scss
+++ b/app/assets/stylesheets/components/progress-bar.scss
@@ -5,3 +5,18 @@ html.turbolinks-progress-bar::before {
   box-shadow: 0 0 10px rgba(#77b6ff, 0.7) !important;
 }
 // scss-lint:enable ImportantRule
+
+// A green progress bar on a grey background.
+.progress-bar {
+  display: block;
+  height: 5px;
+  overflow: hidden; // Crop the progress bar within for rounded corners
+  background-color: lighten($gray-200, 3%);
+  border-radius: 3px;
+
+  .progress {
+    display: block;
+    height: 100%;
+    background-color: darken($green-400, 5%);
+  }
+}

--- a/app/jobs/assignment_repo/porter_status_job.rb
+++ b/app/jobs/assignment_repo/porter_status_job.rb
@@ -29,7 +29,7 @@ class AssignmentRepo
                   RepositoryCreationStatusChannel.channel(user_id: user.id),
                   status: invite_status.status,
                   text: AssignmentRepo::Creator::IMPORT_ONGOING,
-                  percent: ((REPO_IMPORT_STEPS.index(progress[:status]) + 1) * 100) / (REPO_IMPORT_STEPS.count),
+                  percent: ((REPO_IMPORT_STEPS.index(progress[:status]) + 1) * 100) / REPO_IMPORT_STEPS.count,
                   status_text: progress[:status_text]
                 )
                 last_progress = progress[:status]

--- a/app/jobs/assignment_repo/porter_status_job.rb
+++ b/app/jobs/assignment_repo/porter_status_job.rb
@@ -2,6 +2,7 @@
 
 class AssignmentRepo
   class PorterStatusJob < ApplicationJob
+    REPO_IMPORT_STEPS = GitHubRepository::IMPORT_ONGOING + [GitHubRepository::IMPORT_COMPLETE]
     queue_as :porter_status
 
     # rubocop:disable MethodLength
@@ -13,16 +14,26 @@ class AssignmentRepo
       invite_status = assignment_repo.assignment.invitation.status(user)
 
       begin
+        last_progress = nil
         result = Octopoller.poll(timeout: 30.seconds) do
           begin
-            progress = github_repository.import_progress[:status]
-            case progress
+            progress = github_repository.import_progress
+            case progress[:status]
             when GitHubRepository::IMPORT_COMPLETE
               Creator::REPOSITORY_CREATION_COMPLETE
             when *GitHubRepository::IMPORT_ERRORS
               Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED
             when *GitHubRepository::IMPORT_ONGOING
-              logger.info AssignmentRepo::Creator::IMPORT_ONGOING
+              if last_progress != progress[:status]
+                ActionCable.server.broadcast(
+                  RepositoryCreationStatusChannel.channel(user_id: user.id),
+                  status: invite_status.status,
+                  text: AssignmentRepo::Creator::IMPORT_ONGOING,
+                  percent: ((REPO_IMPORT_STEPS.index(progress[:status]) + 1) * 100) / (REPO_IMPORT_STEPS.count),
+                  status_text: progress[:status_text]
+                )
+                last_progress = progress[:status]
+              end
               :re_poll
             end
           rescue GitHub::Error => error
@@ -33,21 +44,22 @@ class AssignmentRepo
 
         case result
         when Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED
-          invite_status&.errored_importing_starter_code!
+          invite_status.errored_importing_starter_code!
           ActionCable.server.broadcast(
             RepositoryCreationStatusChannel.channel(user_id: user.id),
             error: result,
-            status: invite_status&.status
+            status: invite_status.status
           )
           logger.warn result.to_s
           GitHubClassroom.statsd.increment("v2_exercise_repo.import.fail")
           assignment_repo.destroy
         when Creator::REPOSITORY_CREATION_COMPLETE
-          invite_status&.completed!
+          invite_status.completed!
           ActionCable.server.broadcast(
             RepositoryCreationStatusChannel.channel(user_id: user.id),
             text: result,
-            status: invite_status&.status
+            status: invite_status.status,
+            percent: 100
           )
           GitHubClassroom.statsd.increment("v2_exercise_repo.import.success")
         end

--- a/app/views/assignment_invitations/setupv2.html.erb
+++ b/app/views/assignment_invitations/setupv2.html.erb
@@ -11,22 +11,32 @@
 </div>
 
 <div class="site-content-body ">
-  <div class="d-flex flex-justify-between text-center setupv2">
-    <div id="create-repo-progress" class="col-6 border rounded-1 mr-6 p-4">
-      <span class='status d-none'>
-        <%= octicon("check", class: 'text-green complete-indicator', height: 30) %>
-        <%= octicon("x", class: 'text-red failure-indicator', height: 30) %>
-        <%= image_tag 'octocat-spinner-64.gif', width: 30, height: 30, class: 'spinner' %>
-      </span>
-      <p class="v-align-baseline f4 mt-4">1. Creating repository</p>
+  <div class="d-flex flex-justify-between setupv2">
+    <div id="create-repo-progress" class="col-6 border rounded-1 Box box-shadow mr-6">
+      <div class="Box-row">
+        <h4 class="mb-0">Creating repository</h4>
+      </div>
+      <div class="Box-row">
+        <p class="mb-0 alt-text-small text-gray">Waiting</p>
+      </div>
+      <div class="p-3">
+        <span class="progress-bar v-align-middle">
+          <span class="progress bg-green" style="width: 0%"></span>
+        </span>
+      </div>
     </div>
-    <div id="import-repo-progress" class="col-6 border rounded-1 p-4">
-      <span class='status d-none'>
-        <%= octicon("check", class: 'text-green complete-indicator', height: 30) %>
-        <%= octicon("x", class: 'text-red failure-indicator', height: 30) %>
-        <%= image_tag 'octocat-spinner-64.gif', width: 30, height: 30, class: 'spinner' %>
-      </span>
-      <p class="v-align-baseline f4 mt-4">2. Importing starter code</p>
+    <div id="import-repo-progress" class="col-6 border rounded-1 Box box-shadow">
+      <div class="Box-row">
+        <h4 class="mb-0">Importing starter code</h4>
+      </div>
+      <div class="Box-row">
+        <p class="mb-0 alt-text-small text-gray">Waiting</p>
+      </div>
+      <div class="p-3">
+        <span class="progress-bar v-align-middle">
+          <span class="progress bg-green" style="width: 0%"></span>
+        </span>
+      </div>
     </div>
   </div>
   <center>

--- a/spec/jobs/assignment_repo/porter_status_job_spec.rb
+++ b/spec/jobs/assignment_repo/porter_status_job_spec.rb
@@ -87,8 +87,15 @@ RSpec.describe AssignmentRepo::PorterStatusJob, type: :job do
         expect { subject.perform_now(@assignment_repo, student) }
           .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
           .with(
+            text: AssignmentRepo::Creator::IMPORT_ONGOING,
+            status: "importing_starter_code",
+            percent: 40,
+            status_text: "Importing..."
+          )
+          .with(
             text: AssignmentRepo::Creator::REPOSITORY_CREATION_COMPLETE,
-            status: "completed"
+            status: "completed",
+            percent: 100
           )
       end
 
@@ -138,6 +145,12 @@ RSpec.describe AssignmentRepo::PorterStatusJob, type: :job do
           )
         expect { subject.perform_now(@assignment_repo, student) }
           .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+          .with(
+            text: AssignmentRepo::Creator::IMPORT_ONGOING,
+            status: "importing_starter_code",
+            percent: 40,
+            status_text: "Importing..."
+          )
           .with(
             error: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
             status: "errored_importing_starter_code"
@@ -237,6 +250,12 @@ RSpec.describe AssignmentRepo::PorterStatusJob, type: :job do
           )
         expect { subject.perform_now(@assignment_repo, student) }
           .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+          .with(
+            text: AssignmentRepo::Creator::IMPORT_ONGOING,
+            status: "importing_starter_code",
+            percent: 40,
+            status_text: "Importing..."
+          )
           .with(
             error: AssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED,
             status: "errored_importing_starter_code"


### PR DESCRIPTION
## What
This PR introduces some UI improvements to the create/import flow.

## Whats new
* Progress bars instead of spinners
* PorterStatusJob broadcasts `status_text` and `percentage`
* Status text in the sub-line of each step


## What does this look like?
### Success

![new-flow-ui](https://user-images.githubusercontent.com/11095731/43429803-698cdc4e-941a-11e8-9f15-98c11a062c5c.gif)

### Failure
![new-flow-ui-error](https://user-images.githubusercontent.com/11095731/43430165-6e28e8cc-941c-11e8-8899-fc9e57305099.gif)

### Retry
![new-flow-ui-error-retry](https://user-images.githubusercontent.com/11095731/43430171-75ca5052-941c-11e8-9bd8-e81562e00936.gif)



--- 
Closes https://github.com/education/classroom/issues/1420
