### PR TITLE
Move assignment_repos relation helper from controller to RosterEntry model

### DIFF
--- a/app/controllers/orgs/roster_entries_controller.rb
+++ b/app/controllers/orgs/roster_entries_controller.rb
@@ -61,7 +61,7 @@ module Orgs
     end
 
     def find_assignment_repo
-      current_assignment.repos.find_by(user: current_roster_entry.user)
+      current_roster_entry.assignment_repos.find_by(assignment: current_assignment)
     end
 
     def find_current_assignment_repo

--- a/app/controllers/orgs/roster_entries_controller.rb
+++ b/app/controllers/orgs/roster_entries_controller.rb
@@ -61,7 +61,9 @@ module Orgs
     end
 
     def find_assignment_repo
-      current_roster_entry.assignment_repos.find_by(assignment: current_assignment)
+      current_roster_entry
+        .assignment_repos(organization_id: current_assignment.organization_id)
+        .find_by(assignment: current_assignment)
     end
 
     def find_current_assignment_repo

--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -5,6 +5,8 @@ class RosterEntry < ApplicationRecord
   belongs_to :roster
   belongs_to :user, optional: true
 
+  has_many :assignment_repos, primary_key: :user_id, foreign_key: :user_id
+
   validates :identifier, presence: true
   validates :roster,     presence: true
 

--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -5,12 +5,17 @@ class RosterEntry < ApplicationRecord
   belongs_to :roster
   belongs_to :user, optional: true
 
-  has_many :assignment_repos, primary_key: :user_id, foreign_key: :user_id
-
   validates :identifier, presence: true
   validates :roster,     presence: true
 
   before_create :validate_identifiers_are_unique_to_roster
+
+  def assignment_repos(organization_id: nil)
+    AssignmentRepo
+      .joins(:assignment)
+      .where(user: user_id)
+      .where(assignments: { organization_id: organization_id })
+  end
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
   def self.to_csv(user_to_group_map = {})


### PR DESCRIPTION
## What
Currently, `RosterEntriesController` has some helper methods regarding navigating model relationships in it that could benefit from being moved to the model level rather than being kept purely within the controller. One of these best candidates is the `assignment_repo` controller helper method.

Now, given an instance of a `RosterEntry`, its `assignment_repos` may be easily accessed anywhere, not just from within `RosterEntriesController`.