### PR TITLE
Add context_membership_url to lti_configurations table

### DIFF
--- a/db/migrate/20190716211230_add_column_to_lti_configurations.rb
+++ b/db/migrate/20190716211230_add_column_to_lti_configurations.rb
@@ -1,0 +1,5 @@
+class AddColumnToLtiConfigurations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :lti_configurations, :context_membership_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190710202356) do
+ActiveRecord::Schema.define(version: 20190716211230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,9 +169,10 @@ ActiveRecord::Schema.define(version: 20190710202356) do
     t.text "consumer_key", null: false
     t.text "shared_secret", null: false
     t.text "lms_link"
-    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "organization_id"
+    t.string "context_membership_url"
     t.index ["consumer_key"], name: "index_lti_configurations_on_consumer_key", unique: true
     t.index ["organization_id"], name: "index_lti_configurations_on_organization_id"
   end


### PR DESCRIPTION
## What
Migration to persist the `context_membership_url` to a given `LtiConfiguration`. This url is used for importing the members of an LMS context (e.g. a course or a course section), and is unchanging across LMS launches.

As noted in #1987, It'll be nice to have this url persisted because it will mean that after an instructor's first launch of Classroom from their LMS, they won't have to relaunch it in the future to re-import the roster for their linked course.