### PR TITLE
Hide archived classrooms into a sorting option

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,7 +15,7 @@ class OrganizationsController < Orgs::Controller
   skip_before_action :ensure_current_organization_visible_to_current_user, only: %i[index new create search]
 
   def index
-    @organizations = current_user.organizations.order(:id).page(params[:page]).per(12)
+    @organizations = current_user.organizations.where(archived_at: nil).order(:id).page(params[:page]).per(12)
   end
 
   def new

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,9 +33,10 @@ class Organization < ApplicationRecord
 
   before_destroy :silently_remove_organization_webhook
 
-  scope :order_by_newest, ->(_context = nil) { order(created_at: :desc) }
-  scope :order_by_oldest, ->(_context = nil) { order(created_at: :asc) }
-  scope :order_by_title,  ->(_context = nil) { order(:title) }
+  scope :order_by_newest,   ->(_context = nil) { order(created_at: :desc).where(archived_at: nil) }
+  scope :order_by_oldest,   ->(_context = nil) { order(created_at: :asc).where(archived_at: nil) }
+  scope :order_by_title,    ->(_context = nil) { order(:title).where(archived_at: nil) }
+  scope :order_by_archived, ->(query) { where.not(archived_at: nil).order(archived_at: :desc) }
 
   scope :search_by_title, ->(query) { where("title ILIKE ?", "%#{query}%") }
 
@@ -47,7 +48,8 @@ class Organization < ApplicationRecord
     {
       "Oldest first" => :order_by_oldest,
       "Newest first" => :order_by_newest,
-      "Classroom name" => :order_by_title
+      "Classroom name" => :order_by_title,
+      "Archived (newest first)" => :order_by_archived
     }
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,7 +36,7 @@ class Organization < ApplicationRecord
   scope :order_by_newest,   ->(_context = nil) { order(created_at: :desc).where(archived_at: nil) }
   scope :order_by_oldest,   ->(_context = nil) { order(created_at: :asc).where(archived_at: nil) }
   scope :order_by_title,    ->(_context = nil) { order(:title).where(archived_at: nil) }
-  scope :order_by_archived, ->(_contet = nil) { where.not(archived_at: nil).order(archived_at: :desc) }
+  scope :order_by_archived, ->(_context = nil) { where.not(archived_at: nil).order(archived_at: :desc) }
 
   scope :search_by_title, ->(query) { where("title ILIKE ?", "%#{query}%") }
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,7 +36,7 @@ class Organization < ApplicationRecord
   scope :order_by_newest,   ->(_context = nil) { order(created_at: :desc).where(archived_at: nil) }
   scope :order_by_oldest,   ->(_context = nil) { order(created_at: :asc).where(archived_at: nil) }
   scope :order_by_title,    ->(_context = nil) { order(:title).where(archived_at: nil) }
-  scope :order_by_archived, ->(query) { where.not(archived_at: nil).order(archived_at: :desc) }
+  scope :order_by_archived, ->(_contet = nil) { where.not(archived_at: nil).order(archived_at: :desc) }
 
   scope :search_by_title, ->(query) { where("title ILIKE ?", "%#{query}%") }
 


### PR DESCRIPTION
## What
This and #2189 will finish the classroom archiving feature (#602).

This PR moves archived classrooms out of the dashboard into its own `Archived` section.

![R7RkrXebON](https://user-images.githubusercontent.com/1490434/62653674-e855d580-b912-11e9-8d8f-6af447a99648.gif)
