### PR TITLE
Remove download repositories feature flag

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -54,11 +54,6 @@ class ApplicationController
   end
   helper_method :import_resiliency_enabled?
 
-  def download_repositories_enabled?
-    logged_in? && current_user.feature_enabled?(:download_repositories)
-  end
-  helper_method :download_repositories_enabled?
-
   def search_assignments_enabled?
     logged_in? && current_user.feature_enabled?(:search_assignments)
   end

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -27,12 +27,10 @@
         </div>
       </div>
 
-      <% if download_repositories_enabled? %>
-        <%= render partial: 'shared/open_on_assistant_modal', locals: {
-          assistant_url: assistant_organization_assignment_url,
-          enabled: @assignment_repos.present?
-        } %>
-      <% end %>
+      <%= render partial: 'shared/open_on_assistant_modal', locals: {
+        assistant_url: assistant_organization_assignment_url,
+        enabled: @assignment_repos.present?
+      } %>
 
       <div class="text-right mt-3 pl-2 settings">
         <%= link_to edit_organization_assignment_path(@organization, @assignment), class: 'btn right' do %>

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -27,12 +27,10 @@
         </div>
       </div>
 
-      <% if download_repositories_enabled? %>
-        <%= render partial: 'shared/open_on_assistant_modal', locals: {
-          assistant_url: assistant_organization_group_assignment_url,
-          enabled: @group_assignment_repos.present?
-        } %>
-      <% end %>
+      <%= render partial: 'shared/open_on_assistant_modal', locals: {
+        assistant_url: assistant_organization_group_assignment_url,
+        enabled: @group_assignment_repos.present?
+      } %>
 
       <div class="text-right mt-3 pl-2 settings">
         <%= link_to edit_organization_group_assignment_path(@organization, @group_assignment), class: 'btn right' do %>


### PR DESCRIPTION
cc https://github.com/education/classroom/issues/1951

Removes the old `download_repositories` flipper logic.