### PR TITLE
Change multiline styles to indented

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,9 @@ Style/FileName:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented

--- a/app/controllers/api/group_assignments_controller.rb
+++ b/app/controllers/api/group_assignments_controller.rb
@@ -19,8 +19,8 @@ module API
 
     def set_assignment
       @group_assignment = @organization.group_assignments
-                                       .includes(:group_assignment_invitation)
-                                       .find_by!(slug: params[:id])
+        .includes(:group_assignment_invitation)
+        .find_by!(slug: params[:id])
     end
   end
 end

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -88,9 +88,9 @@ class AssignmentInvitationsController < ApplicationController
   # rubocop:disable MethodLength
   def ensure_submission_repository_exists
     github_repo_exists = current_submission &&
-                         current_submission
-                         .github_repository
-                         .present?(headers: GitHub::APIHeaders.no_cache_no_store)
+      current_submission
+        .github_repository
+        .present?(headers: GitHub::APIHeaders.no_cache_no_store)
     return if github_repo_exists
 
     current_submission&.destroy

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -32,8 +32,9 @@ class AssignmentsController < ApplicationController
     if @organization.roster
       @roster_entries = @organization.roster.roster_entries.page(params[:students_page]).order_for_view(@assignment)
 
-      @unlinked_user_repos = AssignmentRepo.where(assignment: @assignment, user: @unlinked_users)
-                                           .page(params[:unlinked_accounts_page])
+      @unlinked_user_repos = AssignmentRepo
+        .where(assignment: @assignment, user: @unlinked_users)
+        .page(params[:unlinked_accounts_page])
     else
       @assignment_repos = AssignmentRepo.where(assignment: @assignment).page(params[:page])
     end

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -140,8 +140,8 @@ class GroupAssignmentInvitationsController < ApplicationController
 
   def invitation
     @invitation ||= GroupAssignmentInvitation
-                    .includes(group_assignment: :group_assignment_repos)
-                    .find_by!(key: params[:id])
+      .includes(group_assignment: :group_assignment_repos)
+      .find_by!(key: params[:id])
   end
   helper_method :invitation
 
@@ -189,8 +189,8 @@ class GroupAssignmentInvitationsController < ApplicationController
   def ensure_github_repo_exists
     return not_found unless group_assignment_repo
     return if group_assignment_repo
-              .github_repository
-              .present?(headers: GitHub::APIHeaders.no_cache_no_store)
+        .github_repository
+        .present?(headers: GitHub::APIHeaders.no_cache_no_store)
 
     group = group_assignment_repo.group
 

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -31,12 +31,12 @@ class GroupAssignmentsController < ApplicationController
   def show
     pagination_key = @organization.roster ? :teams_page : :page
     @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment)
-                                                 .page(params[pagination_key])
+      .page(params[pagination_key])
 
     return unless @organization.roster
     @students_not_on_team = @organization.roster.roster_entries
-                                         .students_not_on_team(@group_assignment)
-                                         .page(params[:students_page])
+      .students_not_on_team(@group_assignment)
+      .page(params[:students_page])
   end
 
   def edit; end
@@ -111,9 +111,9 @@ class GroupAssignmentsController < ApplicationController
 
   def set_group_assignment
     @group_assignment = @organization
-                        .group_assignments
-                        .includes(:group_assignment_invitation)
-                        .find_by!(slug: params[:id])
+      .group_assignments
+      .includes(:group_assignment_invitation)
+      .find_by!(slug: params[:id])
   end
 
   def deadline_param

--- a/app/controllers/invitations_controller_methods.rb
+++ b/app/controllers/invitations_controller_methods.rb
@@ -37,8 +37,8 @@ module InvitationsControllerMethods
   # - The roster=ignore param is not set (we set this if the user chooses to "skip" joining a roster for now)
   def check_should_redirect_to_roster_page
     return if params[:roster] == "ignore" ||
-              organization.roster.blank? ||
-              user_on_roster?
+        organization.roster.blank? ||
+        user_on_roster?
 
     @roster = organization.roster
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,9 +41,9 @@ class OrganizationsController < Orgs::Controller
   def show
     # sort assignments by title
     @assignments = Kaminari
-                   .paginate_array(current_organization.all_assignments(with_invitations: true)
-                   .sort_by(&:title))
-                   .page(params[:page])
+      .paginate_array(current_organization.all_assignments(with_invitations: true)
+      .sort_by(&:title))
+      .page(params[:page])
   end
 
   def edit; end

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -15,8 +15,9 @@ module Orgs
     # rubocop:disable AbcSize
     def show
       @roster_entries = current_roster.roster_entries
-                                      .includes(:user).order(:identifier)
-                                      .page(params[:roster_entries_page])
+        .includes(:user)
+        .order(:identifier)
+        .page(params[:roster_entries_page])
 
       @current_unlinked_users = User.where(id: unlinked_user_ids).page(params[:unlinked_users_page])
 

--- a/app/controllers/stafftools/resources_controller.rb
+++ b/app/controllers/stafftools/resources_controller.rb
@@ -17,10 +17,10 @@ module Stafftools
     def set_resources
       return @resources = nil if params[:query].blank?
       @resources = StafftoolsIndex
-                   .query(match_phrase_prefix(params[:query]))
-                   .order(_type: :asc)
-                   .page(params[:page])
-                   .per(20)
+        .query(match_phrase_prefix(params[:query]))
+        .order(_type: :asc)
+        .page(params[:page])
+        .per(20)
     end
 
     def match_phrase_prefix(query)

--- a/spec/lib/github/search_spec.rb
+++ b/spec/lib/github/search_spec.rb
@@ -20,9 +20,9 @@ describe GitHub::Search do
 
       returned_repo_ids = returned_repos.map(&:id).to_set
       actual_repo_ids = user
-                        .github_client
-                        .search_repos("rails user:rails fork:true")[:items]
-                        .map(&:id).to_set
+        .github_client
+        .search_repos("rails user:rails fork:true")[:items]
+        .map(&:id).to_set
 
       expect(returned_repo_ids).to be_subset(actual_repo_ids)
     end

--- a/spec/support/repository_factory.rb
+++ b/spec/support/repository_factory.rb
@@ -147,7 +147,7 @@ class StubRepository
 
   def head_refs
     Dir.glob(repo_path + "/.git_/refs/**/*").reject { |f| File.directory?(f) }
-       .map { |f| f.split(".git_/").second }
+      .map { |f| f.split(".git_/").second }
   end
 
   def repo_path


### PR DESCRIPTION
## What
This PR proposes we switch our multiline rubocop styles from `aligned` to `indented`.
## Why
IMO this is a cleaner and easier to follow.

## What will the changes look like?
**`MultilineMethodCallIndentation`**
```diff
    @group_assignment = @organization
-                        .group_assignments
-                        .includes(:group_assignment_invitation)
-                        .find_by!(slug: params[:id])
+      .group_assignments
+      .includes(:group_assignment_invitation)
+      .find_by!(slug: params[:id])
```

**`MultilineOperationIndentation`**
```diff
    return if params[:roster] == "ignore" ||
-              organization.roster.blank? ||
-              user_on_roster?
+        organization.roster.blank? ||
+        user_on_roster?
```