### PR TITLE
Rename Organization to Classroom: Part 1 The Great Migration

### DIFF
--- a/db/migrate/20181101202221_change_organizations_to_classrooms.rb
+++ b/db/migrate/20181101202221_change_organizations_to_classrooms.rb
@@ -1,0 +1,21 @@
+class ChangeOrganizationsToClassrooms < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :organizations, :classrooms
+    rename_table :organizations_users, :classrooms_users
+
+    # assignments
+    rename_column :assignments, :organization_id, :classroom_id
+
+    # group_assignments
+    rename_column :group_assignments, :organization_id, :classroom_id
+
+    # groupings
+    rename_column :groupings, :organization_id, :classroom_id
+
+    # classrooms_users
+    rename_column :classrooms_users, :organization_id, :classroom_id
+
+    # repo_accesses
+    rename_column :repo_accesses, :organization_id, :classroom_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180918215254) do
+ActiveRecord::Schema.define(version: 20181101202221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 20180918215254) do
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.boolean "public_repo", default: true
     t.string "title", null: false
-    t.integer "organization_id"
+    t.integer "classroom_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "starter_code_repo_id"
@@ -56,9 +56,33 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.string "slug", null: false
     t.boolean "students_are_repo_admins", default: false, null: false
     t.boolean "invitations_enabled", default: true
+    t.index ["classroom_id"], name: "index_assignments_on_classroom_id"
     t.index ["deleted_at"], name: "index_assignments_on_deleted_at"
-    t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["slug"], name: "index_assignments_on_slug"
+  end
+
+  create_table "classrooms", id: :serial, force: :cascade do |t|
+    t.integer "github_id", null: false
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.string "slug", null: false
+    t.integer "webhook_id"
+    t.boolean "is_webhook_active", default: false
+    t.integer "roster_id"
+    t.string "github_global_relay_id"
+    t.index ["deleted_at"], name: "index_classrooms_on_deleted_at"
+    t.index ["github_id"], name: "index_classrooms_on_github_id"
+    t.index ["roster_id"], name: "index_classrooms_on_roster_id"
+    t.index ["slug"], name: "index_classrooms_on_slug"
+  end
+
+  create_table "classrooms_users", id: false, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "classroom_id"
+    t.index ["classroom_id"], name: "index_classrooms_users_on_classroom_id"
+    t.index ["user_id"], name: "index_classrooms_users_on_user_id"
   end
 
   create_table "deadlines", id: :serial, force: :cascade do |t|
@@ -100,7 +124,7 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.boolean "public_repo", default: true
     t.string "title", null: false
     t.integer "grouping_id"
-    t.integer "organization_id"
+    t.integer "classroom_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "starter_code_repo_id"
@@ -110,8 +134,8 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.integer "max_members"
     t.boolean "students_are_repo_admins", default: false, null: false
     t.boolean "invitations_enabled", default: true
+    t.index ["classroom_id"], name: "index_group_assignments_on_classroom_id"
     t.index ["deleted_at"], name: "index_group_assignments_on_deleted_at"
-    t.index ["organization_id"], name: "index_group_assignments_on_organization_id"
     t.index ["slug"], name: "index_group_assignments_on_slug"
   end
 
@@ -127,11 +151,11 @@ ActiveRecord::Schema.define(version: 20180918215254) do
 
   create_table "groupings", id: :serial, force: :cascade do |t|
     t.string "title", null: false
-    t.integer "organization_id"
+    t.integer "classroom_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug", null: false
-    t.index ["organization_id"], name: "index_groupings_on_organization_id"
+    t.index ["classroom_id"], name: "index_groupings_on_classroom_id"
   end
 
   create_table "groups", id: :serial, force: :cascade do |t|
@@ -162,38 +186,14 @@ ActiveRecord::Schema.define(version: 20180918215254) do
     t.index ["user_id"], name: "index_invite_statuses_on_user_id"
   end
 
-  create_table "organizations", id: :serial, force: :cascade do |t|
-    t.integer "github_id", null: false
-    t.string "title", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.string "slug", null: false
-    t.integer "webhook_id"
-    t.boolean "is_webhook_active", default: false
-    t.integer "roster_id"
-    t.string "github_global_relay_id"
-    t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
-    t.index ["github_id"], name: "index_organizations_on_github_id"
-    t.index ["roster_id"], name: "index_organizations_on_roster_id"
-    t.index ["slug"], name: "index_organizations_on_slug"
-  end
-
-  create_table "organizations_users", id: false, force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "organization_id"
-    t.index ["organization_id"], name: "index_organizations_users_on_organization_id"
-    t.index ["user_id"], name: "index_organizations_users_on_user_id"
-  end
-
   create_table "repo_accesses", id: :serial, force: :cascade do |t|
     t.integer "github_team_id"
-    t.integer "organization_id"
+    t.integer "classroom_id"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["classroom_id"], name: "index_repo_accesses_on_classroom_id"
     t.index ["github_team_id"], name: "index_repo_accesses_on_github_team_id", unique: true
-    t.index ["organization_id"], name: "index_repo_accesses_on_organization_id"
     t.index ["user_id"], name: "index_repo_accesses_on_user_id"
   end
 


### PR DESCRIPTION
This PR proposes we rename the `Organizations` table to `Classrooms` since we added multi classroom functionality in https://github.com/education/classroom/pull/1248

This PR is not safe to deploy on its own and will require the `Organization` model in `app/models/organization.rb` to be renamed to `Classroom` (coming in part 2)

This migration must run in total isolation. To run this in total isolation we will have to turn on Heroku's maintenance mode.

Tests will fail on this PR as it doesn't have the model rename mentioned above ☝️