### PR TITLE
Adds has_many Users through Organizations to OrganizationWebhook

### DIFF
--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -2,6 +2,7 @@
 
 class OrganizationWebhook < ApplicationRecord
   has_many :organizations
+  has_many :users, through: :organizations
 
   validates :github_id, uniqueness: true, allow_nil: true
 

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe OrganizationWebhook, type: :model do
   end
 
   it { should have_many(:organizations) }
+  it { should have_many(:users).through(:organizations) }
 
   it { should validate_uniqueness_of(:github_id).allow_nil }
 


### PR DESCRIPTION
This PR proposes we add `has_many :users, through: :organizations` to `OrganizationWebhook`.

Part of #1647 
