### PR TITLE
Added method #in_good_health? to organization model

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -56,6 +56,10 @@ class Organization < ApplicationRecord
     users.count == 1
   end
 
+  def in_good_health?
+    organization_webhook.github_id.present?
+  end
+
   # Check if we are the last Classroom on this GitHub Organization
   def last_classroom_on_org?
     Organization.where(github_id: github_id).length <= 1

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -89,6 +89,38 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe "#in_good_health?" do
+    context "organization_webhook has a github_id" do
+      let(:organization_webhook) do
+        create(
+          :organization_webhook,
+          github_organization_id: subject.github_id,
+          github_id: 1
+        )
+      end
+
+      before do
+        subject.update(organization_webhook: organization_webhook)
+      end
+
+      it "returns true" do
+        expect(subject.in_good_health?).to be_truthy
+      end
+    end
+
+    context "organization_webhook doesn't have a github_id" do
+      let(:organization_webhook) { create(:organization_webhook, github_organization_id: subject.github_id) }
+
+      before do
+        subject.update(organization_webhook: organization_webhook)
+      end
+
+      it "returns false" do
+        expect(subject.in_good_health?).to be_falsey
+      end
+    end
+  end
+
   describe "callbacks" do
     describe "before_destroy" do
       describe "#silently_remove_organization_webhook", :vcr do


### PR DESCRIPTION
## What
This Pr proposes we add the method `#in_good_health?`, which performs a trivial check to see if a an organization has a hook id. This method will be used to prevent users from trying to use classrooms that don't have webhooks (so will invoked a lot).

Part of #1647 
> - [ ] define a method to check if an `Organization` meets all minimum requirements
>   - if webhooks are present and enabled