### PR TITLE
Adding LTI Configuration Reference to Organization Migration

### DIFF
--- a/db/migrate/20190706000449_add_reference_from_organization_lti_configuration.rb
+++ b/db/migrate/20190706000449_add_reference_from_organization_lti_configuration.rb
@@ -1,0 +1,7 @@
+class AddReferenceFromOrganizationLtiConfiguration < ActiveRecord::Migration[5.1]
+  def change
+    change_table :organizations do |t|
+      t.belongs_to :lti_configuration
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190702222417) do
+ActiveRecord::Schema.define(version: 20190706000449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,9 +194,11 @@ ActiveRecord::Schema.define(version: 20190702222417) do
     t.string "github_global_relay_id"
     t.bigint "organization_webhook_id"
     t.string "google_course_id"
+    t.bigint "lti_configuration_id"
     t.index ["deleted_at"], name: "index_organizations_on_deleted_at"
     t.index ["github_id"], name: "index_organizations_on_github_id"
     t.index ["google_course_id"], name: "index_organizations_on_google_course_id"
+    t.index ["lti_configuration_id"], name: "index_organizations_on_lti_configuration_id"
     t.index ["organization_webhook_id"], name: "index_organizations_on_organization_webhook_id"
     t.index ["roster_id"], name: "index_organizations_on_roster_id"
     t.index ["slug"], name: "index_organizations_on_slug"


### PR DESCRIPTION
## What
This PR adds a LTIConfiguration `belongs_to` relationship to Organization. So we can access the data like `current_organization.lti_configuration`. 
