### PR TITLE
Cache launch message nonce to LtiConfiguration

### DIFF
--- a/app/controllers/orgs/rosters_controller/lti_dependency.rb
+++ b/app/controllers/orgs/rosters_controller/lti_dependency.rb
@@ -37,7 +37,7 @@ module Orgs
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def lms_membership
-      membership_service_url = current_organization.lti_configuration.context_membership_url(nonce: session[:lti_nonce])
+      membership_service_url = current_organization.lti_configuration.context_membership_url
       unless membership_service_url
         lms_name = current_organization.lti_configuration.lms_name(default_name: "your Learning Management System")
         msg = "GitHub Classroom is not configured properly on #{lms_name}.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -62,11 +62,11 @@ class SessionsController < ApplicationController
     message = GitHubClassroom::LTI::MessageStore.construct_message(auth_hash.extra.raw_info)
     raise("invalid lti launch message") unless message_store.message_valid?(message)
 
-    nonce = message_store.save_message(message)
-    session[:lti_nonce] = nonce
+    lti_configuration = LtiConfiguration.find_by_auth_hash(auth_hash)
+    lti_configuration.cached_launch_message_nonce = message_store.save_message(message)
+    lti_configuration.save!
 
-    linked_org = LtiConfiguration.find_by_auth_hash(auth_hash).organization
-
+    linked_org = lti_configuration.organization
     if logged_in?
       @post_launch_url = complete_lti_configuration_url(linked_org)
     else

--- a/app/models/lti_configuration.rb
+++ b/app/models/lti_configuration.rb
@@ -25,12 +25,13 @@ class LtiConfiguration < ApplicationRecord
     lms_settings.platform_name || default_name
   end
 
+  # TODO: this method is more or less entirely unnecessary (and doesn't belong here, really).
+  # Remove it when possible.
   def context_membership_url(use_cache: true, nonce: nil)
     cached_value = self[:context_membership_url] if use_cache
     return cached_value if cached_value
 
-    message_store = GitHubClassroom.lti_message_store(consumer_key: consumer_key)
-    message = message_store.get_message(nonce)
+    message = launch_message
     return nil unless message
 
     membership_url = message.custom_params[lms_settings.context_memberships_url_key]
@@ -40,6 +41,11 @@ class LtiConfiguration < ApplicationRecord
     save!
 
     membership_url
+  end
+
+  def launch_message
+    message_store = GitHubClassroom.lti_message_store(consumer_key: consumer_key)
+    message_store.get_message(cached_launch_message_nonce)
   end
 
   def xml_configuration(launch_url)

--- a/app/models/lti_configuration.rb
+++ b/app/models/lti_configuration.rb
@@ -43,6 +43,13 @@ class LtiConfiguration < ApplicationRecord
     membership_url
   end
 
+  def cached_launch_message_nonce=(value)
+    message_store = GitHubClassroom.lti_message_store(consumer_key: consumer_key)
+    message_store.delete_message(cached_launch_message_nonce)
+
+    super(value)
+  end
+
   def launch_message
     message_store = GitHubClassroom.lti_message_store(consumer_key: consumer_key)
     message_store.get_message(cached_launch_message_nonce)

--- a/app/models/lti_configuration.rb
+++ b/app/models/lti_configuration.rb
@@ -27,7 +27,7 @@ class LtiConfiguration < ApplicationRecord
 
   # TODO: this method is more or less entirely unnecessary (and doesn't belong here, really).
   # Remove it when possible.
-  def context_membership_url(use_cache: true, nonce: nil)
+  def context_membership_url(use_cache: true)
     cached_value = self[:context_membership_url] if use_cache
     return cached_value if cached_value
 
@@ -51,6 +51,7 @@ class LtiConfiguration < ApplicationRecord
   end
 
   def launch_message
+    return nil unless cached_launch_message_nonce
     message_store = GitHubClassroom.lti_message_store(consumer_key: consumer_key)
     message_store.get_message(cached_launch_message_nonce)
   end

--- a/lib/github_classroom/lti/message_store.rb
+++ b/lib/github_classroom/lti/message_store.rb
@@ -40,12 +40,15 @@ module GitHubClassroom
       def get_message(nonce)
         scoped = scoped_nonce(nonce)
         raw_message = @redis_store.get(scoped)
-
         return nil unless raw_message
 
         json_message = JSON.parse(raw_message)
-
         hydrate(json_message)
+      end
+
+      def delete_message(nonce)
+        scoped = scoped_nonce(nonce)
+        @redis_store.del(scoped)
       end
 
       private

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -124,6 +124,7 @@ FactoryBot.define do
 
     consumer_key { SecureRandom.uuid }
     shared_secret { SecureRandom.uuid }
+    cached_launch_message_nonce { SecureRandom.uuid }
     lms_link { "www.example.com" }
     lms_type { :other }
   end

--- a/spec/integration/lti_launch_spec.rb
+++ b/spec/integration/lti_launch_spec.rb
@@ -65,9 +65,10 @@ RSpec.describe "LTI launch", type: :request do
   end
 
   describe "sessions#lti_launch", :vcr do
-    it "sets lti_nonce on session on success" do
+    it "sets cached_launch_message_nonce on corresponding lti_configuration" do
       get auth_lti_launch_path(oauth_consumer_key: consumer_key)
-      expect(session[:lti_nonce]).to eql("mock_nonce")
+      lti_configuration.reload
+      expect(lti_configuration.cached_launch_message_nonce).to eql("mock_nonce")
     end
 
     it "renders lti_launch template" do

--- a/spec/lib/github_classroom/lti/lti_message_store_spec.rb
+++ b/spec/lib/github_classroom/lti/lti_message_store_spec.rb
@@ -75,6 +75,24 @@ describe GitHubClassroom::LTI::MessageStore do
       end
     end
 
+    context "deleting messages" do
+      let(:existing_nonce) { instance.save_message(lti_message) }
+
+      it "deletes existing nonce" do
+        expect(instance.get_message(existing_nonce)).not_to be_nil
+        instance.delete_message(existing_nonce)
+        expect(instance.get_message(existing_nonce)).to be_nil
+      end
+
+      it "does nothing on nonexistant nonce" do
+        nonexisting_nonce = existing_nonce + "-not_existing"
+
+        expect(instance.get_message(existing_nonce)).not_to be_nil
+        instance.delete_message(nonexisting_nonce)
+        expect(instance.get_message(existing_nonce)).not_to be_nil
+      end
+    end
+
     context "retrieving messages" do
       it "returns a message for existing nonce" do
         nonce = instance.save_message(lti_message)


### PR DESCRIPTION
## What
To be merged after #2170. Rids the entire codebase of references to `session[:lti_nonce]`, and instead caches an LMS course's latest nonce (and hence message) to the corresponding `LtiConfiguration` on GitHub Classroom. 

- Frees controller logic from tying together model relationships. 
- Automatically deletes out of date messages from the Redis message store whenever a new launch request with the latest LMS information is received
- Allows us to get rid of the overly complex `context_membership_url` method. (Which we do in #2174)
- Besides avoiding tech debt, most importantly, allows us to easily and dynamically inform the user when a service is not available and why, versus showing an error after the fact, especially after their session is cleared and they haven't relaunched from an LMS (see PR #2174).