### PR TITLE
Add new service to transfer assignments, removes duplicate code

### DIFF
--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -29,11 +29,11 @@ class OrganizationEventJob < ApplicationJob
   end
 
   def user_owns_assignments?
-    @organization.assignments.where(creator_id: @user.id).count.positive?
+    @organization.assignments.where(creator_id: @user.id).any?
   end
 
   def user_owns_group_assignments?
-    @organization.group_assignments.where(creator_id: @user.id).positive?
+    @organization.group_assignments.where(creator_id: @user.id).any?
   end
 
   def transfer_assignments

--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -25,20 +25,20 @@ class OrganizationEventJob < ApplicationJob
   # rubocop:enable Metrics/AbcSize
 
   def user_owns_any_assignments?
-     user_owns_assignments? || user_owns_group_assignments?
+    user_owns_assignments? || user_owns_group_assignments?
   end
 
   def user_owns_assignments?
-    @organization.assignments.where(creator_id: @user.id).count > 0
+    @organization.assignments.where(creator_id: @user.id).count.positive?
   end
 
   def user_owns_group_assignments?
-    @organization.group_assignments.where(creator_id: @user.id).count > 0
+    @organization.group_assignments.where(creator_id: @user.id).positive?
   end
 
   def transfer_assignments
     new_owner = @organization.users.where.not(id: @user.id).first
-    all_assignments_of_user = @organization.all_assignments.select{ |assignment| assignment.creator_id == @user.id }
+    all_assignments_of_user = @organization.all_assignments.select { |assignment| assignment.creator_id == @user.id }
     all_assignments_of_user.map do |assignment|
       assignment.update(creator_id: new_owner.id)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,10 +59,6 @@ class User < ApplicationRecord
     site_admin
   end
 
-  def owns_all_assignments_for?(organization)
-    organization.all_assignments.map(&:creator_id).include? id
-  end
-
   def api_token(exp = 5.minutes.from_now)
     MessageVerifier.encode({ user_id: id }, exp)
   end

--- a/app/services/transfer_assignments_service.rb
+++ b/app/services/transfer_assignments_service.rb
@@ -10,7 +10,7 @@ class TransferAssignmentsService
 
   def transfer
     return false unless user_owns_any_assignments?
-    all_assignments_of_user = organization.all_assignments.select do |assignment| 
+    all_assignments_of_user = organization.all_assignments.select do |assignment|
       assignment.creator_id == old_user.id
     end
     all_assignments_of_user.map do |assignment|
@@ -19,6 +19,7 @@ class TransferAssignmentsService
   end
 
   private
+
   def user_owns_any_assignments?
     user_owns_assignments? || user_owns_group_assignments?
   end
@@ -30,5 +31,4 @@ class TransferAssignmentsService
   def user_owns_group_assignments?
     organization.group_assignments.where(creator_id: old_user.id).any?
   end
-
 end

--- a/app/services/transfer_assignments_service.rb
+++ b/app/services/transfer_assignments_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class TransferAssignmentsService
+  attr_accessor :organization, :old_user, :new_user
+  def initialize(organization, old_user, new_user = nil)
+    @organization = organization
+    @old_user = old_user
+    @new_user = new_user || @organization.users.where.not(id: old_user.id).first
+  end
+
+  def transfer
+    return false unless user_owns_any_assignments?
+    all_assignments_of_user = organization.all_assignments.select do |assignment| 
+      assignment.creator_id == old_user.id
+    end
+    all_assignments_of_user.map do |assignment|
+      assignment.update(creator_id: new_user.id)
+    end
+  end
+
+  private
+  def user_owns_any_assignments?
+    user_owns_assignments? || user_owns_group_assignments?
+  end
+
+  def user_owns_assignments?
+    organization.assignments.where(creator_id: old_user.id).any?
+  end
+
+  def user_owns_group_assignments?
+    organization.group_assignments.where(creator_id: old_user.id).any?
+  end
+
+end

--- a/app/services/transfer_assignments_service.rb
+++ b/app/services/transfer_assignments_service.rb
@@ -2,6 +2,7 @@
 
 class TransferAssignmentsService
   attr_accessor :organization, :old_user, :new_user
+
   def initialize(organization, old_user, new_user = nil)
     @organization = organization
     @old_user = old_user
@@ -10,10 +11,8 @@ class TransferAssignmentsService
 
   def transfer
     return false unless user_owns_any_assignments?
-    all_assignments_of_user = organization.all_assignments.select do |assignment|
-      assignment.creator_id == old_user.id
-    end
-    all_assignments_of_user.map do |assignment|
+    organization.all_assignments.each do |assignment|
+      next unless assignment.creator_id == old_user.id
       assignment.update(creator_id: new_user.id)
     end
   end

--- a/spec/services/transfer_assignments_service_spec.rb
+++ b/spec/services/transfer_assignments_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TransferAssignmentsService do
+  let(:organization) { classroom_org }
+  let(:old_user) { classroom_teacher }
+  let(:new_user) { create(:user) }
+  before(:each) do
+    organization.users << new_user
+    organization.save
+  end
+  context "when teacher owns no assignments" do
+    let(:transfer_assignment_service) { TransferAssignmentsService.new(organization, old_user) }
+    it "is expected to return false" do
+      expect(transfer_assignment_service.transfer).to be_falsey
+    end
+  end
+
+  context "when teacher owns individual assignments" do
+    it "is expected to transfer assignments to random new user" do
+      assignment = create(:assignment, organization: organization, creator: old_user)
+      TransferAssignmentsService.new(organization,old_user).transfer
+      assignment.reload
+      expect(assignment.creator_id).not_to eq(old_user.id)
+    end
+
+    it "is expected to transfer assignments to specified new user" do
+      assignment = create(:assignment, organization: organization, creator: old_user)
+      TransferAssignmentsService.new(organization, old_user, new_user).transfer
+      assignment.reload
+      expect(assignment.creator_id).to eq(new_user.id)
+    end
+  end
+  context "when teacher owns group assignments" do
+    it "is expected to transfer group assignments to random new user" do
+      assignment = create(:group_assignment, organization: organization, creator: old_user)
+      TransferAssignmentsService.new(organization,old_user).transfer
+      assignment.reload
+      expect(assignment.creator_id).not_to eq(old_user.id)
+    end
+
+    it "is expected to transfer group assignments to specified new user" do
+      assignment = create(:group_assignment, organization: organization, creator: old_user)
+      TransferAssignmentsService.new(organization, old_user, new_user).transfer
+      assignment.reload
+      expect(assignment.creator_id).to eq(new_user.id)
+    end
+  end
+end

--- a/spec/services/transfer_assignments_service_spec.rb
+++ b/spec/services/transfer_assignments_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe TransferAssignmentsService do
   let(:organization) { classroom_org }
@@ -20,7 +20,7 @@ describe TransferAssignmentsService do
   context "when teacher owns individual assignments" do
     it "is expected to transfer assignments to random new user" do
       assignment = create(:assignment, organization: organization, creator: old_user)
-      TransferAssignmentsService.new(organization,old_user).transfer
+      TransferAssignmentsService.new(organization, old_user).transfer
       assignment.reload
       expect(assignment.creator_id).not_to eq(old_user.id)
     end
@@ -35,7 +35,7 @@ describe TransferAssignmentsService do
   context "when teacher owns group assignments" do
     it "is expected to transfer group assignments to random new user" do
       assignment = create(:group_assignment, organization: organization, creator: old_user)
-      TransferAssignmentsService.new(organization,old_user).transfer
+      TransferAssignmentsService.new(organization, old_user).transfer
       assignment.reload
       expect(assignment.creator_id).not_to eq(old_user.id)
     end

--- a/spec/services/transfer_assignments_service_spec.rb
+++ b/spec/services/transfer_assignments_service_spec.rb
@@ -6,10 +6,12 @@ describe TransferAssignmentsService do
   let(:organization) { classroom_org }
   let(:old_user) { classroom_teacher }
   let(:new_user) { create(:user) }
+
   before(:each) do
     organization.users << new_user
     organization.save
   end
+
   context "when teacher owns no assignments" do
     let(:transfer_assignment_service) { TransferAssignmentsService.new(organization, old_user) }
     it "is expected to return false" do
@@ -32,6 +34,7 @@ describe TransferAssignmentsService do
       expect(assignment.creator_id).to eq(new_user.id)
     end
   end
+
   context "when teacher owns group assignments" do
     it "is expected to transfer group assignments to random new user" do
       assignment = create(:group_assignment, organization: organization, creator: old_user)


### PR DESCRIPTION
## What

We had duplicate code for transferring assignments from one admin to other. So, in this PR I have created a service `TransferAssignmentsService` which does the transfer process and is called instead of the duplicate code.

P.S. I discovered this when working on #1864 and hence closing the original PR in favor of this.

