### PR TITLE
Fix spelling mistake in assignment view

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -14,7 +14,7 @@
             <h2 class="site-content-heading">
               <%= @assignment.title %>
             </h2>
-            <p class="assignment-type text-gray">Individual assigment
+            <p class="assignment-type text-gray">Individual assignment
               <% if @assignment.deadline %>
                 <% if @assignment.deadline.passed? %>
                   - Deadline Passed


### PR DESCRIPTION
## What
"assignment" has been misspelled as "assigment" on the assignment page for 2 years 🤔