### PR TITLE
Fix disabled Download Repositories button for assignments with rosters

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -30,6 +30,11 @@ class AssignmentsController < ApplicationController
   # rubocop:disable MethodLength
   # rubocop:disable Metrics/AbcSize
   def show
+    @assignment_repos = AssignmentRepo
+        .where(assignment: @assignment)
+        .order(:id)
+        .page(params[:page])
+
     if @organization.roster
       @roster_entries = @organization.roster.roster_entries
         .order(:id)
@@ -40,11 +45,6 @@ class AssignmentsController < ApplicationController
         .where(assignment: @assignment, user: @unlinked_users)
         .order(:id)
         .page(params[:unlinked_accounts_page])
-    else
-      @assignment_repos = AssignmentRepo
-        .where(assignment: @assignment)
-        .order(:id)
-        .page(params[:page])
     end
   end
   # rubocop:enable MethodLength

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -31,21 +31,20 @@ class AssignmentsController < ApplicationController
   # rubocop:disable Metrics/AbcSize
   def show
     @assignment_repos = AssignmentRepo
-        .where(assignment: @assignment)
-        .order(:id)
-        .page(params[:page])
+      .where(assignment: @assignment)
+      .order(:id)
+      .page(params[:page])
+    return unless @organization.roster
 
-    if @organization.roster
-      @roster_entries = @organization.roster.roster_entries
-        .order(:id)
-        .page(params[:students_page])
-        .order_for_view(@assignment)
+    @roster_entries = @organization.roster.roster_entries
+      .order(:id)
+      .page(params[:students_page])
+      .order_for_view(@assignment)
 
-      @unlinked_user_repos = AssignmentRepo
-        .where(assignment: @assignment, user: @unlinked_users)
-        .order(:id)
-        .page(params[:unlinked_accounts_page])
-    end
+    @unlinked_user_repos = AssignmentRepo
+      .where(assignment: @assignment, user: @unlinked_users)
+      .order(:id)
+      .page(params[:unlinked_accounts_page])
   end
   # rubocop:enable MethodLength
   # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
I ran into the bug we had seen earlier in #1657 again where the Download Repositories button was getting disabled for some assignments even when the assignment had repos to download. 

The problem was that the variable `@assignment_repos` was only getting defined by the controller when the assignment had a roster. When we checked if there were any assignment repos (`@assignment_repos.present?`), it returned false every time for any assignment with a roster. 

This is a pretty simple fix so I think I'm going to go ahead and merge it in so people don't hit the issue over the week

cc @BenEmdon 
Screenshot of an affected assignment with a repository:
![Screen Shot 2019-06-01 at 9 55 09 PM](https://user-images.githubusercontent.com/7866060/58751116-fc66fc00-84b7-11e9-9f59-28518450382d.png)
