### PR TITLE
Group invite status migration

### DIFF
--- a/app/models/group_invite_status.rb
+++ b/app/models/group_invite_status.rb
@@ -1,0 +1,3 @@
+class GroupInviteStatus < ApplicationRecord
+  belongs_to :group
+end

--- a/db/migrate/20180802210833_create_group_invite_statuses.rb
+++ b/db/migrate/20180802210833_create_group_invite_statuses.rb
@@ -1,0 +1,10 @@
+class CreateGroupInviteStatuses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :group_invite_statuses do |t|
+      t.integer :status
+      t.belongs_to :group, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180723230724) do
+ActiveRecord::Schema.define(version: 20180802210833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,14 @@ ActiveRecord::Schema.define(version: 20180723230724) do
     t.index ["slug"], name: "index_group_assignments_on_slug"
   end
 
+  create_table "group_invite_statuses", force: :cascade do |t|
+    t.integer "status"
+    t.bigint "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_invite_statuses_on_group_id"
+  end
+
   create_table "groupings", id: :serial, force: :cascade do |t|
     t.string "title", null: false
     t.integer "organization_id"
@@ -213,6 +221,7 @@ ActiveRecord::Schema.define(version: 20180723230724) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "group_invite_statuses", "groups"
   add_foreign_key "invite_statuses", "assignment_invitations"
   add_foreign_key "invite_statuses", "users"
 end

--- a/spec/models/group_invite_status_spec.rb
+++ b/spec/models/group_invite_status_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupInviteStatus, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR proposes to create a new model's migration `group_invite_status`.

First part of:
> Track progress of repo setup with a 1:N:1 model of `Group`:`GroupInviteStatus`:`GroupInvitation`

In  #1452 
