### PR TITLE
Fix message of the day styling error

### DIFF
--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -6,4 +6,10 @@
     font-weight: bold;
     color: #58d984;
   }
+
+  .container-lg {
+    p {
+      margin: 0;
+    }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/education/classroom/issues/1980

Fixed screenshot:
<img width="1022" alt="Screen Shot 2019-07-10 at 3 43 51 PM" src="https://user-images.githubusercontent.com/30920216/61010076-c07e4c80-a329-11e9-94b7-29cf29d21af0.png">
