### PR TITLE
Fix roster es query

### DIFF
--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -207,7 +207,7 @@ module Orgs
       result = User.where(id: unlinked_user_ids).order(:login)
       # result = StafftoolsIndex::User.query(ids: { values: unlinked_user_ids }).order(:login)
 
-      result do |user|
+      result.each do |user|
         @unlinked_users.push(user)
       end
 

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -204,8 +204,7 @@ module Orgs
       return @unlinked_users if defined?(@unlinked_users)
       @unlinked_users = []
 
-      result = User.where(id: unlinked_user_ids).order(:login)
-      # result = StafftoolsIndex::User.query(ids: { values: unlinked_user_ids }).order(:login)
+      result = User.where(id: unlinked_user_ids)
 
       result.each do |user|
         @unlinked_users.push(user)

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -204,10 +204,11 @@ module Orgs
       return @unlinked_users if defined?(@unlinked_users)
       @unlinked_users = []
 
-      result = StafftoolsIndex::User.query(ids: { values: unlinked_user_ids }).order(:login)
+      result = User.where(id: unlinked_user_ids).order(:login)
+      # result = StafftoolsIndex::User.query(ids: { values: unlinked_user_ids }).order(:login)
 
-      result.total_pages.times do |page|
-        @unlinked_users.push(*result.page(page).to_a)
+      result do |user|
+        @unlinked_users.push(user)
       end
 
       @unlinked_users

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 require "rails_helper"
 
 RSpec.describe Orgs::RostersController, type: :controller do

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+#
 require "rails_helper"
 
 RSpec.describe Orgs::RostersController, type: :controller do


### PR DESCRIPTION
## What
Source of the problem was the ES connection.
Temporary fix, as this isn't as efficient as the ES query.
Fixes #1557. 

```ruby
result = User.where(id: [1, 2, 3])
  User Load (17.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (1, 2, 3, 4, 5, 6)
=> [#<User:0x00007f90b40491c8
  id: 2,
  uid: 41388586,
  token: "f53e9d03d4970755f76d7895db58866ec049f391",
  created_at: Fri, 03 Aug 2018 21:03:11 UTC +00:00,
  updated_at: Fri, 03 Aug 2018 21:03:11 UTC +00:00,
  site_admin: false,
  last_active_at: Mon, 10 Sep 2018 21:43:41 UTC +00:00>,
 #<User:0x00007f90b04587b8
  id: 3,
  uid: 41803513,
  token: "cc0842800795c0fbd5639c8ef00cf4affb6914d9",
  created_at: Fri, 03 Aug 2018 21:21:00 UTC +00:00,
  updated_at: Fri, 03 Aug 2018 21:21:00 UTC +00:00,
  site_admin: false,
  last_active_at: Fri, 07 Sep 2018 14:19:44 UTC +00:00>,
 #<User:0x00007f90b0458538
  id: 1,
  uid: 11095731,
  token: "760c8934785a4314d45db8a177e8743229526744",
  created_at: Fri, 03 Aug 2018 21:01:12 UTC +00:00,
  updated_at: Thu, 06 Sep 2018 18:07:03 UTC +00:00,
  site_admin: true,
  last_active_at: Mon, 10 Sep 2018 21:44:17 UTC +00:00>]
[4] pry(main)> result.each do |user|
[4] pry(main)*   puts user
[4] pry(main)* end
#<User:0x00007f90b40491c8>
#<User:0x00007f90b04587b8>
#<User:0x00007f90b0458538>
```
