### PR TITLE
Add linter to test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -37,4 +37,5 @@ else
   bin/rspec
 fi
 
+echo "===> Running linter..."
 script/linter

--- a/script/test
+++ b/script/test
@@ -36,3 +36,5 @@ if [ -n "$1" ]; then
 else
   bin/rspec
 fi
+
+script/linter


### PR DESCRIPTION
## What
This PR makes the test script (`script/test`) run the linter script.

It's very easy to forget to run the linter after running the tests. I think we'd all like to catch these linter issues before pushing!
