### PR TITLE
Migration for max_teams in group assignments

### DIFF
--- a/db/migrate/20190618173308_add_max_teams_to_group_assignments.rb
+++ b/db/migrate/20190618173308_add_max_teams_to_group_assignments.rb
@@ -1,0 +1,5 @@
+class AddMaxTeamsToGroupAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :group_assignments, :max_teams, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190601200321) do
+ActiveRecord::Schema.define(version: 20190618173308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20190601200321) do
     t.integer "max_members"
     t.boolean "students_are_repo_admins", default: false, null: false
     t.boolean "invitations_enabled", default: true
+    t.integer "max_teams"
     t.index ["deleted_at"], name: "index_group_assignments_on_deleted_at"
     t.index ["organization_id"], name: "index_group_assignments_on_organization_id"
     t.index ["slug"], name: "index_group_assignments_on_slug"


### PR DESCRIPTION
## What
This migration is required for #1876. It adds the `max_teams` column to `GroupAssignments`, allowing teachers to set the maximum amount of teams allowed in a group assignment.
