### PR TITLE
Admin org hook scope reduced search

### DIFF
--- a/app/models/organization_webhook.rb
+++ b/app/models/organization_webhook.rb
@@ -11,8 +11,8 @@ class OrganizationWebhook < ApplicationRecord
   validates :github_organization_id, presence:   true
   validates :github_organization_id, uniqueness: true
 
-  # External: Finds a User's token that has the `admin:org_hook` scope
-  # for creating the organization webhook.
+  # External: Finds a User token in the same GitHub organization
+  # that has the `admin:org_hook` scope. Used for creating webhooks.
   #
   # organization - the organization to search for users in.
   #
@@ -38,8 +38,8 @@ class OrganizationWebhook < ApplicationRecord
 
   private
 
-  # Internal: Find Users that has the `admin:org_hook` scope
-  # for creating the organization webhook.
+  # Internal: Finds Users in the same GitHub organization
+  # that have the `admin:org_hook` scope.
   #
   # organization - the organization to search for users in.
   #

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe OrganizationWebhook, type: :model do
 
   describe "#users_with_admin_org_hook_scope" do
     context "search scope is OrganizationWebhook" do
-      context "user with admin_org hook scope doesn't exist" do
+      context "user with `admin:org_hook` scope doesn't exist" do
         before do
           User.any_instance.stub(:github_client_scopes)
             .and_return([])
@@ -53,7 +53,7 @@ RSpec.describe OrganizationWebhook, type: :model do
         end
       end
 
-      context "user with admin_org hook scope exists" do
+      context "user with `admin:org_hook` scope exists" do
         before do
           User.any_instance.stub(:github_client_scopes)
             .and_return(["admin:org_hook"])
@@ -67,7 +67,7 @@ RSpec.describe OrganizationWebhook, type: :model do
   end
 
   context "search scope is specific organization" do
-    context "user with admin_org hook scope doesn't exist" do
+    context "user with `admin:org_hook` scope doesn't exist" do
       before do
         User.any_instance.stub(:github_client_scopes)
           .and_return([])
@@ -78,7 +78,7 @@ RSpec.describe OrganizationWebhook, type: :model do
       end
     end
 
-    context "user with admin_org hook scope exists" do
+    context "user with `admin:org_hook` scope exists" do
       before do
         User.any_instance.stub(:github_client_scopes)
           .and_return(["admin:org_hook"])

--- a/spec/models/organization_webhook_spec.rb
+++ b/spec/models/organization_webhook_spec.rb
@@ -41,6 +41,32 @@ RSpec.describe OrganizationWebhook, type: :model do
   end
 
   describe "#users_with_admin_org_hook_scope" do
+    context "search scope is OrganizationWebhook" do
+      context "user with admin_org hook scope doesn't exist" do
+        before do
+          User.any_instance.stub(:github_client_scopes)
+            .and_return([])
+        end
+
+        it "returns an empty list" do
+          expect(subject.send(:users_with_admin_org_hook_scope)).to be_empty
+        end
+      end
+
+      context "user with admin_org hook scope exists" do
+        before do
+          User.any_instance.stub(:github_client_scopes)
+            .and_return(["admin:org_hook"])
+        end
+
+        it "returns a list with the user" do
+          expect(subject.send(:users_with_admin_org_hook_scope)).to_not be_empty
+        end
+      end
+    end
+  end
+
+  context "search scope is specific organization" do
     context "user with admin_org hook scope doesn't exist" do
       before do
         User.any_instance.stub(:github_client_scopes)
@@ -48,7 +74,7 @@ RSpec.describe OrganizationWebhook, type: :model do
       end
 
       it "returns an empty list" do
-        expect(subject.send(:users_with_admin_org_hook_scope)).to be_empty
+        expect(subject.send(:users_with_admin_org_hook_scope, organization)).to be_empty
       end
     end
 
@@ -59,7 +85,7 @@ RSpec.describe OrganizationWebhook, type: :model do
       end
 
       it "returns a list with the user" do
-        expect(subject.send(:users_with_admin_org_hook_scope)).to_not be_empty
+        expect(subject.send(:users_with_admin_org_hook_scope, organization)).to_not be_empty
       end
     end
   end


### PR DESCRIPTION
This PR proposes we add an optional `organization` argument to `admin_org_hook_scoped_github_client` to shrink it's search scope to a single organization. 

Without the reduced search scope, `admin_org_hook_scoped_github_client` will search through all the organizations associated with the same GitHub org ID for users with the `admin:org_hook` scope. This could be very expensive for organizations with multiple classrooms.

Part of #1647 
> - [ ] move the logic for creating a webhook from the `Organization::Creator` to `GitHubOrganizationWebhook`