### PR TITLE
Migrations for GraphQL work to begin

### DIFF
--- a/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
+++ b/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
@@ -1,6 +1,7 @@
 class GlobalRelayFieldsForAssignmentsOrgsAndUsers < ActiveRecord::Migration[5.1]
   def change
     # With GraphQL in Classroom, an objects global_relay_id will refer to it's local ID. The GitHub global relay ID refers to it's external counterparts ID
+    remove_index :assignment_repos, :global_relay_id
     rename_column :assignment_repos, :global_relay_id, :github_global_relay_id
 
     add_column :group_assignment_repos, :global_relay_id, :string

--- a/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
+++ b/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
@@ -1,0 +1,10 @@
+class GlobalRelayFieldsForAssignmentsOrgsAndUsers < ActiveRecord::Migration[5.1]
+  def change
+    # With GraphQL in Classroom, an objects global_relay_id will refer to it's local ID. The GitHub global relay ID refers to it's external counterparts ID
+    rename_column :assignment_repos, :global_relay_id, :github_global_relay_id
+
+    add_column :group_assignment_repos, :global_relay_id, :string
+    add_column :organizations, :global_relay_id, :string
+    add_column :users, :global_relay_id, :string
+  end
+end

--- a/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
+++ b/db/migrate/20180918215254_global_relay_fields_for_assignments_orgs_and_users.rb
@@ -4,8 +4,8 @@ class GlobalRelayFieldsForAssignmentsOrgsAndUsers < ActiveRecord::Migration[5.1]
     remove_index :assignment_repos, :global_relay_id
     rename_column :assignment_repos, :global_relay_id, :github_global_relay_id
 
-    add_column :group_assignment_repos, :global_relay_id, :string
-    add_column :organizations, :global_relay_id, :string
-    add_column :users, :global_relay_id, :string
+    add_column :group_assignment_repos, :github_global_relay_id, :string
+    add_column :organizations, :github_global_relay_id, :string
+    add_column :users, :github_global_relay_id, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180802210833) do
+ActiveRecord::Schema.define(version: 20180918215254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,11 +36,11 @@ ActiveRecord::Schema.define(version: 20180802210833) do
     t.integer "assignment_id"
     t.integer "user_id"
     t.string "submission_sha"
-    t.string "global_relay_id"
+    t.string "github_global_relay_id"
     t.integer "configuration_state", default: 0
     t.index ["assignment_id"], name: "index_assignment_repos_on_assignment_id"
+    t.index ["github_global_relay_id"], name: "index_assignment_repos_on_github_global_relay_id"
     t.index ["github_repo_id"], name: "index_assignment_repos_on_github_repo_id", unique: true
-    t.index ["global_relay_id"], name: "index_assignment_repos_on_global_relay_id"
     t.index ["repo_access_id"], name: "index_assignment_repos_on_repo_access_id"
     t.index ["user_id"], name: "index_assignment_repos_on_user_id"
   end
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20180802210833) do
     t.integer "group_id", null: false
     t.string "submission_sha"
     t.integer "configuration_state", default: 0
+    t.string "global_relay_id"
     t.index ["github_repo_id"], name: "index_group_assignment_repos_on_github_repo_id", unique: true
     t.index ["group_assignment_id"], name: "index_group_assignment_repos_on_group_assignment_id"
   end
@@ -172,6 +173,7 @@ ActiveRecord::Schema.define(version: 20180802210833) do
     t.integer "webhook_id"
     t.boolean "is_webhook_active", default: false
     t.integer "roster_id"
+    t.string "global_relay_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
     t.index ["github_id"], name: "index_organizations_on_github_id"
     t.index ["roster_id"], name: "index_organizations_on_roster_id"
@@ -219,6 +221,7 @@ ActiveRecord::Schema.define(version: 20180802210833) do
     t.datetime "updated_at", null: false
     t.boolean "site_admin", default: false
     t.datetime "last_active_at", null: false
+    t.string "global_relay_id"
     t.index ["token"], name: "index_users_on_token", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,7 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.integer "group_id", null: false
     t.string "submission_sha"
     t.integer "configuration_state", default: 0
-    t.string "global_relay_id"
+    t.string "github_global_relay_id"
     t.index ["github_repo_id"], name: "index_group_assignment_repos_on_github_repo_id", unique: true
     t.index ["group_assignment_id"], name: "index_group_assignment_repos_on_group_assignment_id"
   end
@@ -172,7 +172,7 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.integer "webhook_id"
     t.boolean "is_webhook_active", default: false
     t.integer "roster_id"
-    t.string "global_relay_id"
+    t.string "github_global_relay_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
     t.index ["github_id"], name: "index_organizations_on_github_id"
     t.index ["roster_id"], name: "index_organizations_on_roster_id"
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.datetime "updated_at", null: false
     t.boolean "site_admin", default: false
     t.datetime "last_active_at", null: false
-    t.string "global_relay_id"
+    t.string "github_global_relay_id"
     t.index ["token"], name: "index_users_on_token", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.string "github_global_relay_id"
     t.integer "configuration_state", default: 0
     t.index ["assignment_id"], name: "index_assignment_repos_on_assignment_id"
-    t.index ["github_global_relay_id"], name: "index_assignment_repos_on_github_global_relay_id"
     t.index ["github_repo_id"], name: "index_assignment_repos_on_github_repo_id", unique: true
     t.index ["repo_access_id"], name: "index_assignment_repos_on_repo_access_id"
     t.index ["user_id"], name: "index_assignment_repos_on_user_id"


### PR DESCRIPTION
cc https://github.com/education/classroom/issues/1518

The initial migrations for GraphQL work in Classroom to begin.

`assignment_repos` had a field already from some spike work I did a year ago, but I renamed it to be more correct. The things we store in the database are GitHub global relay IDs, not local global relay IDs, as those can be calculated at runtime.

I also removed the index since we'll never be `SELECT`ing or ordering by the global relay ID.