### PR TITLE
Locked invite status migration

### DIFF
--- a/app/models/invite_status.rb
+++ b/app/models/invite_status.rb
@@ -3,6 +3,7 @@
 class InviteStatus < ApplicationRecord
   ERRORED_STATUSES = %w[errored_creating_repo errored_importing_starter_code].freeze
   SETUP_STATUSES = %w[accepted waiting creating_repo importing_starter_code].freeze
+  LOCKED_STATUSES = %w[waiting creating_repo importing_starter_code].freeze
 
   belongs_to :assignment_invitation
   belongs_to :user

--- a/lib/tasks/locked_invite_status_migration.rake
+++ b/lib/tasks/locked_invite_status_migration.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Runs a migration on possible locked (stuck) invite_statuses to change their status to "unaccepted"
+task locked_invite_status_migration: :environment do
+  InviteStatus
+    .where(status: InviteStatus::LOCKED_STATUSES)
+    .find_in_batches(batch_size: 100) do |invite_statuses|
+      invite_statuses.each do |invite_status|
+        time_difference = Time.now.utc - invite_status.updated_at.utc
+        if time_difference > 1.hour
+          puts("InviteStatus id: #{invite_status.id} – \"#{invite_status.status}\" => \"unaccepted\"")
+          invite_status.unaccepted!
+        end
+      end
+    end
+end


### PR DESCRIPTION
## What
This PR proposes a rake task that takes possibly stuck `invite_statuses` and unsticks them. 

## How
It does this by iterating though all `invite_statuses` that are in a _locked_ status. It takes those invite statuses and checks if they've been updated more recently than in the last hour. If not, it changes the  `invite_statuses` to `"unaccepted"`.

Closes #1527 