### PR TITLE
Add a progress bar to OrganizationWebhookHealthService

### DIFF
--- a/spec/services/organization_webhook_health_service_spec.rb
+++ b/spec/services/organization_webhook_health_service_spec.rb
@@ -37,9 +37,9 @@ describe OrganizationWebhookHealthService do
         organization_webhooks
       end
 
-      it "invokes OrganizationWebhook.where.find_in_batches" do
+      it "invokes OrganizationWebhook.where(github_id: nil)" do
         expect(OrganizationWebhook)
-          .to receive_message_chain(:where, :find_in_batches) { nil }
+          .to receive(:where).with(github_id: nil).twice.and_return(OrganizationWebhook.where(github_id: nil))
         subject.perform
       end
 
@@ -91,9 +91,9 @@ describe OrganizationWebhookHealthService do
         organization_webhooks
       end
 
-      it "invokes OrganizationWebhook.find_in_batches" do
+      it "OrganizationWebhook does not receive :where" do
         expect(OrganizationWebhook)
-          .to receive(:find_in_batches)
+          .to_not receive(:where)
         subject.perform
       end
 


### PR DESCRIPTION
## What
Adds a progress bar to `OrganizationWebhookHealthService`:
```
➜  rake organization_webhook_health_migration:migrate_all
Iterating over OrganizationWebhooks: Time: 00:00:00 Time: 00:00:00 2/2 (100%) 0 |=============================================================|

Organization Webhook Health Service Results
–––––––––––––––––––––––––––––––––––––––––––
Success count: 2
Errored organization webhooks:
{}
```


