### PR TITLE
Order paginated requests

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -27,18 +27,27 @@ class AssignmentsController < ApplicationController
     end
   end
 
+  # rubocop:disable MethodLength
   # rubocop:disable Metrics/AbcSize
   def show
     if @organization.roster
-      @roster_entries = @organization.roster.roster_entries.page(params[:students_page]).order_for_view(@assignment)
+      @roster_entries = @organization.roster.roster_entries
+        .order(:id)
+        .page(params[:students_page])
+        .order_for_view(@assignment)
 
       @unlinked_user_repos = AssignmentRepo
+        .order(:id)
         .where(assignment: @assignment, user: @unlinked_users)
         .page(params[:unlinked_accounts_page])
     else
-      @assignment_repos = AssignmentRepo.where(assignment: @assignment).page(params[:page])
+      @assignment_repos = AssignmentRepo
+        .where(assignment: @assignment)
+        .order(:id)
+        .page(params[:page])
     end
   end
+  # rubocop:enable MethodLength
   # rubocop:enable Metrics/AbcSize
 
   def edit; end

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -31,12 +31,15 @@ class GroupAssignmentsController < ApplicationController
 
   def show
     pagination_key = @organization.roster ? :teams_page : :page
-    @group_assignment_repos = GroupAssignmentRepo.where(group_assignment: @group_assignment)
+    @group_assignment_repos = GroupAssignmentRepo
+      .where(group_assignment: @group_assignment)
+      .order(:id)
       .page(params[pagination_key])
 
     return unless @organization.roster
     @students_not_on_team = @organization.roster.roster_entries
       .students_not_on_team(@group_assignment)
+      .order(:id)
       .page(params[:students_page])
   end
 

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -19,7 +19,10 @@ module Orgs
         .order(:identifier)
         .page(params[:roster_entries_page])
 
-      @current_unlinked_users = User.where(id: unlinked_user_ids).page(params[:unlinked_users_page])
+      @current_unlinked_users = User
+        .where(id: unlinked_user_ids)
+        .order(:id)
+        .page(params[:unlinked_users_page])
 
       download_roster if params.dig("format")
     end


### PR DESCRIPTION
This PR proposes a fix for #1661 and #1659 
There appears to have been weird behavior when querying without `order` on Assignments#show
https://github.com/education/classroom/blob/master/app/controllers/assignments_controller.rb#L33-L39

## How I determined the source of the bug
1. I discovered that our paginated assignment repo query was producing duplicates and missing records: https://github.com/education/classroom/issues/1659#issuecomment-431140486
1. I uncovered that there wasn't anything wrong with our pagination gem since I was able to reproduce the bug using `limit` and `offset`: https://github.com/education/classroom/issues/1659#issuecomment-431140486
1. Then I finally discovered that adding `order(:id)` would prevent duplicates and missing records in pagination: https://github.com/education/classroom/issues/1659#issuecomment-431157685


## Why would query yield a response like this? (updated)
Without `order` in the presence of a `limit`, the result will be an unpredictable subset of the query rows.

> When using LIMIT, it is important to use an ORDER BY clause that constrains the result rows into a unique order. Otherwise you will get an unpredictable subset of the query's rows. You might be asking for the tenth through twentieth rows, but tenth through twentieth in what ordering? The ordering is unknown, unless you specified ORDER BY.

From Postgres documentation: https://www.postgresql.org/docs/9.3/static/queries-limit.html


## No tests?
Unfortunately I was unable to confirm the problem by creating a local failing test. I did however test the queries on production in https://github.com/education/classroom/issues/1659#issuecomment-431157685
I hope that sufficient evidence of the fix ☝️ 

Closes #1661 Closes #1659 