### PR TITLE
Move linting to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - bundle exec rake factory_bot:lint
 
 script:
-  - "KNAPSACK_GENERATE_REPORT=true ./bin/rake knapsack:rspec && ./bin/rubocop"
+  - "KNAPSACK_GENERATE_REPORT=true ./bin/rake knapsack:rspec && ./bin/rubocop -D"
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - bundle exec rake factory_bot:lint
 
 script:
-  - "KNAPSACK_GENERATE_REPORT=true ./bin/rake knapsack:rspec"
+  - "KNAPSACK_GENERATE_REPORT=true ./bin/rake knapsack:rspec && ./bin/rubocop"
 
 cache:
   bundler: true

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -123,10 +123,7 @@ module Orgs
 
       redirect_to roster_path(current_organization)
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
-    # rubocop:disable Metrics/MethodLength
     def download_roster
       grouping = current_organization.groupings.find(params[:grouping]) if params[:grouping]
 
@@ -144,6 +141,7 @@ module Orgs
       end
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,8 @@ module GitHubClassroom
 
     # Health checks endpoint for monitoring
     if ENV["PINGLISH_ENABLED"] == "true"
+
+      # rubocop:disable Metrics/BlockLength
       config.middleware.use Pinglish do |ping|
         ping.check :db do
           ActiveRecord::Base.connection.tables.size
@@ -91,6 +93,7 @@ module GitHubClassroom
           "ok"
         end
       end
+      # rubocop:enable Metrics/BlockLength
     end
   end
 end

--- a/lib/tasks/locked_invite_status_migration.rake
+++ b/lib/tasks/locked_invite_status_migration.rake
@@ -8,11 +8,11 @@ task locked_invite_status_migration: :environment do
     .find_in_batches(batch_size: 100) do |invite_statuses|
       invite_statuses.each do |invite_status|
         time_difference = Time.now.utc - invite_status.updated_at.utc
-        if time_difference > 1.hour
-          puts("=> InviteStatus id: #{invite_status.id} – \"#{invite_status.status}\" => \"unaccepted\"")
-          invite_status.unaccepted!
-          invite_statuses_touched += 1
-        end
+        next unless time_difference > 1.hour
+
+        puts("=> InviteStatus id: #{invite_status.id} – \"#{invite_status.status}\" => \"unaccepted\"")
+        invite_status.unaccepted!
+        invite_statuses_touched += 1
       end
     end
 


### PR DESCRIPTION
This PR moves our linting process to TravisCI instead of Hound. Hound crashes when we upload a specific vendored Gem. Until that's fixed, let's move to TravisCI for now.

<img width="474" alt="screen shot 2018-10-15 at 11 33 39 am" src="https://user-images.githubusercontent.com/30920216/47047275-00722380-d14c-11e8-8879-c7b6fa67e43b.png">
