### PR TITLE
Add beta badge to template repos option

### DIFF
--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -52,7 +52,8 @@
   <% if @organization.feature_enabled?(:template_repos) %>
     <div id="import-options" style=<%= "display:none;" if not @assignment.starter_code? %>>
       <div class="form-checkbox">
-        <label><%= f.radio_button :template_repos_enabled, true, checked: (true if @assignment.new_record? || @assignment.template_repos_enabled?) %> Import starter code using a template repository (recommended)</label>
+        <label><%= f.radio_button :template_repos_enabled, true, checked: (true if @assignment.new_record? || @assignment.template_repos_enabled?) %> Import starter code using a template repository</label>
+        <span class="Label border border-green text-gray-dark">Beta</span>
         <span class="note">Starter code repository should be a <%= link_to "template repository", "https://help.github.com/en/articles/creating-a-template-repository", target: "_blank" %>. Increases student repository creation and code import speed dramatically.</span>
       </div>
 

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -53,7 +53,8 @@
     <div id="import-options" style=<%= "display:none;" if not @group_assignment.starter_code? %>>
       <div class="form-checkbox">
         <label><%= f.radio_button :template_repos_enabled, true, checked: (true if @group_assignment.new_record? || @group_assignment.template_repos_enabled?) %> Import starter code using a template repository</label>
-        <span class="note">(Recommended) Starter code repository should be a <%= link_to "template repository", "https://help.github.com/en/articles/creating-a-template-repository", target: "_blank" %>. Increases student repository creation and code import speed dramatically.</span>
+        <span class="Label border border-green text-gray-dark">Beta</span>
+        <span class="note">Starter code repository should be a <%= link_to "template repository", "https://help.github.com/en/articles/creating-a-template-repository", target: "_blank" %>. Increases student repository creation and code import speed dramatically.</span>
       </div>
 
       <div class="form-checkbox">


### PR DESCRIPTION
## What
Since template repos in general are very new and we've seen some minor issues, we should note that this feature is a beta using a badge.

![image](https://user-images.githubusercontent.com/1490434/61651131-1c21d180-ac6a-11e9-868d-9f7531995d4c.png)
