### PR TITLE
MembershipEventJob: add condition to check if repo_access is present before deleting

### DIFF
--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -4,6 +4,7 @@
 class MembershipEventJob < ApplicationJob
   queue_as :github_event
 
+  # rubocop:disable AbcSize
   def perform(payload_body)
     return true unless payload_body["action"] == "removed"
 
@@ -16,6 +17,9 @@ class MembershipEventJob < ApplicationJob
     return true unless group.present? && user.present?
 
     repo_access = group.repo_accesses.find_by(user_id: user.id)
+
+    return true if repo_access.blank?
     group.repo_accesses.delete(repo_access)
   end
+  # rubocop:enable AbcSize
 end

--- a/spec/jobs/membership_event_job_spec.rb
+++ b/spec/jobs/membership_event_job_spec.rb
@@ -28,5 +28,22 @@ RSpec.describe MembershipEventJob, type: :job do
 
       expect(group.repo_accesses.find_by(user_id: student.id)).to be_nil
     end
+
+    it "returns early if user not found" do
+      allow(payload).to receive(:dig).with("member", "id").and_return(nil)
+      allow(payload).to receive(:dig).with("team", "id").and_return(:default)
+      expect(MembershipEventJob.perform_now(payload)).to be true
+    end
+
+    it "returns early if group not found" do
+      allow(payload).to receive(:dig).with("member", "id").and_return(:default)
+      allow(payload).to receive(:dig).with("team", "id").and_return(nil)
+      expect(MembershipEventJob.perform_now(payload)).to be true
+    end
+
+    it "returns early if repo_access not found" do
+      allow_any_instance_of(Group).to receive_message_chain("repo_accesses.find_by").and_return(nil)
+      expect(MembershipEventJob.perform_now(payload)).to be true
+    end
   end
 end


### PR DESCRIPTION


## What
Adds a condition in MembershipEventJob to check if repo_access is present before deleting it. This fixes #1898 and will reduce the backlog of retries in `sidekiq`.
