### PR TITLE
Bump ES to 6.3.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   elasticsearch:
     container_name: "classroom_elasticsearch"
-    image: elasticsearch:1.7.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     ports:
       - "127.0.0.1:9337:9300"
       - "127.0.0.1:9227:9200"


### PR DESCRIPTION
## What
This PR proposes we bump our docker image of ES to 6.3.2 to reflect the version that our service provider is providing us. This will help us resolve breaking ES changes locally.

Docs: https://www.elastic.co/guide/en/elasticsearch/reference/6.3/docker.html

