### PR TITLE
Remove Postgres 9.4 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,6 @@ env:
     - WEBHOOK_SECRET=abcdefg
     - API_SECRET=abcdefg
   matrix:
-    - CI_NODE_INDEX=0 DB_VERSION=9.4
-    - CI_NODE_INDEX=1 DB_VERSION=9.4
     - CI_NODE_INDEX=0 DB_VERSION=10
     - CI_NODE_INDEX=1 DB_VERSION=10
 


### PR DESCRIPTION
Closes https://github.com/education/classroom/issues/2059

Removes the 9.4 PG builds since we're using 10 in prod now 🎉 