### PR TITLE
Added a flash message to direct long import times to GitHub support

### DIFF
--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -1,6 +1,7 @@
 (function() {
   var POLL_INTERVAL = 1000;
   var PROGRESS_HALF_LIFE = 1000;
+  var contact_support_message = "\nIf importing starter code takes a very long time, please <a href=\"https://github.com/contact\">contact GitHub support</a>.";
   var progress_asymptotically,
     create_flash_container,
     display_progress,
@@ -150,7 +151,6 @@
   };
 
   display_progress = function(progress) {
-    flash_progress(progress);
     var create_repo_progress_indicator = $("#create-repo-progress");
     var import_repo_progress_indicator = $("#import-repo-progress");
     switch(progress.status) {
@@ -173,7 +173,7 @@
         hide_retry_button();
         break;
       case "importing_starter_code":
-        flash_text("If importing starter code takes a very long time, please <a href=\"https://github.com/contact\">contact GitHub support</a>.");
+        progress.text = progress.text ? progress.text + contact_support_message : contact_support_message;
         indicate_completion(create_repo_progress_indicator);
         indicate_in_progress(import_repo_progress_indicator);
         set_progress(create_repo_progress_indicator, 100);
@@ -211,6 +211,7 @@
         setTimeout(show_success, 500);
         break;
     }
+    flash_progress(progress);
   };
 
   wrap_in_parapgraph = function(text) {

--- a/app/assets/javascripts/setup.js
+++ b/app/assets/javascripts/setup.js
@@ -150,6 +150,7 @@
   };
 
   display_progress = function(progress) {
+    flash_progress(progress);
     var create_repo_progress_indicator = $("#create-repo-progress");
     var import_repo_progress_indicator = $("#import-repo-progress");
     switch(progress.status) {
@@ -172,6 +173,7 @@
         hide_retry_button();
         break;
       case "importing_starter_code":
+        flash_text("If importing starter code takes a very long time, please <a href=\"https://github.com/contact\">contact GitHub support</a>.");
         indicate_completion(create_repo_progress_indicator);
         indicate_in_progress(import_repo_progress_indicator);
         set_progress(create_repo_progress_indicator, 100);
@@ -209,7 +211,6 @@
         setTimeout(show_success, 500);
         break;
     }
-    flash_progress(progress);
   };
 
   wrap_in_parapgraph = function(text) {
@@ -225,6 +226,7 @@
       flash_text(wrap_in_parapgraph(progress.text));
     } else {
       $("#flash-messages").empty();
+      create_flash_container();
     }
   };
 


### PR DESCRIPTION
## What
This PR proposes we add a new flash message which appears when importing starter code:
![](https://user-images.githubusercontent.com/11095731/57803133-a3f8d600-7725-11e9-9e5e-07fb130c3747.png)

The flash message says:
> _"If importing starter code takes a very long time, please [contact GitHub Support](https://github.com/contact)."_

## Motivation
Whenever the source importer experiences slow import times, students and teachers flock to the [education/classroom](https://github.com/education/classroom) project to create [issues](https://github.com/education/classroom/issues?utf8=✓&q=is%3Aissue+code+import+). Since the source import API is maintained by GitHub.com, contacting GitHub support would be more desirable, since support is better equipped to address these situations. 