### PR TITLE
Organization webhook migration

### DIFF
--- a/db/migrate/20181101185901_create_organization_webhooks.rb
+++ b/db/migrate/20181101185901_create_organization_webhooks.rb
@@ -1,0 +1,12 @@
+class CreateOrganizationWebhooks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :organization_webhooks do |t|
+      t.integer :github_webhook_id
+      t.integer :github_organization_id, null: false
+      t.datetime :last_webhook_recieved
+
+      t.timestamps
+    end
+    add_index :organization_webhooks, :github_webhook_id, unique: true
+  end
+end

--- a/db/migrate/20181101185917_add_organization_webhook_ref_to_organizations.rb
+++ b/db/migrate/20181101185917_add_organization_webhook_ref_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddOrganizationWebhookRefToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :organizations, :organization_webhook, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180918215254) do
+ActiveRecord::Schema.define(version: 20181101185917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,15 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.index ["user_id"], name: "index_invite_statuses_on_user_id"
   end
 
+  create_table "organization_webhooks", force: :cascade do |t|
+    t.integer "github_webhook_id"
+    t.integer "github_organization_id", null: false
+    t.datetime "last_webhook_recieved"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["github_webhook_id"], name: "index_organization_webhooks_on_github_webhook_id", unique: true
+  end
+
   create_table "organizations", id: :serial, force: :cascade do |t|
     t.integer "github_id", null: false
     t.string "title", null: false
@@ -173,8 +182,10 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.boolean "is_webhook_active", default: false
     t.integer "roster_id"
     t.string "github_global_relay_id"
+    t.bigint "organization_webhook_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
     t.index ["github_id"], name: "index_organizations_on_github_id"
+    t.index ["organization_webhook_id"], name: "index_organizations_on_organization_webhook_id"
     t.index ["roster_id"], name: "index_organizations_on_roster_id"
     t.index ["slug"], name: "index_organizations_on_slug"
   end
@@ -236,4 +247,5 @@ ActiveRecord::Schema.define(version: 20180918215254) do
   add_foreign_key "group_invite_statuses", "groups"
   add_foreign_key "invite_statuses", "assignment_invitations"
   add_foreign_key "invite_statuses", "users"
+  add_foreign_key "organizations", "organization_webhooks"
 end


### PR DESCRIPTION
This PR proposes we add a new model named `OrganizationWebhook` which has 2 purposes:
1. keep a record of when the last webhook was received using the `last_webhook_recieved` column 
1. persist and manage an organization's webhook via its `github_webhook_id` column

## Why not add extra columns to the Organization model?
It might be too write heavy on the Organization model if we commit to writing to it every time we get a webhook event.


## What will this look like for multiple classrooms?
![org webhook relationship](https://user-images.githubusercontent.com/11095731/47874772-0c681180-ddeb-11e8-8d91-bb03b1f11446.png)


Part of #1647
Models for this coming in a follow up PR