### PR TITLE
Organization webhook model backfill

### DIFF
--- a/app/models/organization/creator.rb
+++ b/app/models/organization/creator.rb
@@ -66,17 +66,18 @@ class Organization
       begin
         github_organization = GitHubOrganization.new(users.first.github_client, github_id)
 
-        org_webhook = OrganizationWebhook.find_or_create_by(github_organization_id: github_id)
+        organization_webhook = OrganizationWebhook.find_or_initialize_by(github_organization_id: github_id)
         webhook_id = create_organization_webhook!
 
-        org_webhook.update!(github_id: webhook_id)
+        organization_webhook.github_id = webhook_id
+        organization_webhook.save!
         organization.update_attributes!(
           github_id: github_id,
           title: title,
           users: users,
           webhook_id: webhook_id,
           github_global_relay_id: github_organization.node_id,
-          organization_webhook: org_webhook
+          organization_webhook: organization_webhook
         )
       rescue ActiveRecord::RecordInvalid => err
         raise Result::Error, err.message

--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -3,7 +3,7 @@
 class OrganizationWebhook < ApplicationRecord
   has_many :organizations
 
-  validates :github_id, uniqueness: true
+  validates :github_id, uniqueness: true, allow_nil: true
 
   validates :github_organization_id, presence:   true
   validates :github_organization_id, uniqueness: true

--- a/lib/tasks/organization_webhook_backfill.rake
+++ b/lib/tasks/organization_webhook_backfill.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+task organization_webhook_backfill: :environment do
+  puts "Backfilling Organizations to belong to a OrganizationWebhook."
+
+  # Record number of organizations updated
+  organizations_updated = 0
+
+  puts "Updating Organizations..."
+
+  Organizations.where(organization_webhook_id: nil).find_in_batches(batch_size: 250) do |organizations|
+    organizations_updated += organizations.length
+    organizations.each do |organization|
+      organization_webhook = OrganizationWebhook.find_or_initialize_by(github_organization_id: organization.github_id)
+      organization_webhook.github_id ||= organization.webhook_id
+      organization_webhook.save!
+      organization.update!(organization_webhook_id: organization_webhook.id)
+    end
+  end
+
+  puts "Done! We backfilled Organizations to belong to a OrganizationWebhook."
+  puts "=> #{organizations_updated} Organizations were updated"
+end

--- a/lib/tasks/organization_webhook_backfill.rake
+++ b/lib/tasks/organization_webhook_backfill.rake
@@ -8,7 +8,7 @@ task organization_webhook_backfill: :environment do
 
   puts "Updating Organizations..."
 
-  Organizations.where(organization_webhook_id: nil).find_in_batches(batch_size: 250) do |organizations|
+  Organization.where(organization_webhook_id: nil).find_in_batches(batch_size: 250) do |organizations|
     organizations_updated += organizations.length
     organizations.each do |organization|
       organization_webhook = OrganizationWebhook.find_or_initialize_by(github_organization_id: organization.github_id)

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OrganizationWebhook, type: :model do
 
   it { should have_many(:organizations) }
 
-  it { should validate_uniqueness_of(:github_id) }
+  it { should validate_uniqueness_of(:github_id).allow_nil }
 
   it { should validate_presence_of(:github_organization_id) }
   it { should validate_uniqueness_of(:github_organization_id) }


### PR DESCRIPTION
## Before reviewing:
- The model migration was introduced in #1692 
- The model was introduced in #1694 

☝️ Review these first

## This PR
This PR proposes a task to backfill `Organizations` to belong to an `OrganizationWebhook`.
The task can be found in `lib/tasks/organization_webhook_backfill.rake`

## Diagram of the relation
![org webhook relationship](https://user-images.githubusercontent.com/11095731/47874772-0c681180-ddeb-11e8-8d91-bb03b1f11446.png)

Part of #1647