### PR TITLE
Fix linux download link for Assistant

### DIFF
--- a/app/views/pages/_download_assistant_button.html.erb
+++ b/app/views/pages/_download_assistant_button.html.erb
@@ -1,6 +1,6 @@
 <a class="mx-1 my-3 f3 btn btn-large btn-white" href="https://classroom.github.com/assistant/download/mac" data-for-os="mac" data-download="mac">Download for macOS</a>
 <a class="mx-1 my-3 f3 btn btn-large btn-white" href="https://classroom.github.com/assistant/download/win" data-for-os="windows" data-download="windows">Download for Windows</a>
-<a class="mx-1 my-3 f3 btn btn-large btn-white" href="https://classroom.github.com/assistant/download/linux" data-for-os="linux" data-download="linux">Download for Linux</a>
+<a class="mx-1 my-3 f3 btn btn-large btn-white" href="https://classroom.github.com/assistant/download/linux_deb_64" data-for-os="linux" data-download="linux">Download for Linux</a>
 <a class="mx-1 my-3 f3 btn btn-large btn-white" href="https://github.com/education/classroom-assistant/releases/latest" data-for-os="unknownOS">Download Classroom Assistant</a>
 
 <p data-for-os="windows" class="mb-0">


### PR DESCRIPTION
There was a typo in one of the download links for downloading Assistant 🍎 