### PR TITLE
[Idea] Sleep until rate limit updates and try again

### DIFF
--- a/app/models/github_model.rb
+++ b/app/models/github_model.rb
@@ -118,6 +118,14 @@ class GitHubModel
   # Returns a Sawyer::Resource or raises and error.
   def github_client_request(client, id, **options)
     GitHub::Errors.with_error_handling { client.send(github_type, id, options) }
+  rescue GitHub::TooManyRequests
+    retries ||= 0
+    if retries < 1
+      retries +=1
+      sleep client.rate_limit.resets_in + 1
+      retry
+    end
+    nil
   rescue GitHub::Error
     nil
   end
@@ -132,6 +140,14 @@ class GitHubModel
     GitHub::Errors.with_error_handling do
       GitHubClassroom.github_client.send(github_type, id, options)
     end
+  rescue GitHub::TooManyRequests
+    retries ||= 0
+    if retries < 1
+      retries +=1
+      sleep client.rate_limit.resets_in + 1
+      retry
+    end
+    nil
   rescue GitHub::Error
     nil
   end


### PR DESCRIPTION
In working on updating ES indexes, I'm slightly worried about exhausting some rate limits.

This is just an idea for how we could rescue from a hitting our rate limits, hold off for a cool down period, and then resume work.

If something like this would work, I think it might be worth defaulting to not behaving this way and implementing a way to choose the behavior, similar to how we can choose to skip the API cache.

cc/ @d12 @tarebyte for your opinions on the approach.