### PR TITLE
Prevent duplicate AssignmentRepos

### DIFF
--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -81,13 +81,13 @@ class AssignmentRepo
 
       assignment_repo.save!
       assignment_repo
-    rescue ActiveRecord::RecordInvalid => err
-      creator.delete_github_repository(assignment_repo.try(:github_repo_id))
-      logger.warn(err.message)
+    rescue ActiveRecord::RecordInvalid => error
+      creator.delete_github_repository(github_repository&.id)
+      logger.warn(error.message)
       raise Creator::Result::Error, Creator::DEFAULT_ERROR_MESSAGE
-    rescue Creator::Result::Error => err
-      creator.delete_github_repository(assignment_repo.try(:github_repo_id))
-      raise err
+    rescue Creator::Result::Error => error
+      creator.delete_github_repository(github_repository&.id)
+      raise error
     end
     # rubocop:enable AbcSize
     # rubocop:enable MethodLength

--- a/app/jobs/assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/assignment_repo/create_github_repository_job.rb
@@ -81,13 +81,13 @@ class AssignmentRepo
 
       assignment_repo.save!
       assignment_repo
-    rescue ActiveRecord::RecordInvalid => error
-      creator.delete_github_repository(github_repository&.id)
-      logger.warn(error.message)
+    rescue ActiveRecord::RecordInvalid => err
+      creator.delete_github_repository(assignment_repo.try(:github_repo_id))
+      logger.warn(err.message)
       raise Creator::Result::Error, Creator::DEFAULT_ERROR_MESSAGE
-    rescue Creator::Result::Error => error
-      creator.delete_github_repository(github_repository&.id)
-      raise error
+    rescue Creator::Result::Error => err
+      creator.delete_github_repository(assignment_repo.try(:github_repo_id))
+      raise err
     end
     # rubocop:enable AbcSize
     # rubocop:enable MethodLength

--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -78,12 +78,12 @@ class AssignmentRepo < ApplicationRecord
     true
   end
 
-  # Validate that the set of <user, assignment> is unique to each AssignmentRepo
-  # Only validate on new models (to preserve old models)
+  # Internal: Validate uniqueness of <user, assignment> key.
+  # Does not invalidate pre-existing invalid records.
+  #
   def assignment_user_key_uniqueness
     return if persisted?
-    if AssignmentRepo.find_by(user: user, assignment: assignment)
-      errors.add(:assignment, "Should only have one assignment repository for each user-assignment combination")
-    end
+    return unless AssignmentRepo.find_by(user: user, assignment: assignment)
+    errors.add(:assignment, "Should only have one assignment repository for each user-assignment combination")
   end
 end

--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -3,6 +3,7 @@
 class AssignmentRepo < ApplicationRecord
   update_index("assignment_repo#assignment_repo") { self }
 
+  # TODO: remove this enum (dead code)
   enum configuration_state: %i[not_configured configuring configured]
 
   belongs_to :assignment

--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -16,6 +16,8 @@ class AssignmentRepo < ApplicationRecord
   validates :github_repo_id, presence:   true
   validates :github_repo_id, uniqueness: true
 
+  validate :assignment_user_key_uniqueness
+
   # TODO: Remove this dependency from the model.
   before_destroy :silently_destroy_github_repository
 
@@ -74,5 +76,14 @@ class AssignmentRepo < ApplicationRecord
     true
   rescue GitHub::Error
     true
+  end
+
+  # Validate that the set of <user, assignment> is unique to each AssignmentRepo
+  # Only validate on new models (to preserve old models)
+  def assignment_user_key_uniqueness
+    return if persisted?
+    if AssignmentRepo.find_by(user: user, assignment: assignment)
+      errors.add(:assignment, "Should only have one assignment repository for each user-assignment combination")
+    end
   end
 end

--- a/app/models/assignment_repo.rb
+++ b/app/models/assignment_repo.rb
@@ -80,7 +80,7 @@ class AssignmentRepo < ApplicationRecord
   end
 
   # Internal: Validate uniqueness of <user, assignment> key.
-  # Does not invalidate pre-existing invalid records.
+  # Only runs the validation on new records.
   #
   def assignment_user_key_uniqueness
     return if persisted?

--- a/spec/models/assignment_repo_spec.rb
+++ b/spec/models/assignment_repo_spec.rb
@@ -73,7 +73,11 @@ RSpec.describe AssignmentRepo, type: :model do
     context "invalid but already exists" do
       it "passes validation" do
         assignment_repo = subject
-        non_unique_assignment_repo = build(:assignment_repo, assignment: assignment_repo.assignment, user: assignment_repo.user)
+        non_unique_assignment_repo = build(
+          :assignment_repo,
+          assignment: assignment_repo.assignment,
+          user: assignment_repo.user
+        )
         non_unique_assignment_repo.save!(validate: false)
         expect(non_unique_assignment_repo.valid?).to be_truthy
       end

--- a/spec/models/assignment_repo_spec.rb
+++ b/spec/models/assignment_repo_spec.rb
@@ -54,4 +54,29 @@ RSpec.describe AssignmentRepo, type: :model do
       expect(repo.valid?).to be_truthy
     end
   end
+
+  describe "#assignment_user_key_uniqueness" do
+    context "valid" do
+      it "passes validation" do
+        expect(subject.valid?).to be_truthy
+      end
+    end
+
+    context "invalid" do
+      it "fails validation" do
+        assignment_repo = subject
+        expect { create(:assignment_repo, assignment: assignment_repo.assignment, user: assignment_repo.user) }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "invalid but already exists" do
+      it "passes validation" do
+        assignment_repo = subject
+        non_unique_assignment_repo = build(:assignment_repo, assignment: assignment_repo.assignment, user: assignment_repo.user)
+        non_unique_assignment_repo.save!(validate: false)
+        expect(non_unique_assignment_repo.valid?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What :sparkles:
This PR proposes a fix for #1646 

## Source of the problem
In https://github.com/education/classroom/issues/1462 I checked to see if each duplicate GitHub repo had an associated `AssignmentRepo` and I found that there were two assignment repos for the same `<User, Assignment>` key.


```ruby
PRODUCTION [2] pry(main)> a1 = AssignmentRepo.find_by(github_repo_id: 142300727)
D, [2018-10-15T19:22:26.217594 #4] DEBUG -- :   AssignmentRepo Load (1.2ms)  SELECT  "assignment_repos".* FROM "assignment_repos" WHERE "assignment_repos"."github_repo_id" = $1 LIMIT $2  [["github_repo_id", 142300727], ["LIMIT", 1]]
=> #<AssignmentRepo:0x0000000008381eb0
 id: 741547,
 github_repo_id: 142300727,
 repo_access_id: nil,
 created_at: Wed, 25 Jul 2018 13:02:41 UTC +00:00,
 updated_at: Wed, 25 Jul 2018 13:02:41 UTC +00:00,
 assignment_id: 32794,
 user_id: 146696,
 submission_sha: nil,
 github_global_relay_id: "MDEwOlJlcG9zaXRvcnkxNDIzMDA3Mjc=",
 configuration_state: "not_configured">
PRODUCTION [3] pry(main)> a2 = AssignmentRepo.find_by(github_repo_id: 142668458)
D, [2018-10-15T19:22:54.993108 #4] DEBUG -- :   AssignmentRepo Load (1.4ms)  SELECT  "assignment_repos".* FROM "assignment_repos" WHERE "assignment_repos"."github_repo_id" = $1 LIMIT $2  [["github_repo_id", 142668458], ["LIMIT", 1]]
=> #<AssignmentRepo:0x00000000083c57f0
 id: 742859,
 github_repo_id: 142668458,
 repo_access_id: nil,
 created_at: Sat, 28 Jul 2018 10:28:55 UTC +00:00,
 updated_at: Sat, 28 Jul 2018 10:28:55 UTC +00:00,
 assignment_id: 32794,
 user_id: 146696,
 submission_sha: nil,
 github_global_relay_id: "MDEwOlJlcG9zaXRvcnkxNDI2Njg0NTg=",
 configuration_state: "not_configured">
```

We should not be able to have multiple `AssignmentRepo`s for each `<User, Assignment>` key.

## The Fix
This PR proposes that we validate that there is only 1 `AssignmentRepo` per `<User, Assignment>` key.  This validation was overlooked when `AssignmentRepo` was written.

Since adding this validation could possibly invalidate some already persisted records, this validation will only be applied to new records.

Closes #1646, Closes #1586, Closes #1462