### PR TITLE
Change layout of LMS links

### DIFF
--- a/app/views/organizations/link_lms.html.erb
+++ b/app/views/organizations/link_lms.html.erb
@@ -10,15 +10,15 @@
     <div class="site-content-body markdown-body">
       <p>Would you like to connect GitHub Classroom to your Learning Management System (LMS)? You can always skip this step and come back later.</p>
       <div class="d-flex flex-wrap gutter">
-        <div class="col-6 col-md-4 col-lg-3">
+        <div class="col-6 col-md-4 col-lg-4">
           <%= button_to select_google_classroom_roster_path(current_organization), method: :get, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
             <%= image_tag "google-classroom-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
-            <span class="css-truncate css-truncate-target" title="Google Classroom">Google Class</span>
+            <span class="css-truncate-target" title="Google Classroom">Google Classroom</span>
           <% end %>
         </div>
         <% LtiConfiguration.lms_types.each_pair do |lms_type, lms_name| %>
           <% lms_name = "Other LMS" if lms_type == "other" %>
-          <div class="col-6 col-md-4 col-lg-3">
+          <div class="col-6 col-md-4 col-lg-4">
             <%= button_to info_lti_configuration_path(current_organization), method: :get, params: { lms_type: lms_type }, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
               <%= image_tag "#{lms_type}-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
               <span class="css-truncate css-truncate-target" title=<%= lms_name %>><%= lms_name %></span>

--- a/app/views/organizations/link_lms.html.erb
+++ b/app/views/organizations/link_lms.html.erb
@@ -8,8 +8,7 @@
 
 
     <div class="site-content-body markdown-body">
-      <p>thebradbain 12:27 PM
-Connecting GitHub Classroom to your institution's Learning Management System (LMS) will allow you to automatically import your course roster. You can always skip this step and come back later.</p>
+      <p>Connecting GitHub Classroom to your institution's Learning Management System (LMS) will allow you to automatically import your course roster. You can always skip this step and come back later.</p>
       <div class="d-flex flex-wrap gutter">
         <div class="col-6 col-md-4 col-lg-4">
           <%= button_to select_google_classroom_roster_path(current_organization), method: :get, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>

--- a/app/views/organizations/link_lms.html.erb
+++ b/app/views/organizations/link_lms.html.erb
@@ -8,7 +8,8 @@
 
 
     <div class="site-content-body markdown-body">
-      <p>Would you like to connect GitHub Classroom to your Learning Management System (LMS)? You can always skip this step and come back later.</p>
+      <p>thebradbain 12:27 PM
+Connecting GitHub Classroom to your institution's Learning Management System (LMS) will allow you to automatically import your course roster. You can always skip this step and come back later.</p>
       <div class="d-flex flex-wrap gutter">
         <div class="col-6 col-md-4 col-lg-4">
           <%= button_to select_google_classroom_roster_path(current_organization), method: :get, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>


### PR DESCRIPTION
## What
Currently, Google Classroom is displayed as "Google Class" which we should not do. So this PR makes it so that we can display the full name. To do that I'm also changing how many LMSs are displayed in one row.

Also updated the text copy!

### Before
![image](https://user-images.githubusercontent.com/22784140/61973248-7e474300-af98-11e9-9656-29889cd3540f.png)

### After
![image](https://user-images.githubusercontent.com/22784140/61976845-b2733180-afa1-11e9-9f00-de478d118e29.png)


