### PR TITLE
Remove TODOs

### DIFF
--- a/app/jobs/group_assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/group_assignment_repo/create_github_repository_job.rb
@@ -26,8 +26,6 @@ class GroupAssignmentRepo
 
       broadcast_message(CREATE_REPO, invite_status, group_assignment, group)
 
-      # TODO: Implement PorterStatusJob (follow up PR)
-      # group_assignment_repo = GroupAssignmentRepo.create!(group_assignment: group_assignment, group: group)
       GroupAssignmentRepo.create!(group_assignment: group_assignment, group: group)
       report_time(start)
 
@@ -35,8 +33,6 @@ class GroupAssignmentRepo
       if group_assignment.starter_code?
         invite_status.importing_starter_code!
         broadcast_message(IMPORT_STARTER_CODE, invite_status, group_assignment, group)
-        # TODO: Implement PorterStatusJob (follow up PR)
-        # PorterStatusJob.perform_later(group_assignment_repo, group) create new PorterStatusJob for groups
       else
         invite_status.completed!
         broadcast_message(CREATE_COMPLETE, invite_status, group_assignment, group)

--- a/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
 
   subject { described_class }
 
-  # TODO: Implement GroupAssignmentRepo::PorterStatusJob (follow up PR)
-  #
-  # let(:cascading_job)      { GroupAssignmentRepo::PorterStatusJob }
   let(:group_repo_channel) { GroupRepositoryCreationStatusChannel }
 
   context "with created objects", :vcr do
@@ -126,12 +123,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           repo_name = assignment_repo.github_repository.full_name
           expect(WebMock).to have_requested(:put, github_url("/teams/#{group.github_team_id}/repos/#{repo_name}"))
         end
-
-        # TODO: Implement GroupAssignmentRepo::PorterStatusJob (follow up PR)
-        #
-        # it "kicks off a cascading porter status job" do
-        #   expect(cascading_job).to have_been_enqueued.on_queue("porter_status")
-        # end
       end
 
       describe "successful creation" do


### PR DESCRIPTION
## What
Remove TODO comments about a `GroupAssignmentRepo` `PorterStatusJob`.

We have since taken the approach to use webhooks instead of polling the GitHub API (#1498)
