### PR TITLE
Drop Ticker Stat Schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -224,13 +224,6 @@ ActiveRecord::Schema.define(version: 20181101185917) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "ticker_stats", force: :cascade do |t|
-    t.integer "user_count"
-    t.integer "repo_count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "users", id: :serial, force: :cascade do |t|
     t.integer "uid", null: false
     t.string "token", null: false


### PR DESCRIPTION
I brought in the `ticker_stats` table into `schema.rb` inadvertently when we were working on the Classroom Assistant launch. At the time we were planning on adding a repository ticker visualization to the Classroom homepage which has since been scrapped. The actual migration file was never committed so rails automatically deletes this snippet every time the app is run locally right now.