### PR TITLE
Adding the classroom-reviewers team as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners
 # -----------
 
-*               @srinjoym @benemdon @d12
+*               @srinjoym @benemdon @d12 @education/classroom-reviewers
 
 README.md       @mozzadrella
 ROADMAP.md      @mozzadrella

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners
 # -----------
 
-*               @srinjoym @benemdon @d12 @education/classroom-reviewers
+*               @education/classroom-reviewers
 
 README.md       @mozzadrella
 ROADMAP.md      @mozzadrella


### PR DESCRIPTION
Right now we only have a few code owners. Now that we have a larger `-reviewers` team we can share the work and get approvals. Also, we can add and remove people from the team externally.

cc @andrewbredow 