### PR TITLE
Better error reporting on group assignment repo creator

### DIFF
--- a/app/models/group_assignment_repo/creator.rb
+++ b/app/models/group_assignment_repo/creator.rb
@@ -57,7 +57,7 @@ class GroupAssignmentRepo
         group_assignment_repo.save!
       rescue ActiveRecord::RecordInvalid => error
         Rails.logger.warn(error.message)
-        raise Result::Error, DEFAULT_ERROR_MESSAGE
+        raise Result::Error.new DEFAULT_ERROR_MESSAGE, error.message
       end
 
       GitHubClassroom.statsd.increment("v2_group_exercise_repo.create.success")
@@ -94,8 +94,8 @@ class GroupAssignmentRepo
         private: group_assignment.private?,
         description: "#{repository_name} created by GitHub Classroom"
       )
-    rescue GitHub::Error
-      raise Result::Error, REPOSITORY_CREATION_FAILED
+    rescue GitHub::Error => error
+      raise Result::Error.new REPOSITORY_CREATION_FAILED, error.message
     end
 
     def add_team_to_github_repository!(github_repository_id)
@@ -103,8 +103,8 @@ class GroupAssignmentRepo
       github_team       = GitHubTeam.new(organization.github_client, group.github_team_id)
 
       github_team.add_team_repository(github_repository.full_name, repository_permissions)
-    rescue GitHub::Error
-      raise Result::Error, REPOSITORY_TEAM_ADDITION_FAILED
+    rescue GitHub::Error => error
+      raise Result::Error.new REPOSITORY_TEAM_ADDITION_FAILED, error.message
     end
 
     def push_starter_code!(github_repository_id)
@@ -114,8 +114,8 @@ class GroupAssignmentRepo
       starter_code_repository = GitHubRepository.new(client, starter_code_repo_id)
 
       assignment_repository.get_starter_code_from(starter_code_repository)
-    rescue GitHub::Error
-      raise Result::Error, REPOSITORY_STARTER_CODE_IMPORT_FAILED
+    rescue GitHub::Error => error
+      raise Result::Error.new REPOSITORY_STARTER_CODE_IMPORT_FAILED, error.message
     end
 
     def delete_github_repository(github_repository_id)

--- a/app/models/group_assignment_repo/creator/result.rb
+++ b/app/models/group_assignment_repo/creator/result.rb
@@ -3,7 +3,12 @@
 class GroupAssignmentRepo
   class Creator
     class Result
-      class Error < StandardError; end
+      class Error < StandardError
+        def initialize(message, github_error_message = nil)
+          message += " (#{github_error_message})" if github_error_message
+          super(message)
+        end
+      end
 
       def self.success(group_assignment_repo)
         new(:success, group_assignment_repo: group_assignment_repo)

--- a/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
@@ -238,8 +238,10 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect { subject.perform_now(group_assignment, group) }
                 .to have_broadcasted_to(channel)
                 .with(
-                  error: "GitHub repository could not be created, please try again.",
-                  status: "errored_creating_repo"
+                  hash_including(
+                    :error,
+                    status: "errored_creating_repo"
+                  )
                 )
             end
           end
@@ -273,7 +275,7 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             it "logs error" do
               expect(Rails.logger)
                 .to receive(:warn)
-                .with("GitHub repository could not be created, please try again.")
+                .with(a_string_starting_with(GroupAssignmentRepo::Creator::REPOSITORY_CREATION_FAILED))
             end
           end
         end
@@ -295,8 +297,10 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect { subject.perform_now(group_assignment, group) }
                 .to have_broadcasted_to(channel)
                 .with(
-                  status: "errored_creating_repo",
-                  error: "We were not able to import you the starter code to your group assignment, please try again."
+                  hash_including(
+                    :error,
+                    status: "errored_creating_repo"
+                  )
                 )
             end
           end
@@ -330,7 +334,7 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             it "logs error" do
               expect(Rails.logger)
                 .to receive(:warn)
-                .with("We were not able to import you the starter code to your group assignment, please try again.")
+                .with(a_string_starting_with(GroupAssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED))
             end
           end
         end
@@ -359,8 +363,10 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect { subject.perform_now(group_assignment, group, retries: 0) }
                 .to have_broadcasted_to(channel)
                 .with(
-                  status: "errored_creating_repo",
-                  error: GroupAssignmentRepo::Creator::REPOSITORY_TEAM_ADDITION_FAILED
+                  hash_including(
+                    :error,
+                    status: "errored_creating_repo"
+                  )
                 )
             end
           end
@@ -394,7 +400,7 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             it "logs error" do
               expect(Rails.logger)
                 .to receive(:warn)
-                .with("We were not able to add the team to the repository, please try again.")
+                .with(a_string_starting_with(GroupAssignmentRepo::Creator::REPOSITORY_TEAM_ADDITION_FAILED))
             end
           end
         end
@@ -415,8 +421,10 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect { subject.perform_now(group_assignment, group) }
                 .to have_broadcasted_to(channel)
                 .with(
-                  error: "Group assignment could not be created, please try again.",
-                  status: "errored_creating_repo"
+                  hash_including(
+                    :error,
+                    status: "errored_creating_repo"
+                  )
                 )
             end
           end

--- a/spec/models/group_assignment_repo/creator_spec.rb
+++ b/spec/models/group_assignment_repo/creator_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe GroupAssignmentRepo::Creator do
         result = GroupAssignmentRepo::Creator.perform(group_assignment: group_assignment, group: group)
 
         expect(result.failed?).to be_truthy
-        expect(result.error).to eql(GroupAssignmentRepo::Creator::REPOSITORY_CREATION_FAILED)
+        expect(result.error).to start_with(GroupAssignmentRepo::Creator::REPOSITORY_CREATION_FAILED)
       end
 
       it "tracks create fail stat" do
@@ -184,7 +184,7 @@ RSpec.describe GroupAssignmentRepo::Creator do
           result = GroupAssignmentRepo::Creator.perform(group_assignment: group_assignment, group: group)
 
           expect(result.failed?).to be_truthy
-          expect(result.error).to eql(GroupAssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED)
+          expect(result.error).to start_with(GroupAssignmentRepo::Creator::REPOSITORY_STARTER_CODE_IMPORT_FAILED)
           expect(WebMock).to have_requested(:put, import_regex)
         end
 
@@ -198,7 +198,7 @@ RSpec.describe GroupAssignmentRepo::Creator do
           result = GroupAssignmentRepo::Creator.perform(group_assignment: group_assignment, group: group)
 
           expect(result.failed?).to be_truthy
-          expect(result.error).to eql(GroupAssignmentRepo::Creator::REPOSITORY_TEAM_ADDITION_FAILED)
+          expect(result.error).to start_with(GroupAssignmentRepo::Creator::REPOSITORY_TEAM_ADDITION_FAILED)
           expect(WebMock).to have_requested(:put, regex)
         end
 
@@ -208,7 +208,7 @@ RSpec.describe GroupAssignmentRepo::Creator do
           result = GroupAssignmentRepo::Creator.perform(group_assignment: group_assignment, group: group)
 
           expect(result.failed?).to be_truthy
-          expect(result.error).to eql(GroupAssignmentRepo::Creator::DEFAULT_ERROR_MESSAGE)
+          expect(result.error).to start_with(GroupAssignmentRepo::Creator::DEFAULT_ERROR_MESSAGE)
         end
       end
     end


### PR DESCRIPTION
## What
Second (2/2) part which closes #1684.

This PR adds the detailed GitHub error to the user-friendly (but very uninformative) error messages we're reporting when creating group assignments.

Identical to #1892.

![image](https://user-images.githubusercontent.com/1490434/60056147-c0791e00-9694-11e9-82d4-84bfd4fbd640.png)

