### PR TITLE
Reduced porter status polling + added data dog event

### DIFF
--- a/app/jobs/assignment_repo/porter_status_job.rb
+++ b/app/jobs/assignment_repo/porter_status_job.rb
@@ -16,6 +16,7 @@ class AssignmentRepo
 
       begin
         last_progress = nil
+        # rubocop:disable BlockLength
         result = Octopoller.poll(wait: WAIT_TIME, retries: 3) do
           begin
             GitHubClassroom.statsd.increment("v2_exercise_repo.import.poll")
@@ -44,6 +45,7 @@ class AssignmentRepo
             Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED
           end
         end
+        # rubocop:enable BlockLength
 
         case result
         when Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED


### PR DESCRIPTION
## What
This PR proposes:
* we reduce porter status polling from once a second to once every ten seconds
* we add a data dog event for each time we poll the source imports API (`v2_exercise_repo.import.poll`)

This resolves the incident that occurred today.
Resolves #1536 #1537  