### PR TITLE
Stop indexing users for now

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include Flippable
   include GraphQLNode
 
-  update_index("user#user") { self }
+  # update_index("user#user") { self }
 
   has_many :assignment_repos
   has_many :repo_accesses, dependent: :destroy


### PR DESCRIPTION
While our ES is down, lets stop trying to index users, it's causing floods of exceptions.