### PR TITLE
Avoid loading of all assignments objects multiple times when transferring assignments to new user.

### DIFF
--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -29,11 +29,11 @@ class OrganizationEventJob < ApplicationJob
   end
 
   def user_owns_assignments?
-    @organization.assignments.where(creator_id: @user.id).count.positive?
+    @organization.assignments.where(creator_id: @user.id).any?
   end
 
   def user_owns_group_assignments?
-    @organization.group_assignments.where(creator_id: @user.id).positive?
+    @organization.group_assignments.where(creator_id: @user.id).any?
   end
 
   def transfer_assignments

--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -25,20 +25,20 @@ class OrganizationEventJob < ApplicationJob
   # rubocop:enable Metrics/AbcSize
 
   def user_owns_any_assignments?
-     user_owns_assignments? || user_owns_group_assignments?
+    user_owns_assignments? || user_owns_group_assignments?
   end
 
   def user_owns_assignments?
-    @organization.assignments.where(creator_id: @user.id).count > 0
+    @organization.assignments.where(creator_id: @user.id).count.positive?
   end
 
   def user_owns_group_assignments?
-    @organization.group_assignments.where(creator_id: @user.id).count > 0
+    @organization.group_assignments.where(creator_id: @user.id).positive?
   end
 
   def transfer_assignments
     new_owner = @organization.users.where.not(id: @user.id).first
-    all_assignments_of_user = @organization.all_assignments.select{ |assignment| assignment.creator_id == @user.id }
+    all_assignments_of_user = @organization.all_assignments.select { |assignment| assignment.creator_id == @user.id }
     all_assignments_of_user.map do |assignment|
       assignment.update(creator_id: new_owner.id)
     end


### PR DESCRIPTION

## What

In `OrganizationEventJob` whenever we transfer assignments from one user to other, in order to check the creator we load all the assignments. This PR is a small optimization to not load these objects and use the `.count` query for the same purpose. It also updates the transfer assignments to first select all assignments of the user, and then update them instead of iterating over all assignments.