### PR TITLE
Remove assistant_landing_page and public_assistant_landing_page

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -19,16 +19,6 @@ class ApplicationController
   end
   helper_method :multiple_classrooms_per_org_enabled?
 
-  def public_assistant_landing_page_enabled?
-    GitHubClassroom.flipper[:public_assistant_landing_page].enabled?
-  end
-  helper_method :public_assistant_landing_page_enabled?
-
-  def assistant_landing_page_enabled?
-    logged_in? && current_user.feature_enabled?(:assistant_landing_page)
-  end
-  helper_method :assistant_landing_page_enabled?
-
   def public_home_v2_enabled?
     GitHubClassroom.flipper[:public_home_v2].enabled?
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,7 +32,6 @@ class PagesController < ApplicationController
   end
 
   def assistant
-    return not_found unless assistant_landing_page_enabled? || public_assistant_landing_page_enabled?
     render layout: "layouts/pagesv2"
   end
 


### PR DESCRIPTION
cc https://github.com/education/classroom/issues/1951

Removes:
- public_assistant_landing_page
- assistant_landing_page

assistand_landing_page is not 100%, but it's also not being used in the codebase. Is this OK @srinjoym ?