### PR TITLE
Don't call methods on nil when indexing

### DIFF
--- a/app/chewy/assignment_index.rb
+++ b/app/chewy/assignment_index.rb
@@ -8,6 +8,6 @@ class AssignmentIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :organization_login, value: ->(assignment) { assignment.organization.github_organization.login }
+    field :organization_login, value: ->(assignment) { assignment&.organization&.github_organization&.login }
   end
 end

--- a/app/chewy/assignment_invitation_index.rb
+++ b/app/chewy/assignment_invitation_index.rb
@@ -7,6 +7,6 @@ class AssignmentInvitationIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :assignment_title, value: ->(assignment_invitation) { assignment_invitation.assignment.title }
+    field :assignment_title, value: ->(assignment_invitation) { assignment_invitation&.assignment&.title }
   end
 end

--- a/app/chewy/assignment_repo_index.rb
+++ b/app/chewy/assignment_repo_index.rb
@@ -7,7 +7,7 @@ class AssignmentRepoIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :assignment_title, value: ->(assignment_repo) { assignment_repo.assignment.title }
-    field :user_login,       value: ->(assignment_repo) { assignment_repo.user.github_user.login }
+    field :assignment_title, value: ->(assignment_repo) { assignment_repo&.assignment&.title        }
+    field :user_login,       value: ->(assignment_repo) { assignment_repo&.user&.github_user&.login }
   end
 end

--- a/app/chewy/group_assignment_index.rb
+++ b/app/chewy/group_assignment_index.rb
@@ -8,6 +8,7 @@ class GroupAssignmentIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :organization_login, value: ->(group_assignment) { group_assignment.organization.github_organization.login }
+    field :organization_login,
+      value: ->(group_assignment) { group_assignment&.organization&.github_organization&.login }
   end
 end

--- a/app/chewy/group_assignment_invitation_index.rb
+++ b/app/chewy/group_assignment_invitation_index.rb
@@ -7,8 +7,7 @@ class GroupAssignmentInvitationIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :group_assignment_title, value: (lambda do |group_assignment_invitation|
-      group_assignment_invitation.group_assignment.title
-    end)
+    field :group_assignment_title,
+      value: ->(group_assignment_invitation) { group_assignment_invitation&.group_assignment&.title }
   end
 end

--- a/app/chewy/group_assignment_repo_index.rb
+++ b/app/chewy/group_assignment_repo_index.rb
@@ -7,7 +7,7 @@ class GroupAssignmentRepoIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :group_assignment_title, value: ->(group_assignment_repo) { group_assignment_repo.group_assignment.title }
-    field :group_title,            value: ->(group_assignment_repo) { group_assignment_repo.group.title            }
+    field :group_assignment_title, value: ->(group_assignment_repo) { group_assignment_repo&.group_assignment&.title }
+    field :group_title,            value: ->(group_assignment_repo) { group_assignment_repo&.group&.title            }
   end
 end

--- a/app/chewy/group_index.rb
+++ b/app/chewy/group_index.rb
@@ -8,6 +8,6 @@ class GroupIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :organization_login, value: ->(group) { group.organization.github_organization.login }
+    field :organization_login, value: ->(group) { group&.organization&.github_organization&.login }
   end
 end

--- a/app/chewy/grouping_index.rb
+++ b/app/chewy/grouping_index.rb
@@ -6,6 +6,6 @@ class GroupingIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :organization_login, value: ->(grouping) { grouping.organization.github_organization.login }
+    field :organization_login, value: ->(grouping) { grouping&.organization&.github_organization&.login }
   end
 end

--- a/app/chewy/organization_index.rb
+++ b/app/chewy/organization_index.rb
@@ -9,7 +9,7 @@ class OrganizationIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :login, value: ->(organization) { organization.github_organization.login }
-    field :name,  value: ->(organization) { organization.github_organization.name  }
+    field :login, value: ->(organization) { organization&.github_organization&.login }
+    field :name,  value: ->(organization) { organization&.github_organization&.name  }
   end
 end

--- a/app/chewy/repo_access_index.rb
+++ b/app/chewy/repo_access_index.rb
@@ -6,7 +6,7 @@ class RepoAccessIndex < Chewy::Index
     field :created_at
     field :updated_at
 
-    field :organization_login, value: ->(repo_access) { repo_access.organization.github_organization.login }
-    field :user_login,         value: ->(repo_access) { repo_access.user.github_user.login                 }
+    field :organization_login, value: ->(repo_access) { repo_access&.organization&.github_organization&.login }
+    field :user_login,         value: ->(repo_access) { repo_access&.user&.github_user&.login                 }
   end
 end


### PR DESCRIPTION
This avoids hitting exceptions during bulk index syncs / imports by ensuring we never call a method on `nil`.