### PR TITLE
Fixed stafftools search to identify multiple classrooms per org

### DIFF
--- a/app/views/stafftools/organizations/_organization.html.erb
+++ b/app/views/stafftools/organizations/_organization.html.erb
@@ -5,9 +5,10 @@
 
   <div class="col-10 col-md-10 d-flex flex-column">
     <%= link_to stafftools_organization_path(organization.id) do %>
-      <strong class="search-result-title"><%= organization.login %></strong>
+      <strong class="search-result-title"><%= organization.title %></strong>
     <% end %>
 
-    <span class="text-gray css-truncate css-truncate-target"><%= t('views.stafftools.organizations.added') %> <%= local_time_ago(organization.created_at) %></span><br>
+    <span class="text-gray css-truncate css-truncate-target"> <%= organization.login %></span>
+    <span class="text-gray css-truncate css-truncate-target"><%= t('views.stafftools.organizations.added') %> <%= local_time_ago(organization.created_at) %></span>
   </div>
 </div>


### PR DESCRIPTION
When you search for an org in staff tools search:

### Before this change
> <img width="695" alt="screen shot 2018-10-29 at 9 57 01 am" src="https://user-images.githubusercontent.com/11095731/47654394-1971d000-db61-11e8-8975-117bb7a93edd.png">

### After this change
> <img width="693" alt="screen shot 2018-10-29 at 9 56 33 am" src="https://user-images.githubusercontent.com/11095731/47654411-22fb3800-db61-11e8-81a2-3a3d9706d8b9.png">

