### PR TITLE
Fetch GitHub Team name for Classroom Assistant

### DIFF
--- a/app/serializers/group_assignment_repo_serializer.rb
+++ b/app/serializers/group_assignment_repo_serializer.rb
@@ -6,7 +6,7 @@ class GroupAssignmentRepoSerializer < ActiveModel::Serializer
   attributes :displayName
 
   def username
-    object.group.title
+    object.group.github_team.name
   end
 
   # rubocop:disable MethodName


### PR DESCRIPTION
Fetch the team name from GitHub everytime we serialize a group assignment repo. This fixes https://github.com/education/classroom-assistant/issues/117