### PR TITLE
Finds a User's token that has the `admin:org_hook` scope

### DIFF
--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -27,7 +27,7 @@ class OrganizationWebhook < ApplicationRecord
     token = if Rails.env.test?
               users.first&.token
             else
-              user_with_admin_org_hook_scope.sample&.token
+              users_with_admin_org_hook_scope.sample&.token
             end
     raise NoValidTokenError, "No valid token with the `admin:org` hook scope." if token.nil?
     Octokit::Client.new(access_token: token)

--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -9,7 +9,48 @@ class OrganizationWebhook < ApplicationRecord
   validates :github_organization_id, presence:   true
   validates :github_organization_id, uniqueness: true
 
-  def github_organization
-    @github_organization ||= organizations&.first&.github_organization
+  def admin_org_hook_scope_github_client
+    if Rails.env.test?
+      token = users.first.token unless users.first.nil?
+    else
+      token = user_with_admin_org_hook_scope.sample
+    end
+    Octokit::Client.new(access_token: token)
+  end
+
+  private
+
+  # Internal: Find Users that has the `admin:org_hook` scope
+  # for creating the organization webhook.
+  #
+  # Example:
+  #
+  #   users_with_admin_org_hook_scope
+  #   # => [#<User:0x007fd7f0320a30
+  #      id: 1,
+  #      uid: 564113,
+  #      token: "8675309",
+  #      created_at: Sun, 20 Nov 2016 16:29:43 UTC +00:00,
+  #      updated_at: Tue, 22 Nov 2016 03:46:10 UTC +00:00,
+  #      site_admin: true,
+  #      last_active_at: Fri, 25 Nov 2016 03:39:54 UTC +00:00>]
+  #
+  # Returns a User or nil if one could not be found.
+  #
+  # Warning: This could potentially take very long for organizations
+  # of a large size, so invoke cautiously.
+  def users_with_admin_org_hook_scope
+    return @users_with_scope if defined?(@users_with_scope)
+
+    @users_with_scope = []
+
+    users.find_in_batches(batch_size: 100) do |users|
+      users.each do |user|
+        next unless user.github_client_scopes.include?("admin:org_hook")
+        @users_with_scope << user
+      end
+    end
+
+    @users_with_scope
   end
 end

--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -24,10 +24,10 @@ class OrganizationWebhook < ApplicationRecord
   # Warning: This could potentially take very long for organizations
   # of a large size, so invoke cautiously.
   def admin_org_hook_scoped_github_client
-    if Rails.env.test?
-      token = users.first.token unless users.first.nil?
+    token = if Rails.env.test?
+      users.first&.token
     else
-      token = user_with_admin_org_hook_scope.sample&.token
+      user_with_admin_org_hook_scope.sample&.token
     end
     raise NoValidTokenError, "No valid token with the `admin:org` hook scope." if token.nil?
     Octokit::Client.new(access_token: token)

--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -25,10 +25,10 @@ class OrganizationWebhook < ApplicationRecord
   # of a large size, so invoke cautiously.
   def admin_org_hook_scoped_github_client
     token = if Rails.env.test?
-      users.first&.token
-    else
-      user_with_admin_org_hook_scope.sample&.token
-    end
+              users.first&.token
+            else
+              user_with_admin_org_hook_scope.sample&.token
+            end
     raise NoValidTokenError, "No valid token with the `admin:org` hook scope." if token.nil?
     Octokit::Client.new(access_token: token)
   end

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -18,6 +18,29 @@ RSpec.describe OrganizationWebhook, type: :model do
   it { should validate_presence_of(:github_organization_id) }
   it { should validate_uniqueness_of(:github_organization_id) }
 
+
+  describe "#admin_org_hook_scoped_github_client" do
+    context "token is present" do
+      before do
+        allow(subject).to receive_message_chain(:users, :first, :token) { "token" }
+      end
+
+      it "raises a NoValidTokenError" do
+        expect(subject.admin_org_hook_scoped_github_client).to be_a(Octokit::Client)
+      end
+    end
+
+    context "token is nil" do
+      before do
+        allow(subject).to receive_message_chain(:users, :first) { nil }
+      end
+
+      it "raises a NoValidTokenError" do
+        expect { subject.admin_org_hook_scoped_github_client }.to raise_error(described_class::NoValidTokenError)
+      end
+    end
+  end
+
   describe "#users_with_admin_org_hook_scope" do
     context "user with admin_org hook scope exists doesn't exist" do
       before do

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe OrganizationWebhook, type: :model do
   end
 
   describe "#users_with_admin_org_hook_scope" do
-    context "user with admin_org hook scope exists doesn't exist" do
+    context "user with admin_org hook scope doesn't exist" do
       before do
         User.any_instance.stub(:github_client_scopes)
           .and_return([])

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe OrganizationWebhook, type: :model do
         allow(subject).to receive_message_chain(:users, :first, :token) { "token" }
       end
 
-      it "raises a NoValidTokenError" do
+      it "returns a Octokit::Client" do
         expect(subject.admin_org_hook_scoped_github_client).to be_a(Octokit::Client)
       end
     end

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -18,18 +18,26 @@ RSpec.describe OrganizationWebhook, type: :model do
   it { should validate_presence_of(:github_organization_id) }
   it { should validate_uniqueness_of(:github_organization_id) }
 
-  describe "#github_organization" do
-    it "requests a GitHubOrganization" do
-      expect_any_instance_of(Organization).to receive(:github_organization)
-      subject.github_organization
+  describe "#users_with_admin_org_hook_scope" do
+    context "user with admin_org hook scope exists doesn't exist" do
+      before do
+        User.any_instance.stub(:github_client_scopes)
+          .and_return([])
+      end
+
+      it "returns an empty list" do
+        expect(subject.send(:users_with_admin_org_hook_scope)).to be_empty
+      end
     end
 
-    context "has no organizations" do
-      it "returns nil" do
-        expect(subject)
-          .to receive(:organizations)
-          .and_return([])
-        expect(subject.github_organization).to be_nil
+    context "user with admin_org hook scope exists" do
+      before do
+        User.any_instance.stub(:github_client_scopes)
+          .and_return(["admin:org_hook"])
+      end
+
+      it "returns a list with the user" do
+        expect(subject.send(:users_with_admin_org_hook_scope)).to_not be_empty
       end
     end
   end

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe OrganizationWebhook, type: :model do
   it { should validate_presence_of(:github_organization_id) }
   it { should validate_uniqueness_of(:github_organization_id) }
 
-
   describe "#admin_org_hook_scoped_github_client" do
     context "token is present" do
       before do


### PR DESCRIPTION
This PR proposes methods for `OrganizationWebhook` to find User tokens with the `admin:org_hook` scope. These tokens are required to create webhooks for organizations.

In a follow up PR I will make the methods for creating the webhooks using these tokens.

Part of #1647 
> - [ ] move the logic for creating a webhook from the `Organization::Creator` to `GitHubOrganizationWebhook`