### PR TITLE
Fix header styling on assignment invitations

### DIFF
--- a/app/views/shared/_invitation_header.html.erb
+++ b/app/views/shared/_invitation_header.html.erb
@@ -1,44 +1,42 @@
 <header class="site-header">
-  <div class="container-lg">
-    <%= image_tag('logo@2x.png', :class => 'site-logo', :alt => 'GitHub for Classrooms') %>
+  <div class="container-lg d-md-flex flex-items-center flex-justify-between p-responsive py-3">
+    <%= link_to(image_tag('logo@2x.png', class: 'site-logo', alt: 'GitHub for Classrooms'), (logged_in? ? organizations_path : root_path), class: 'd-block text-center mb-2 mb-md-0') %>
 
-    <nav class="site-nav">
-      <ul>
-        <li>
-          <%= link_to "GitHub Education", 'https://education.github.com', target: '_blank' %>
-        </li>
+    <nav class="site-nav d-sm-flex flex-wrap flex-content-start flex-justify-center">
+      <%= link_to "GitHub Education", 'https://education.github.com', target: '_blank', class: 'd-block text-center mx-sm-3 mb-2 mb-sm-0' %>
 
-        <li>
+      <ul class="list-style-none d-flex flex-justify-center">
+        <li class="mx-3">
           <%= link_to 'https://education.github.com/forum', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.community_discussion') do %>
             <%= octicon 'comment-discussion' %>
           <% end %>
         </li>
 
-        <li>
+        <li class="mx-3">
           <%= link_to videos_path, class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.video_tutorials') do %>
             <%= octicon 'device-camera-video' %>
           <% end %>
         </li>
 
-        <li>
+        <li class="mx-3">
           <%= link_to 'https://github.com/education/classroom/issues/new?template=bug_report.md', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.report_bug') do %>
             <%= octicon 'bug' %>
           <% end %>
         </li>
 
-        <li>
+        <li class="mx-3">
           <%= link_to 'https://github.com/education/classroom/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc', target: '_blank', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.changelog') do %>
             <%= octicon 'git-pull-request' %>
           <% end %>
         </li>
 
-        <li>
+        <li class="mx-3">
           <%= link_to current_user.github_user.html_url, class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.view_gh_profile') do %>
             <%= image_tag current_user.github_user.github_avatar_url(40), class: 'avatar', alt: "@#{current_user.github_user.login}", height: 20, width: 20 %>
           <% end %>
         </li>
 
-        <li>
+        <li class="ml-3">
           <%= link_to logout_path, method: :post, class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.sign_out') do %>
             <%= octicon 'sign-out' %>
           <% end %>


### PR DESCRIPTION
## What

Fixes #1830.

Looks like we have a separate header partial for the invitations view that is very similar to the main header partial. I simply copied the styling from the [main header](https://github.com/education/classroom/blob/master/app/views/shared/_header.html.erb) to this one.

### Before

![image](https://user-images.githubusercontent.com/1490434/57725694-bb6b8c80-765b-11e9-992b-6f81883181a1.png)


### After

![image](https://user-images.githubusercontent.com/1490434/57725596-895a2a80-765b-11e9-8900-548ee48f830c.png)