### PR TITLE
Fix too many redirects bug

### DIFF
--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -9,7 +9,6 @@ class GroupAssignmentInvitationsController < ApplicationController
   layout "layouts/invitations"
 
   before_action :route_based_on_status,                  only: %i[setup successful_invitation]
-  before_action :check_group_not_previous_acceptee,      only: :show
   before_action :check_user_not_group_member,            only: :show
   before_action :check_should_redirect_to_roster_page,   only: :show
   before_action :authorize_group_access,                 only: :accept_invitation
@@ -132,12 +131,6 @@ class GroupAssignmentInvitationsController < ApplicationController
 
     report_invitation_failure
     raise NotAuthorized, "You are not permitted to select this team"
-  end
-
-  def check_group_not_previous_acceptee
-    return unless group.present? && group_assignment_repo.present?
-
-    redirect_to successful_invitation_group_assignment_invitation_path
   end
 
   def check_user_not_group_member

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -249,7 +249,7 @@ class GroupAssignmentInvitationsController < ApplicationController
   helper_method :organization
 
   def repo_ready?
-    return false unless group_assignment_repo.present?
+    return false if group_assignment_repo.blank?
     return false if group_assignment.starter_code? && !group_assignment_repo.github_repository.imported?
     true
   end

--- a/app/models/group_assignment_invitation.rb
+++ b/app/models/group_assignment_invitation.rb
@@ -71,7 +71,6 @@ class GroupAssignmentInvitation < ApplicationRecord
     Group::Creator.perform(title: selected_group_title, grouping: grouping)
   end
 
-  # rubocop:disable MethodLength
   def group_assignment_repo(invitees_group)
     group_assignment_params = { group_assignment: group_assignment, group: invitees_group }
     repo                    = GroupAssignmentRepo.find_by(group_assignment_params)
@@ -84,5 +83,4 @@ class GroupAssignmentInvitation < ApplicationRecord
       Result.pending
     end
   end
-  # rubocop:enable MethodLength
 end

--- a/app/models/group_assignment_invitation.rb
+++ b/app/models/group_assignment_invitation.rb
@@ -75,17 +75,13 @@ class GroupAssignmentInvitation < ApplicationRecord
   def group_assignment_repo(invitees_group)
     group_assignment_params = { group_assignment: group_assignment, group: invitees_group }
     repo                    = GroupAssignmentRepo.find_by(group_assignment_params)
+    invite_status           = status(invitees_group)
 
-    return Result.success(repo) if repo
-
-    if organization.feature_enabled?(:group_import_resiliency)
-      invite_status = status(invitees_group)
-      invite_status.accepted! if invite_status.unaccepted?
-      return Result.pending
+    invite_status.accepted! if invite_status.unaccepted?
+    if repo
+      Result.success(repo)
     else
-      repo = GroupAssignmentRepo.create(group_assignment_params)
-      return Result.success(repo) if repo
-      Result.failed("An error has occurred, please refresh the page and try again.")
+      Result.pending
     end
   end
   # rubocop:enable MethodLength

--- a/spec/controllers/group_assignment_invitations_controller_spec.rb
+++ b/spec/controllers/group_assignment_invitations_controller_spec.rb
@@ -326,29 +326,7 @@ RSpec.describe GroupAssignmentInvitationsController, type: :controller do
 
         it "allows user to join" do
           patch :accept_invitation, params: { id: invitation.key, group: { id: group.id } }
-          expect(group_assignment.group_assignment_repos.count).to eql(1)
           expect(student.repo_accesses.count).to eql(1)
-        end
-      end
-
-      context "github repository with the same name already exists" do
-        let(:group) { create(:group, grouping: grouping, github_team_id: 2_973_107) }
-
-        before do
-          group_assignment_repo = GroupAssignmentRepo.create!(group_assignment: group_assignment, group: group)
-          @original_repository = organization.github_client.repository(group_assignment_repo.github_repo_id)
-          group_assignment_repo.delete
-          patch :accept_invitation, params: { id: invitation.key, group: { id: group.id } }
-        end
-
-        it "creates a new group assignment repo" do
-          expect(group_assignment.group_assignment_repos.count).to eql(1)
-        end
-
-        it "new repository name has expected suffix" do
-          expect(WebMock)
-            .to have_requested(:post, %r{#{github_url("/organizations/")}\d+/repos$})
-            .with(body: /^.*#{@original_repository.name}-1.*$/)
         end
       end
 

--- a/spec/models/group_assignment_invitation_spec.rb
+++ b/spec/models/group_assignment_invitation_spec.rb
@@ -58,19 +58,7 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
 
     subject { create(:group_assignment_invitation, group_assignment: group_assignment) }
 
-    after(:each) do
-      RepoAccess.destroy_all
-      Group.destroy_all
-      GroupAssignmentRepo.destroy_all
-      GroupInviteStatus.destroy_all
-    end
-
     context "success result" do
-      it "success?" do
-        result = subject.redeem_for(student, nil, group_name)
-        expect(result.success?).to be_truthy
-      end
-
       it "returns the GroupAssignmentRepo" do
         result = subject.redeem_for(student, nil, group_name)
         expect(result.group_assignment_repo).to eql(GroupAssignmentRepo.last)
@@ -143,12 +131,12 @@ RSpec.describe GroupAssignmentInvitation, type: :model do
     let(:invitation)   { create(:group_assignment_invitation) }
 
     it "returns a list of invite statuses" do
-      group_invite_status = GroupInviteStatus.create(group: group, group_assignment_invitation: invitation)
+      group_invite_status = create(:group_invite_status, group: group, group_assignment_invitation: invitation)
       expect(invitation.group_invite_statuses).to eq([group_invite_status])
     end
 
     it "on #destroy destroys invite status and not the group" do
-      group_invite_status = GroupInviteStatus.create(group: group, group_assignment_invitation: invitation)
+      group_invite_status = create(:group_invite_status, group: group, group_assignment_invitation: invitation)
       invitation.destroy
       expect { group_invite_status.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect(group.reload.nil?).to be_falsey


### PR DESCRIPTION
## What
This PR proposes the following changes:
* removed the before_action `check_group_not_previous_acceptee` from `group_assignment_invitations_controller.rb`. This before_action was previously solving an edge case before the `group_import_resiliency` changes went into place, but is no longer needed since we now have `route_based_on_status`.
* in `#create_repo` we now check if a pre existing assignment repo is present. If that assignment repo is ready, succeed otherwise retry the repo creation process.

## Note
A lot of dead code still exists behind the `group_import_resiliency` and we must make an issue to clean that up!

Fixes #1704  