### PR TITLE
Add parent class to support bulk API jobs and scheduling

### DIFF
--- a/app/jobs/bulk_api_job.rb
+++ b/app/jobs/bulk_api_job.rb
@@ -33,10 +33,10 @@ class BulkApiJob < ApplicationJob
 
     if cooldown.nil? || Time.zone.now > cooldown
       job.scheduled_at = Time.zone.now
-      GitHubClassroom.redis.set("user_api_job:#{user.id}", (Time.zone.now + 1.hour).to_datetime)
+      GitHubClassroom.redis.set("user_bulk_job_cooldown:#{user.id}", (Time.zone.now + 1.hour).to_datetime)
     else
       job.scheduled_at = cooldown.to_i
-      GitHubClassroom.redis.set("user_api_job:#{user.id}", (cooldown + 1.hour).to_datetime)
+      GitHubClassroom.redis.set("user_bulk_job_cooldown:#{user.id}", (cooldown + 1.hour).to_datetime)
     end
   end
 end

--- a/app/jobs/bulk_api_job.rb
+++ b/app/jobs/bulk_api_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class BulkApiJob < ApplicationJob
+  class Error < StandardError
+    class JobAlreadyRunning < Error
+      def message
+        "User is already running a bulk API job. Users can only run one bulk job at a time."
+      end
+    end
+
+    class MissingUser < Error
+      def message
+        "First argument in perform method must be the User performing the job."
+      end
+    end
+  end
+
+  queue_as :bulk_api_job
+
+  rescue_from(GitHub::Forbidden, Error::JobAlreadyRunning) do
+    user = arguments.first
+    retries = arguments.last[:retries] if arguments.last.is_a? Hash
+    arguments.last[:retries] -= 1 if retries
+    api_wait_time = user.bulk_api_job
+
+    self.class.set(wait_until: api_wait_time).perform_later(*arguments) if retries && retries.positive?
+  end
+
+  before_perform do |job|
+    user = job.arguments.first
+
+    raise Error::MissingUser unless user.is_a? User
+    raise Error::JobAlreadyRunning if user.running_bulk_api_job?
+
+    GitHubClassroom.redis.set("user_api_job:#{user.id}", (Time.zone.now + 1.hour).to_datetime)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
     existing_api_job && existing_api_job.future?
   end
 
-  def bulk_api_job
+  def bulk_api_job_cooldown
     redis = GitHubClassroom.redis
     redis.get("user_api_job:#{id}")&.to_datetime
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   def running_bulk_api_job?
     redis = GitHubClassroom.redis
     existing_api_job = redis.get("user_api_job:#{id}")&.to_datetime
-    existing_api_job && existing_api_job.future?
+    existing_api_job&.future?
   end
 
   def bulk_api_job_cooldown

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,13 +66,13 @@ class User < ApplicationRecord
 
   def running_bulk_api_job?
     redis = GitHubClassroom.redis
-    existing_api_job = redis.get("user_api_job:#{id}")&.to_datetime
+    existing_api_job = redis.get("user_bulk_job_cooldown:#{id}")&.to_datetime
     existing_api_job&.future?
   end
 
   def bulk_api_job_cooldown
     redis = GitHubClassroom.redis
-    redis.get("user_api_job:#{id}")&.to_datetime
+    redis.get("user_bulk_job_cooldown:#{id}")&.to_datetime
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,17 @@ class User < ApplicationRecord
     MessageVerifier.encode({ user_id: id }, exp)
   end
 
+  def running_bulk_api_job?
+    redis = GitHubClassroom.redis
+    existing_api_job = redis.get("user_api_job:#{id}")&.to_datetime
+    existing_api_job && existing_api_job.future?
+  end
+
+  def bulk_api_job
+    redis = GitHubClassroom.redis
+    redis.get("user_api_job:#{id}")&.to_datetime
+  end
+
   private
 
   # Internal: We need to make sure that the user

--- a/spec/jobs/bulk_api_job_spec.rb
+++ b/spec/jobs/bulk_api_job_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class FakeBulkApiJob < BulkApiJob
+  def perform(user, some_other_variable, retries: 0); end
+end
+
+RSpec.describe BulkApiJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject { FakeBulkApiJob }
+
+  let(:teacher) { classroom_teacher }
+  let(:redis) { GitHubClassroom.redis }
+  let(:_) { "some other variable" }
+
+  before(:each) do
+    redis.keys("user_api_job:*").each { |key| redis.del(key) }
+    Timecop.freeze
+  end
+
+  after(:each) do
+    Timecop.return
+  end
+
+  context "successful execution" do
+    it "does not raise an error" do
+      expect { subject.perform_now(teacher, _) }.to_not raise_error
+    end
+  end
+
+  context "user performing the job is not the first argument" do
+    it "raises an exception" do
+      expect { subject.perform_now(_, teacher) }.to raise_error(BulkApiJob::Error::MissingUser)
+    end
+  end
+
+  context "user is already running a bulk API job" do
+    before(:each) do
+      redis.set("user_api_job:#{teacher.id}", (Time.zone.now + 1.hour).to_datetime)
+    end
+
+    # rubocop:disable Rails/TimeZone
+    it "enqueues the retry for one hour later" do
+      expect { subject.perform_now(teacher, _, retries: 1) }
+        .to have_enqueued_job(FakeBulkApiJob)
+        .on_queue("bulk_api_job")
+        .at(Time.at((Time.now + 1.hour).to_i))
+    end
+  end
+
+  context "failure by rate limit or job already running" do
+    before(:each) do
+      allow_any_instance_of(subject).to receive(:perform).and_raise(BulkApiJob::Error::JobAlreadyRunning)
+    end
+
+    it "does not retry if retries not passed" do
+      expect { subject.perform_now(teacher, _) }.to_not have_enqueued_job(FakeBulkApiJob)
+    end
+
+    it "does not retry if retries is zero" do
+      expect { subject.perform_now(teacher, _, retries: 0) }.to_not have_enqueued_job(FakeBulkApiJob)
+    end
+
+    it "does retry if retries are greater than zero" do
+      expect { subject.perform_now(teacher, _, retries: 1) }.to have_enqueued_job(FakeBulkApiJob)
+    end
+
+    it "decreases retry count and passes correct variables when retrying" do
+      expect { subject.perform_now(teacher, _, retries: 2) }
+        .to have_enqueued_job(FakeBulkApiJob)
+        .with(teacher, _, retries: 1)
+    end
+  end
+end

--- a/spec/jobs/bulk_api_job_spec.rb
+++ b/spec/jobs/bulk_api_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BulkApiJob, type: :job do
   let(:_) { "some other variable" }
 
   before(:each) do
-    redis.keys("user_api_job:*").each { |key| redis.del(key) }
+    redis.keys("user_bulk_job_cooldown:*").each { |key| redis.del(key) }
     Timecop.freeze
   end
 
@@ -33,7 +33,7 @@ RSpec.describe BulkApiJob, type: :job do
 
     context "cooldown is in the past" do
       before(:each) do
-        redis.set("user_api_job:#{teacher.id}", (Time.zone.now - 2.hours).to_datetime)
+        redis.set("user_bulk_job_cooldown:#{teacher.id}", (Time.zone.now - 2.hours).to_datetime)
       end
 
       it "succeeds" do
@@ -50,7 +50,7 @@ RSpec.describe BulkApiJob, type: :job do
 
   context "user is already running a bulk API job" do
     before(:each) do
-      redis.set("user_api_job:#{teacher.id}", (Time.zone.now + 1.hour).to_datetime)
+      redis.set("user_bulk_job_cooldown:#{teacher.id}", (Time.zone.now + 1.hour).to_datetime)
     end
 
     # rubocop:disable Rails/TimeZone


### PR DESCRIPTION
Closes #2184. More context here: https://github.com/education/classroom/pull/2127#issuecomment-517335542

## The Problem

Over the next few weeks we'll be introducing a lot of jobs that make changes to student repos in bulk. We already have the `RepositoryVisibilityJob` (https://github.com/education/classroom/blob/master/app/jobs/assignment/repository_visibility_job.rb) that can be adjusted to use this. I plan to introduce `ClassroomVisibilityJob` (#2127), `TransferOwnershipJob`, `ArchiveRepositoriesJob`, etc. that will execute thousands of API calls on behalf of a teacher for large classrooms. 

It makes sense to create a parent class that does all of the error handling, rescheduling and prevents us from executing bulk API jobs in parallel.

## The Solution

This PR adds the `BulkApiJob` class which all bulk jobs should inherit. It's essentially a queue that forces a 1-hour interval between each bulk API job and prevents the User from running another in parallel.

When a bulk job is enqueued, it will check the `User`'s cooldown time. If it does not exist or has passed, it will set the cooldown for 1 hour from now and perform the job. If the cooldown is still in effect, it will schedule the job for after the cooldown.

If a job fails mid-execution because of the rate limit (`GitHub::Forbidden`) it will be re-scheduled similarly (added to the end of the queue).

![twTRkxSHqA](https://user-images.githubusercontent.com/1490434/62580538-35767080-b85b-11e9-8e9e-d4456aafab6d.gif)
_This case shows how Teacher (ID: 12345) splits the ClassroomVisibilityJob into 3 jobs to cover all 453 repos. The second fails mid-execution and is rescheduled._
