### PR TITLE
Remove Pre-release badge for Multiple classrooms

### DIFF
--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,7 +1,6 @@
 <div class="site-content">
   <div class="site-content-cap">
     <h2 class="site-content-heading d-inline-flex"><%= t('views.organizations.select_organization') %></h2>
-    <%= prerelease_badge :multiple_classrooms_per_org, public_name: "Creating multiple Classrooms in a GitHub Organization", feedback_url: "https://goo.gl/forms/nY9Z35Oa6Vu7BWvz2", additional_classes: "float-right mt-2"%>
   </div>
 
   <div class="site-content-body">


### PR DESCRIPTION
Removed the pre-release badge for feedback on multiple classrooms per org since we've shipped to the public!