### PR TITLE
When Google Classroom Integration Exists Show Sync Modal

### DIFF
--- a/app/views/orgs/rosters/_new_student_modal.html.erb
+++ b/app/views/orgs/rosters/_new_student_modal.html.erb
@@ -4,7 +4,7 @@
   <button data-remodal-action="close" class="remodal-close"><%= octicon 'x' %></button>
   <h2 class="remodal-header text-left">Add students to your Roster</h2>
 
-  <% if @google_course_id && google_classroom_roster_import_enabled? %>
+  <% if @google_course_name && google_classroom_roster_import_enabled? %>
     <div class="my-3">
       <h3 class="h4 mb-2">Sync with Google Classroom</h3>
       <div class="f5 mt-2 d-block">Linked with <strong><%= @google_course_name %></strong></div>


### PR DESCRIPTION
## What
There was a bug in the initial PR which did not show the sync modal when there was an existing Google Classroom integration. This PR fixes it.

No tests are written as it is very difficult to render the partial and have the google credentials for it. 

![oOVh5j8HMl](https://user-images.githubusercontent.com/22784140/61145643-d35d6200-a48c-11e9-9efd-9ffb82a03d4c.gif)

