### PR TITLE
Fix download repos button

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -29,7 +29,7 @@
 
       <%= render partial: 'shared/open_on_assistant_modal', locals: {
         assistant_url: assistant_organization_assignment_url,
-        enabled: @assignment_repos.present?
+        enabled: @assignment.assignment_repos.any?
       } %>
 
       <div class="text-right mt-3 pl-2 settings">

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -29,7 +29,7 @@
 
       <%= render partial: 'shared/open_on_assistant_modal', locals: {
         assistant_url: assistant_organization_group_assignment_url,
-        enabled: @group_assignment_repos.present?
+        enabled: @group_assignment.group_assignment_repos.present?
       } %>
 
       <div class="text-right mt-3 pl-2 settings">


### PR DESCRIPTION
## What
Fixes #2093.

We're enabling the "Download Repositories" button based on the `@assignment_repos` variable being present. If we're using rosters, `@assignment_repos` is not defined and we use `@roster_entries` and `@unlinked_user_repos` instead. We shouldn't check these since they're defined for the view (for the search bar it looks like). See here: https://github.com/education/classroom/blob/master/app/controllers/assignments_controller.rb#L35

This change checks if the assignment record has any assignment repositories.
