### PR TITLE
Add stats for repo creation time with importer

### DIFF
--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -64,7 +64,7 @@ class AssignmentRepo
         Rails.logger.warn(error.message)
         raise Result::Error.new DEFAULT_ERROR_MESSAGE, error.message
       end
-      report_time(start)
+      report_time(start, assignment)
 
       GitHubClassroom.statsd.increment("v2_exercise_repo.create.success")
       GitHubClassroom.statsd.increment("exercise_repo.create.success")

--- a/app/models/assignment_repo/creator/reporter.rb
+++ b/app/models/assignment_repo/creator/reporter.rb
@@ -34,10 +34,14 @@ class AssignmentRepo
 
       # Reports the elapsed time to Datadog
       #
-      def report_time(start_time)
+      def report_time(start_time, assignment)
         duration_in_millseconds = (Time.zone.now - start_time) * 1_000
-        GitHubClassroom.statsd.timing("v2_exercise_repo.create.time", duration_in_millseconds)
-        GitHubClassroom.statsd.timing("exercise_repo.create.time", duration_in_millseconds)
+        if group_assignment.starter_code?
+          GitHubClassroom.statsd.timing("exercise_repo.create.time.with_importer", duration_in_millseconds)
+        else
+          GitHubClassroom.statsd.timing("v2_exercise_repo.create.time", duration_in_millseconds)
+          GitHubClassroom.statsd.timing("exercise_repo.create.time", duration_in_millseconds)
+        end
       end
 
       # Maps the type of error to a Datadog error

--- a/app/models/assignment_repo/creator/reporter.rb
+++ b/app/models/assignment_repo/creator/reporter.rb
@@ -36,7 +36,7 @@ class AssignmentRepo
       #
       def report_time(start_time, assignment)
         duration_in_millseconds = (Time.zone.now - start_time) * 1_000
-        if group_assignment.starter_code?
+        if assignment.starter_code?
           GitHubClassroom.statsd.timing("exercise_repo.create.time.with_importer", duration_in_millseconds)
         else
           GitHubClassroom.statsd.timing("v2_exercise_repo.create.time", duration_in_millseconds)

--- a/app/models/group_assignment_repo/creator.rb
+++ b/app/models/group_assignment_repo/creator.rb
@@ -75,8 +75,7 @@ class GroupAssignmentRepo
         broadcast_message(CREATE_COMPLETE)
       end
 
-      duration_in_millseconds = (Time.zone.now - start) * 1_000
-      GitHubClassroom.statsd.timing("exercise_repo.create.time", duration_in_millseconds)
+      report_time(start, group_assignment)
       GitHubClassroom.statsd.increment("exercise_repo.create.success")
 
       Result.success(group_assignment_repo)

--- a/app/models/group_assignment_repo/creator/reporter.rb
+++ b/app/models/group_assignment_repo/creator/reporter.rb
@@ -42,6 +42,7 @@ class GroupAssignmentRepo
           GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time.with_importer", duration_in_millseconds)
         else
           GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)
+          GitHubClassroom.statsd.timing("group_exercise_repo.create.time", duration_in_millseconds)
         end
       end
     end

--- a/app/models/group_assignment_repo/creator/reporter.rb
+++ b/app/models/group_assignment_repo/creator/reporter.rb
@@ -36,9 +36,9 @@ class GroupAssignmentRepo
 
       # Reports the elapsed time to Datadog
       #
-      def report_time(start_time, assignment)
+      def report_time(start_time, group_assignment)
         duration_in_millseconds = (Time.zone.now - start_time) * 1_000
-        if assignment.starter_code?
+        if group_assignment.starter_code?
           GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time.with_importer", duration_in_millseconds)
         else
           GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)

--- a/app/models/group_assignment_repo/creator/reporter.rb
+++ b/app/models/group_assignment_repo/creator/reporter.rb
@@ -36,10 +36,13 @@ class GroupAssignmentRepo
 
       # Reports the elapsed time to Datadog
       #
-      def report_time(start_time)
+      def report_time(start_time, assignment)
         duration_in_millseconds = (Time.zone.now - start_time) * 1_000
-        GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)
-        GitHubClassroom.statsd.timing("group_exercise_repo.create.time", duration_in_millseconds)
+        if assignment.starter_code?
+          GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time.with_importer", duration_in_millseconds)
+        else
+          GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)
+        end
       end
     end
   end

--- a/app/models/group_assignment_repo/creator/reporter.rb
+++ b/app/models/group_assignment_repo/creator/reporter.rb
@@ -39,7 +39,7 @@ class GroupAssignmentRepo
       def report_time(start_time, group_assignment)
         duration_in_millseconds = (Time.zone.now - start_time) * 1_000
         if group_assignment.starter_code?
-          GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time.with_importer", duration_in_millseconds)
+          GitHubClassroom.statsd.timing("group_exercise_repo.create.time.with_importer", duration_in_millseconds)
         else
           GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)
           GitHubClassroom.statsd.timing("group_exercise_repo.create.time", duration_in_millseconds)

--- a/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
     end
 
     it "tracks how long it too to be created" do
-      expect(GitHubClassroom.statsd).to receive(:timing).with("exercise_repo.create.time", anything)
-      expect(GitHubClassroom.statsd).to receive(:timing).with("v2_exercise_repo.create.time", anything)
+      expect(GitHubClassroom.statsd).to receive(:timing).with("exercise_repo.create.time.with_importer", anything)
       subject.perform_now(assignment, teacher)
     end
   end

--- a/spec/models/assignment_repo/creator_spec.rb
+++ b/spec/models/assignment_repo/creator_spec.rb
@@ -99,8 +99,7 @@ RSpec.describe AssignmentRepo::Creator, type: :model do
       end
 
       it "tracks the how long it too to be created" do
-        expect(GitHubClassroom.statsd).to receive(:timing).with("exercise_repo.create.time", anything)
-        expect(GitHubClassroom.statsd).to receive(:timing).with("v2_exercise_repo.create.time", anything)
+        expect(GitHubClassroom.statsd).to receive(:timing).with("exercise_repo.create.time.with_importer", anything)
         AssignmentRepo::Creator.perform(assignment: assignment, user: student)
       end
 


### PR DESCRIPTION
## What
This PR adds a metric for the repo creation time when using the source importer.

I'll also add a metric for template repo creation which lets us compare the time/performance difference when using template repos vs the source importer.