### PR TITLE
Switch from Bonsai to Elasticsearch

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,7 @@
     }
   },
   "addons": [
-    "bonsai",
+    "foundelasticsearch",
     "heroku-postgresql",
     "heroku-redis",
     "memcachedcloud",

--- a/config/chewy.yml
+++ b/config/chewy.yml
@@ -8,4 +8,4 @@ development:
   host: 'localhost:9227'
 
 production:
-  host: <%= ENV['BONSAI_URL'] %>
+  host: <%= ENV['FOUNDELASTICSEARCH_URL'] %>


### PR DESCRIPTION
## What
This PR changes all instance of bonsai to elasticsearch ("elasticsearch"  has the prefix "found" in heroku land).