### PR TITLE
Link to issues page

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
           </li>
 
           <li class="mx-3">
-            <%= link_to 'https://github.com/education/classroom/issues/new?template=bug_report.md', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.report_bug') do %>
+            <%= link_to 'https://github.com/education/classroom/issues', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.report_bug') do %>
               <%= octicon 'bug' %>
             <% end %>
           </li>

--- a/app/views/shared/_invitation_header.html.erb
+++ b/app/views/shared/_invitation_header.html.erb
@@ -19,7 +19,7 @@
         </li>
 
         <li class="mx-3">
-          <%= link_to 'https://github.com/education/classroom/issues/new?template=bug_report.md', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.report_bug') do %>
+          <%= link_to 'https://github.com/education/classroom/issues', class: 'tooltipped tooltipped-s', 'aria-label' => t('views.shared.report_bug') do %>
             <%= octicon 'bug' %>
           <% end %>
         </li>


### PR DESCRIPTION
## What ✨ 

![Screen Shot 2019-05-29 at 10 50 41 AM](https://user-images.githubusercontent.com/11095731/58567123-c861b180-81ff-11e9-8366-cacfa04d0086.png)

* Previously the link would take you page where you draft a new bug issue: https://github.com/education/classroom/issues/new?template=bug_report.md
* Now the link would take you to the page where you can see the issues board: https://github.com/education/classroom/issues

## Why 
By bringing future bug reporters to the issues board first, they will be more likely to see if the issue they are experiencing already exists. This will hopefully reduce the number of duplicate issues.