### PR TITLE
Align function params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,8 +54,11 @@ Style/FileName:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
   # errors_dependency
   rescue_from StandardError, with: :send_to_statsd_and_reraise
   rescue_from GitHub::Error,
-              GitHub::Forbidden,
-              GitHub::NotFound,
-              NotAuthorized, with: :flash_and_redirect_back_with_message
+    GitHub::Forbidden,
+    GitHub::NotFound,
+    NotAuthorized, with: :flash_and_redirect_back_with_message
   rescue_from ActionController::RoutingError, ActiveRecord::RecordNotFound, with: :render_404
 
   rescue_from ActionController::InvalidAuthenticityToken do

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable ClassLength
 class GroupAssignmentsController < ApplicationController
   include OrganizationAuthorization
   include StarterCode
@@ -87,16 +88,27 @@ class GroupAssignmentsController < ApplicationController
     GroupAssignmentService.new(new_group_assignment_params, new_grouping_params).build_group_assignment
   end
 
+  # rubocop:disable MethodLength
   def new_group_assignment_params
     params
       .require(:group_assignment)
-      .permit(:title, :slug, :public_repo, :grouping_id, :max_members, :students_are_repo_admins,
-              :invitations_enabled)
-      .merge(creator: current_user,
-             organization: @organization,
-             starter_code_repo_id: starter_code_repo_id_param,
-             deadline: deadline_param)
+      .permit(
+        :title,
+        :slug,
+        :public_repo,
+        :grouping_id,
+        :max_members,
+        :students_are_repo_admins,
+        :invitations_enabled
+      )
+      .merge(
+        creator: current_user,
+        organization: @organization,
+        starter_code_repo_id: starter_code_repo_id_param,
+        deadline: deadline_param
+      )
   end
+  # rubocop:enable MethodLength
 
   def new_grouping_params
     params
@@ -130,11 +142,21 @@ class GroupAssignmentsController < ApplicationController
     end
   end
 
+  # rubocop:disable MethodLength
   def update_group_assignment_params
     params
       .require(:group_assignment)
-      .permit(:title, :slug, :public_repo, :max_members, :students_are_repo_admins, :deadline,
-              :invitations_enabled)
+      .permit(
+        :title,
+        :slug,
+        :public_repo,
+        :max_members,
+        :students_are_repo_admins,
+        :deadline,
+        :invitations_enabled
+      )
       .merge(starter_code_repo_id: starter_code_repo_id_param)
   end
+  # rubocop:enable MethodLength
 end
+# rubocop:enable ClassLength

--- a/app/controllers/invitations_controller_methods.rb
+++ b/app/controllers/invitations_controller_methods.rb
@@ -7,9 +7,9 @@ module InvitationsControllerMethods
     layout "layouts/invitations"
 
     helper_method :current_assignment,
-                  :current_invitation,
-                  :current_submission,
-                  :organization
+      :current_invitation,
+      :current_submission,
+      :organization
   end
 
   def accept

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -110,8 +110,10 @@ class OrganizationsController < Orgs::Controller
   end
 
   def github_organization_from_params
-    @github_organization_from_params ||= GitHubOrganization.new(current_user.github_client,
-                                                                params[:organization][:github_id].to_i)
+    @github_organization_from_params ||= GitHubOrganization.new(
+      current_user.github_client,
+      params[:organization][:github_id].to_i
+    )
   end
 
   def new_organization_params

--- a/app/models/concerns/github_repoable.rb
+++ b/app/models/concerns/github_repoable.rb
@@ -16,9 +16,11 @@ module GitHubRepoable
   #
   def create_github_repository
     repo_description = "#{repo_name} created by GitHub Classroom"
-    github_repository = github_organization.create_repository(repo_name,
-                                                              private: private?,
-                                                              description: repo_description)
+    github_repository = github_organization.create_repository(
+      repo_name,
+      private: private?,
+      description: repo_description
+    )
     self.github_repo_id = github_repository.id
   end
 

--- a/app/models/github_organization.rb
+++ b/app/models/github_organization.rb
@@ -44,10 +44,12 @@ class GitHubOrganization < GitHubResource
 
   def create_team(team_name)
     github_team = GitHub::Errors.with_error_handling do
-      @client.create_team(@id,
-                          description: "#{team_name} created by GitHub Classroom",
-                          name: team_name,
-                          permission: "push")
+      @client.create_team(
+        @id,
+        description: "#{team_name} created by GitHub Classroom",
+        name: team_name,
+        permission: "push"
+      )
     end
 
     GitHubTeam.new(@client, github_team.id)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,8 +10,9 @@ class Group < ApplicationRecord
 
   has_one :organization, -> { unscope(where: :deleted_at) }, through: :grouping
 
-  has_and_belongs_to_many :repo_accesses, before_add:    :add_member_to_github_team, unless: :new_record?,
-                                          before_remove: :remove_from_github_team
+  has_and_belongs_to_many :repo_accesses,
+    before_add: :add_member_to_github_team, unless: :new_record?,
+    before_remove: :remove_from_github_team
 
   validates :github_team_id, presence: true
   validates :github_team_id, uniqueness: true

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,7 @@
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :github,
-           Rails.application.secrets.github_client_id,
-           Rails.application.secrets.github_client_secret,
-           scope: "user:email,repo,delete_repo,admin:org,admin:org_hook"
+    Rails.application.secrets.github_client_id,
+    Rails.application.secrets.github_client_secret,
+    scope: "user:email,repo,delete_repo,admin:org,admin:org_hook"
 end

--- a/spec/controllers/group_assignment_invitations_controller_spec.rb
+++ b/spec/controllers/group_assignment_invitations_controller_spec.rb
@@ -162,8 +162,10 @@ RSpec.describe GroupAssignmentInvitationsController, type: :controller do
         end
 
         it "sends an event to statsd" do
-          expect(GitHubClassroom.statsd).to receive(:increment).with("exception.swallowed",
-                                                                     tags: [ApplicationController::NotAuthorized.to_s])
+          expect(GitHubClassroom.statsd).to receive(:increment).with(
+            "exception.swallowed",
+            tags: [ApplicationController::NotAuthorized.to_s]
+          )
           expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_invitation.fail")
 
           patch :accept_invitation, params: { id: invitation.key, group: { id: group.id } }

--- a/spec/jobs/repository_event_job_spec.rb
+++ b/spec/jobs/repository_event_job_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe RepositoryEventJob, type: :job do
     end
 
     it "deletes the matching AssignmentRepo" do
-      assignment_repo = create(:assignment_repo,
-                               assignment: create(:assignment, organization: organization),
-                               github_repo_id: payload.dig("repository", "id"))
+      assignment_repo = create(
+        :assignment_repo,
+        assignment: create(:assignment, organization: organization),
+        github_repo_id: payload.dig("repository", "id")
+      )
 
       RepositoryEventJob.perform_now(payload)
       expect { assignment_repo.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/models/github_organization_spec.rb
+++ b/spec/models/github_organization_spec.rb
@@ -103,8 +103,10 @@ describe GitHubOrganization do
 
     it "successfully removes the GitHub organization webhook" do
       @github_organization.remove_organization_webhook(@org_hook.id)
-      expect(WebMock).to have_requested(:delete,
-                                        github_url("/organizations/#{organization.github_id}/hooks/#{@org_hook.id}"))
+      expect(WebMock).to have_requested(
+        :delete,
+        github_url("/organizations/#{organization.github_id}/hooks/#{@org_hook.id}")
+      )
     end
   end
 

--- a/spec/models/group_assignment_invitation_spec.rb
+++ b/spec/models/group_assignment_invitation_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
     let(:organization)  { classroom_org     }
 
     let(:group_assignment) do
-      create(:group_assignment,
-             title: "JavaScript",
-             organization: organization,
-             public_repo: false)
+      create(
+        :group_assignment,
+        title: "JavaScript",
+        organization: organization,
+        public_repo: false
+      )
     end
 
     subject { create(:group_assignment_invitation, group_assignment: group_assignment) }

--- a/spec/models/group_assignment_repo_spec.rb
+++ b/spec/models/group_assignment_repo_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe GroupAssignmentRepo, type: :model do
     let(:group)        { Group.create(title: "Group 1", grouping: grouping) }
 
     let(:group_assignment) do
-      create(:group_assignment,
-             grouping: grouping,
-             title: "Learn JavaScript",
-             organization: organization,
-             public_repo: true,
-             starter_code_repo_id: 1_062_897)
+      create(
+        :group_assignment,
+        grouping: grouping,
+        title: "Learn JavaScript",
+        organization: organization,
+        public_repo: true,
+        starter_code_repo_id: 1_062_897
+      )
     end
 
     before(:each) do

--- a/spec/support/repository_factory.rb
+++ b/spec/support/repository_factory.rb
@@ -161,10 +161,12 @@ module RepositoryFactory
   end
 
   def create_github_branch(client, repo, branch)
-    client.create_contents(repo.full_name,
-                           "README.md",
-                           "Add README.md",
-                           "Hello world GitHub Classroom",
-                           branch: branch)
+    client.create_contents(
+      repo.full_name,
+      "README.md",
+      "Add README.md",
+      "Hello world GitHub Classroom",
+      branch: branch
+    )
   end
 end


### PR DESCRIPTION
## What
This PR proposes we use `fixed_indentation` for function parameters instead of `aligned` 

## Why
IMO this is easier to follow and nicer to write for long function calls.

## What does this look like?

```diff
-    github_repository = github_organization.create_repository(repo_name,
-                                                              private: private?,
-                                                              description: repo_description)
+    github_repository = github_organization.create_repository(
+      repo_name,
+      private: private?,
+      description: repo_description
+    )
```