### PR TITLE
Add order to API Calls

### DIFF
--- a/app/controllers/api/assignment_repos_controller.rb
+++ b/app/controllers/api/assignment_repos_controller.rb
@@ -8,7 +8,7 @@ module API
     before_action :set_assignment
 
     def index
-      repos = AssignmentRepo.where(assignment: @assignment)
+      repos = AssignmentRepo.where(assignment: @assignment).order(:id)
       paginate json: repos
     end
 

--- a/app/controllers/api/group_assignment_repos_controller.rb
+++ b/app/controllers/api/group_assignment_repos_controller.rb
@@ -8,7 +8,7 @@ module API
     before_action :set_assignment
 
     def index
-      repos = GroupAssignmentRepo.where(group_assignment: @group_assignment)
+      repos = GroupAssignmentRepo.where(group_assignment: @group_assignment).order(:id)
       paginate json: repos
     end
 


### PR DESCRIPTION
Related to #1667 and #1670 
Fixes https://github.com/education/classroom-assistant/issues/113

Looks like this issue has been affecting Classroom Assistant as well since the API has been returning duplicated assignments/missing assignments because there is no `order` in the query