### PR TITLE
Remove v2 prefix from stats used for repo creation

### DIFF
--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -17,12 +17,12 @@ class AssignmentInvitationsController < ApplicationController
     case result.status
     when :success
       current_invitation_status.completed! if current_invitation_status.unaccepted?
-      GitHubClassroom.statsd.increment("v2_exercise_invitation.accept")
+      GitHubClassroom.statsd.increment("exercise_invitation.accept")
     when :pending
       current_invitation_status.accepted!
-      GitHubClassroom.statsd.increment("v2_exercise_invitation.accept")
+      GitHubClassroom.statsd.increment("exercise_invitation.accept")
     when :failed
-      GitHubClassroom.statsd.increment("v2_exercise_invitation.fail")
+      GitHubClassroom.statsd.increment("exercise_invitation.fail")
       current_invitation_status.unaccepted!
       flash[:error] = result.error
     end
@@ -43,9 +43,9 @@ class AssignmentInvitationsController < ApplicationController
       assignment_repo = AssignmentRepo.find_by(assignment: current_assignment, user: current_user)
       assignment_repo&.destroy if assignment_repo&.github_repository&.empty?
       if current_invitation_status.errored_creating_repo?
-        GitHubClassroom.statsd.increment("v2_exercise_repo.create.retry")
+        GitHubClassroom.statsd.increment("exercise_repo.create.retry")
       elsif current_invitation_status.errored_importing_starter_code?
-        GitHubClassroom.statsd.increment("v2_exercise_repo.import.retry")
+        GitHubClassroom.statsd.increment("exercise_repo.import.retry")
       end
       current_invitation_status.waiting!
       if unified_repo_creators_enabled?

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -187,7 +187,7 @@ class GroupAssignmentInvitationsController < ApplicationController
       flash[:error] = result.error
       redirect_to group_assignment_invitation_path
     when :success, :pending
-      GitHubClassroom.statsd.increment("v2_group_exercise_invitation.accept")
+      GitHubClassroom.statsd.increment("group_exercise_invitation.accept")
       route_based_on_status
     end
   end
@@ -198,14 +198,14 @@ class GroupAssignmentInvitationsController < ApplicationController
 
   def report_retry
     if group_invite_status.errored_creating_repo?
-      GitHubClassroom.statsd.increment("v2_group_exercise_repo.create.retry")
+      GitHubClassroom.statsd.increment("group_exercise_repo.create.retry")
     elsif group_invite_status.errored_importing_starter_code?
-      GitHubClassroom.statsd.increment("v2_group_exercise_repo.import.retry")
+      GitHubClassroom.statsd.increment("group_exercise_repo.import.retry")
     end
   end
 
   def report_invitation_failure
-    GitHubClassroom.statsd.increment("v2_group_exercise_invitation.fail")
+    GitHubClassroom.statsd.increment("group_exercise_invitation.fail")
   end
 
   ## Resource Helpers

--- a/app/jobs/group_assignment_repo/create_github_repository_job.rb
+++ b/app/jobs/group_assignment_repo/create_github_repository_job.rb
@@ -34,7 +34,6 @@ class GroupAssignmentRepo
       else
         creator.invite_status.errored_creating_repo!
         creator.broadcast_error(error)
-        GitHubClassroom.statsd.increment("v2_group_exercise_repo.create.fail")
         GitHubClassroom.statsd.increment("group_exercise_repo.create.fail")
       end
       logger.warn(error.message)

--- a/app/models/assignment_repo/creator.rb
+++ b/app/models/assignment_repo/creator.rb
@@ -74,7 +74,6 @@ class AssignmentRepo
       end
       report_time(start, assignment)
 
-      GitHubClassroom.statsd.increment("v2_exercise_repo.create.success")
       GitHubClassroom.statsd.increment("exercise_repo.create.success")
       if assignment.use_importer?
         invite_status.importing_starter_code!

--- a/app/models/assignment_repo/creator/reporter.rb
+++ b/app/models/assignment_repo/creator/reporter.rb
@@ -42,34 +42,27 @@ class AssignmentRepo
           GitHubClassroom.statsd.timing("exercise_repo.create.time.with_templates", duration_in_millseconds)
         else
           GitHubClassroom.statsd.timing("exercise_repo.create.time", duration_in_millseconds)
-          GitHubClassroom.statsd.timing("v2_exercise_repo.create.time", duration_in_millseconds)
         end
       end
 
       # Maps the type of error to a Datadog error
       #
       # rubocop:disable MethodLength
-      # rubocop:disable AbcSize
       def report_error(err)
         case err.message
         when /^#{REPOSITORY_CREATION_FAILED}/
-          GitHubClassroom.statsd.increment("v2_exercise_repo.create.repo.fail")
           GitHubClassroom.statsd.increment("exercise_repo.create.repo.fail")
         when /^#{REPOSITORY_COLLABORATOR_ADDITION_FAILED}/
-          GitHubClassroom.statsd.increment("v2_exercise_repo.create.adding_collaborator.fail")
           GitHubClassroom.statsd.increment("exercise_repo.create.adding_collaborator.fail")
         when /^#{REPOSITORY_STARTER_CODE_IMPORT_FAILED}/
-          GitHubClassroom.statsd.increment("v2_exercise_repo.create.importing_starter_code.fail")
           GitHubClassroom.statsd.increment("exercise_repo.create.importing_starter_code.fail")
         when /^#{TEMPLATE_REPOSITORY_CREATION_FAILED}/
           GitHubClassroom.statsd.increment("exercise_repo.create.repo.with_templates.failed")
         else
-          GitHubClassroom.statsd.increment("v2_exercise_repo.create.fail")
           GitHubClassroom.statsd.increment("exercise_repo.create.fail")
         end
       end
       # rubocop:enable MethodLength
-      # rubocop:enable AbcSize
     end
   end
 end

--- a/app/models/group_assignment_repo/creator.rb
+++ b/app/models/group_assignment_repo/creator.rb
@@ -69,7 +69,6 @@ class GroupAssignmentRepo
         raise Result::Error.new DEFAULT_ERROR_MESSAGE, error.message
       end
 
-      GitHubClassroom.statsd.increment("v2_group_exercise_repo.create.success")
       GitHubClassroom.statsd.increment("group_exercise_repo.create.success")
 
       if group_assignment.use_importer?

--- a/app/models/group_assignment_repo/creator/reporter.rb
+++ b/app/models/group_assignment_repo/creator/reporter.rb
@@ -43,7 +43,6 @@ class GroupAssignmentRepo
         elsif group_assignment.use_template_repos?
           GitHubClassroom.statsd.timing("group_exercise_repo.create.time.with_templates", duration_in_millseconds)
         else
-          GitHubClassroom.statsd.timing("v2_group_exercise_repo.create.time", duration_in_millseconds)
           GitHubClassroom.statsd.timing("group_exercise_repo.create.time", duration_in_millseconds)
         end
       end

--- a/spec/controllers/assignment_invitations_controller_spec.rb
+++ b/spec/controllers/assignment_invitations_controller_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe AssignmentInvitationsController, type: :controller do
     end
 
     it "sends an event to statsd" do
-      expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_invitation.accept")
+      expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_invitation.accept")
 
       allow_any_instance_of(AssignmentInvitation).to receive(:redeem_for).with(user).and_return(result)
 
@@ -278,7 +278,7 @@ RSpec.describe AssignmentInvitationsController, type: :controller do
       end
 
       it "records error stat" do
-        expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_invitation.fail")
+        expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_invitation.fail")
         patch :accept, params: { id: invitation.key }
       end
 
@@ -295,7 +295,7 @@ RSpec.describe AssignmentInvitationsController, type: :controller do
 
     context "with import resiliency enabled" do
       it "sends an event to statsd" do
-        expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_invitation.accept")
+        expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_invitation.accept")
 
         allow_any_instance_of(AssignmentInvitation).to receive(:redeem_for)
           .with(user)
@@ -407,13 +407,13 @@ RSpec.describe AssignmentInvitationsController, type: :controller do
         end
 
         it "reports an error was retried" do
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.retry")
+          expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.retry")
           post :create_repo, params: { id: invitation.key }
         end
 
         it "reports an error importing was retried" do
           invite_status.errored_importing_starter_code!
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.import.retry")
+          expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.import.retry")
           post :create_repo, params: { id: invitation.key }
         end
       end

--- a/spec/controllers/group_assignment_invitations_controller_spec.rb
+++ b/spec/controllers/group_assignment_invitations_controller_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe GroupAssignmentInvitationsController, type: :controller do
       it "sends an event to statsd" do
         expect(GitHubClassroom.statsd)
           .to receive(:increment)
-          .with("v2_group_exercise_invitation.accept")
+          .with("group_exercise_invitation.accept")
         patch :accept_invitation, params: { id: invitation.key, group: { title: "Code Squad" } }
       end
 
@@ -362,7 +362,7 @@ RSpec.describe GroupAssignmentInvitationsController, type: :controller do
       context "with group import resiliency enabled" do
         describe "success" do
           it "sends an event to statsd" do
-            expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_invitation.accept")
+            expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_invitation.accept")
             patch :accept_invitation, params: { id: invitation.key, group: { title: group.title } }
           end
 

--- a/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/assignment_repo/create_github_repository_job_spec.rb
@@ -141,7 +141,6 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
 
     it "tracks create success stat" do
       expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
-      expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.success")
       expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.import.started")
       subject.perform_now(assignment, teacher)
     end
@@ -157,7 +156,6 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
       stub_request(:post, github_url("/organizations/#{organization.github_id}/repos"))
         .to_return(body: "{}", status: 401)
       expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.repo.fail")
-      expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.repo.fail")
       expect(GitHubClassroom.statsd).to receive(:increment).with("github.error.Unauthorized")
       subject.perform_now(assignment, student)
     end
@@ -257,9 +255,6 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           .with("exercise_repo.create.importing_starter_code.fail")
         expect(GitHubClassroom.statsd)
           .to receive(:increment)
-          .with("v2_exercise_repo.create.importing_starter_code.fail")
-        expect(GitHubClassroom.statsd)
-          .to receive(:increment)
           .with("github.error.Unauthorized")
         subject.perform_now(assignment, student)
       end
@@ -305,7 +300,6 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
         stub_request(:put, repo_invitation_regex)
           .to_return(body: "{}", status: 401)
         expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.adding_collaborator.fail")
-        expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.adding_collaborator.fail")
         expect(GitHubClassroom.statsd).to receive(:increment).with("github.error.Unauthorized")
         subject.perform_now(assignment, student)
       end
@@ -348,7 +342,6 @@ RSpec.describe AssignmentRepo::CreateGitHubRepositoryJob, type: :job do
       it "fails to save the AssignmentRepo and reports" do
         allow_any_instance_of(AssignmentRepo).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
         expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.fail")
-        expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.fail")
         subject.perform_now(assignment, student)
       end
     end

--- a/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
+++ b/spec/jobs/group_assignment_repo/create_github_repository_job_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
           it "tracks create success and import started" do
             expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.success")
             expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
-            expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.success")
             expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.import.started")
           end
 
@@ -196,7 +195,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             it "tracks create success" do
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.success")
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.import.started")
-              expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.success")
               expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
             end
 
@@ -274,7 +272,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.fail")
               expect(GitHubClassroom.statsd).to receive(:increment).with("github.error.InternalServerError")
               expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.fail")
-              expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.fail")
             end
 
             it "logs error" do
@@ -334,7 +331,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.fail")
               expect(GitHubClassroom.statsd).to receive(:increment).with("github.error.InternalServerError")
               expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.fail")
-              expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.fail")
             end
 
             it "logs error" do
@@ -401,7 +397,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.fail")
               expect(GitHubClassroom.statsd).to receive(:increment).with("github.error.InternalServerError")
               expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.fail")
-              expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.fail")
             end
 
             it "logs error" do
@@ -459,7 +454,6 @@ RSpec.describe GroupAssignmentRepo::CreateGitHubRepositoryJob, type: :job do
             it "tracks create fail" do
               expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.fail")
               expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.fail")
-              expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.fail")
             end
           end
         end

--- a/spec/models/assignment_repo/creator_spec.rb
+++ b/spec/models/assignment_repo/creator_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe AssignmentRepo::Creator, type: :model do
 
         it "tracks create success stat" do
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.import.started")
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
           AssignmentRepo::Creator.perform(assignment: assignment, user: student)
         end
@@ -192,7 +191,6 @@ RSpec.describe AssignmentRepo::Creator, type: :model do
 
         it "tracks create success stat" do
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.repo.with_templates.success")
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
           AssignmentRepo::Creator.perform(assignment: assignment, user: student)
         end

--- a/spec/models/group_assignment_repo/creator_spec.rb
+++ b/spec/models/group_assignment_repo/creator_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe GroupAssignmentRepo::Creator do
         end
 
         it "tracks create success stat" do
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.import.started")
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
@@ -194,7 +193,6 @@ RSpec.describe GroupAssignmentRepo::Creator do
         it "tracks create success stat" do
           expect(GitHubClassroom.statsd).to receive(:increment)
             .with("group_exercise_repo.create.repo.with_templates.success")
-          expect(GitHubClassroom.statsd).to receive(:increment).with("v2_group_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("group_exercise_repo.create.success")
           expect(GitHubClassroom.statsd).to receive(:increment).with("exercise_repo.create.success")
           GroupAssignmentRepo::Creator.perform(group_assignment: group_assignment, group: group)


### PR DESCRIPTION
This pull request removes the `v2` prefix that was added when `import_resiliency` was introduced. Since that feature is now 100% deployed, we remove the `v2` prefix and consider all the stats sent as primary.

__IMPORTANT:__ This affects our graphs in datadog, so we need to update them *before* or *as soon as* this pull request is in production.