### PR TITLE
Multiple Classrooms per Org UI Tweaks

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -69,7 +69,7 @@ class OrganizationsController < Orgs::Controller
     if current_organization.update_attributes(deleted_at: Time.zone.now)
       DestroyResourceJob.perform_later(current_organization)
 
-      flash[:success] = "Your organization, @#{current_organization.github_organization.login} is being reset"
+      flash[:success] = "Your classroom, @#{current_organization.title} is being deleted"
       redirect_to organizations_path
     else
       render :edit

--- a/app/models/github_organization.rb
+++ b/app/models/github_organization.rb
@@ -62,10 +62,6 @@ class GitHubOrganization < GitHubResource
     end
   end
 
-  def geo_pattern_data_uri
-    @geo_pattern_data_uri ||= GeoPattern.generate(id, color: "#5fb27b").to_data_uri
-  end
-
   def github_avatar_url(size = 40)
     "#{avatar_url}&size=#{size}"
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -60,6 +60,10 @@ class Organization < ApplicationRecord
     organization_webhook.github_id.present?
   end
 
+  def geo_pattern_data_uri
+    @geo_pattern_data_uri ||= GeoPattern.generate(id, color: "#5fb27b").to_data_uri
+  end
+
   # Check if we are the last Classroom on this GitHub Organization
   def last_classroom_on_org?
     Organization.where(github_id: github_id).length <= 1

--- a/app/views/organizations/_organization_banner.html.erb
+++ b/app/views/organizations/_organization_banner.html.erb
@@ -1,7 +1,7 @@
 <% organization = @organization || current_organization %>
 
 <% content_for :organization_banner do %>
-  <div class="organization-banner" style="background-image: <%= organization.github_organization.geo_pattern_data_uri %>">
+  <div class="organization-banner" style="background-image: <%= organization.geo_pattern_data_uri %>">
     <div class="container-lg">
       <%= link_to t('views.organizations.manage_classroom'), edit_organization_path(organization), class: 'btn btn-primary' %>
       <h1 class="organization-name"><%= link_to organization.title, organization %></h1>

--- a/app/views/organizations/_organization_invitation_banner.html.erb
+++ b/app/views/organizations/_organization_invitation_banner.html.erb
@@ -1,5 +1,5 @@
 <% content_for :organization_invitation_banner do %>
-  <div class="organization-banner" style="background-image: <%= organization.github_organization.geo_pattern_data_uri %>">
+  <div class="organization-banner" style="background-image: <%= organization.geo_pattern_data_uri %>">
     <div class="container-lg">
       <h1 class="organization-name"><%= organization.title %></h1>
       <p class="organization-login"><%= link_to "@#{organization.github_organization.login}", organization.github_organization.html_url %></p>


### PR DESCRIPTION
Updated the flash banner message when an org is deleted and moved the background generation for each Classroom page onto the `Organization` model from `GitHub_Organization` (also allows us for more UI upgrades coming in the future 😄)