### PR TITLE
Add 'assignment_id' argument to RepositoryCreationStatusChannel

### DIFF
--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -287,19 +287,25 @@
   };
 
   setup_assignment_cable = function() {
-    App.repository_creation_status = App.cable.subscriptions.create("RepositoryCreationStatusChannel", {
-      connected: function() {
-        // Called when the subscription is ready for use on the server
-        start_job();
-      },
-      disconnected: function() {
-        // Called when the subscription has been terminated by the server
-      },
-      received: function(data) {
-        // Called when there's incoming data on the websocket for this channel
-        display_progress(data);
+    var assignment_id = $("#assignment_id").val();
+    App.repository_creation_status = App.cable.subscriptions.create(
+      {
+        channel: "RepositoryCreationStatusChannel",
+        assignment_id: assignment_id
+      }, {
+        connected: function() {
+          // Called when the subscription is ready for use on the server
+          start_job();
+        },
+        disconnected: function() {
+          // Called when the subscription has been terminated by the server
+        },
+        received: function(data) {
+          // Called when there's incoming data on the websocket for this channel
+          display_progress(data);
+        }
       }
-    });
+    );
   };
 
   setup_group_assignment_cable = function() {

--- a/app/channels/repository_creation_status_channel.rb
+++ b/app/channels/repository_creation_status_channel.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class RepositoryCreationStatusChannel < ApplicationCable::Channel
-  def self.channel(user_id:)
-    "#{channel_name}_#{user_id}"
+  def self.channel(user_id:, assignment_id:)
+    "#{channel_name}_#{user_id}_#{assignment_id}"
   end
 
   def subscribed
-    stream_from self.class.channel(user_id: current_user.id)
+    stream_from self.class.channel(user_id: current_user.id, assignment_id: params[:assignment_id])
   end
 
   def unsubscribed

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -150,6 +150,11 @@ class AssignmentInvitationsController < ApplicationController
     end
   end
 
+  def assignment
+    @assignment ||= current_invitation.assignment
+  end
+  helper_method :assignment
+
   def current_submission
     @current_submission ||= AssignmentRepo.find_by(assignment: current_assignment, user: current_user)
   end

--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -23,11 +23,12 @@ class AssignmentRepo
 
       broadcast_message(
         message: CREATE_REPO,
+        assignment: assignment,
         user: user,
         invite_status: invite_status,
         status_text: CREATE_REPO.chomp(".")
       )
-      assignment_repo = create_assignment_repo(assignment, user)
+      create_assignment_repo(assignment, user)
       report_time(start)
 
       GitHubClassroom.statsd.increment("v2_exercise_repo.create.success")
@@ -35,6 +36,7 @@ class AssignmentRepo
         invite_status.importing_starter_code!
         broadcast_message(
           message: IMPORT_STARTER_CODE,
+          assignment: assignment,
           user: user,
           invite_status: invite_status,
           status_text: "Import started"
@@ -44,6 +46,7 @@ class AssignmentRepo
         invite_status.completed!
         broadcast_message(
           message: Creator::REPOSITORY_CREATION_COMPLETE,
+          assignment: assignment,
           user: user,
           invite_status: invite_status,
           status_text: "Completed"
@@ -102,6 +105,7 @@ class AssignmentRepo
         broadcast_message(
           type: :error,
           message: err,
+          assignment: assignment,
           user: user,
           invite_status: invite_status,
           status_text: "Failed"
@@ -114,14 +118,17 @@ class AssignmentRepo
     # Broadcasts a ActionCable message with a status to the given user
     #
     # rubocop:disable ParameterLists
-    def broadcast_message(type: :text, message:, user:, invite_status:, status_text:)
+    def broadcast_message(type: :text, message:, assignment:, user:, invite_status:, status_text:)
       raise ArgumentError unless %i[text error].include?(type)
       broadcast_args = {
         status: invite_status.status,
         status_text: status_text
       }
       broadcast_args[type] = message
-      ActionCable.server.broadcast(RepositoryCreationStatusChannel.channel(user_id: user.id), broadcast_args)
+      ActionCable.server.broadcast(
+        RepositoryCreationStatusChannel.channel(user_id: user.id, assignment_id: assignment.id),
+        broadcast_args
+      )
     end
     # rubocop:enable ParameterLists
 

--- a/app/jobs/repository_import_event_job.rb
+++ b/app/jobs/repository_import_event_job.rb
@@ -25,12 +25,14 @@ class RepositoryImportEventJob < ApplicationJob
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable MethodLength
   def handle_assignment_repo(assignment_repo, status)
     user = assignment_repo.user
-    invitation = assignment_repo.assignment.invitation
+    assignment = assignment_repo.assignment
+    invitation = assignment.invitation
     invite_status = invitation.status(user)
-    channel = RepositoryCreationStatusChannel.channel(user_id: user.id)
+    channel = RepositoryCreationStatusChannel.channel(user_id: user.id, assignment_id: assignment_repo.assignment.id)
 
     case status
     when "success"
@@ -48,6 +50,7 @@ class RepositoryImportEventJob < ApplicationJob
     end
   end
   # rubocop:enable MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable MethodLength
   # rubocop:disable Metrics/AbcSize

--- a/app/views/assignment_invitations/setup.html.erb
+++ b/app/views/assignment_invitations/setup.html.erb
@@ -1,6 +1,7 @@
 <%= render 'organizations/organization_invitation_banner' %>
 
 <%= hidden_field_tag "assignment_setup" %>
+<%= hidden_field_tag 'assignment_id', assignment.id %>
 
 <div id="flash-messages" class="flash-messages"></div>
 

--- a/app/views/group_assignment_invitations/setup.html.erb
+++ b/app/views/group_assignment_invitations/setup.html.erb
@@ -1,6 +1,8 @@
 <%= render 'organizations/organization_invitation_banner' %>
 
 <%= hidden_field_tag "group_assignment_setup" %>
+<%= hidden_field_tag 'group_id', group.id %>
+<%= hidden_field_tag 'group_assignment_id', group_assignment.id %>
 
 <div id="flash-messages" class="flash-messages"></div>
 
@@ -11,9 +13,6 @@
     </h2>
   </div>
 </div>
-
-<%= hidden_field_tag 'group_id', group.id %>
-<%= hidden_field_tag 'group_assignment_id', group_assignment.id %>
 
 <div class="site-content-body ">
   <div class="d-flex flex-justify-between group-setup">

--- a/spec/channels/repository_creation_status_channel_spec.rb
+++ b/spec/channels/repository_creation_status_channel_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RepositoryCreationStatusChannel, type: :channel do
 
   it "subscribes to stream" do
     stub_connection current_user: student
-    subscribe
-    expect(streams).to include(RepositoryCreationStatusChannel.channel(user_id: student.id))
+    subscribe(assignment_id: 1)
+    expect(streams).to include(RepositoryCreationStatusChannel.channel(user_id: student.id, assignment_id: 1))
   end
 end

--- a/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
@@ -113,7 +113,9 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
 
     it "broadcasts status on channel" do
       expect { subject.perform_now(assignment, teacher) }
-        .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: teacher.id))
+        .to have_broadcasted_to(
+          RepositoryCreationStatusChannel.channel(user_id: teacher.id, assignment_id: assignment.id)
+        )
         .with(
           text: subject::CREATE_REPO,
           status: "creating_repo",
@@ -153,7 +155,9 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
         .to_return(body: "{}", status: 401)
 
       expect { subject.perform_now(assignment, student) }
-        .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+        .to have_broadcasted_to(
+          RepositoryCreationStatusChannel.channel(user_id: student.id, assignment_id: assignment.id)
+        )
         .with(
           text: subject::CREATE_REPO,
           status: "creating_repo",
@@ -198,7 +202,9 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           .to_return(body: "{}", status: 401)
 
         expect { subject.perform_now(assignment, student) }
-          .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+          .to have_broadcasted_to(
+            RepositoryCreationStatusChannel.channel(user_id: student.id, assignment_id: assignment.id)
+          )
           .with(
             text: subject::CREATE_REPO,
             status: "creating_repo",
@@ -242,7 +248,9 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           .to_return(body: "{}", status: 401)
 
         expect { subject.perform_now(assignment, student) }
-          .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+          .to have_broadcasted_to(
+            RepositoryCreationStatusChannel.channel(user_id: student.id, assignment_id: assignment.id)
+          )
           .with(
             text: subject::CREATE_REPO,
             status: "creating_repo",
@@ -284,7 +292,9 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
         allow_any_instance_of(AssignmentRepo).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
 
         expect { subject.perform_now(assignment, student) }
-          .to have_broadcasted_to(RepositoryCreationStatusChannel.channel(user_id: student.id))
+          .to have_broadcasted_to(
+            RepositoryCreationStatusChannel.channel(user_id: student.id, assignment_id: assignment.id)
+          )
           .with(
             text: subject::CREATE_REPO,
             status: "creating_repo",

--- a/spec/jobs/repository_import_event_job_spec.rb
+++ b/spec/jobs/repository_import_event_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe RepositoryImportEventJob, type: :job do
   subject { described_class }
 
-  let(:individual_channel)  { RepositoryCreationStatusChannel.channel(user_id: user.id) }
+  let(:individual_channel)  { RepositoryCreationStatusChannel.channel(user_id: user.id, assignment_id: assignment.id) }
   let(:group_channel) do
     GroupRepositoryCreationStatusChannel
       .channel(


### PR DESCRIPTION
Currently if you try to accept two individual assignments at the same time, their ActionCable messages get broadcasted to each others setup process. This is not ideal.

This PR proposes we add another level of identification to the `RepositoryCreationStatusChannel` by giving it an `assignment_id` argument. 

By giving it an `assignment_id` argument, we will prevent messages being cross broadcasted to other repository setup processes.
