### PR TITLE
Cange lti_launch to :post

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,11 +18,11 @@ Rails.application.routes.draw do
   post "/logout", to: "sessions#destroy", as: "logout"
 
   get  "/login/oauth/authorize", to: "oauth#authorize"
-  post  "/login/oauth/access_token", to: "oauth#access_token"
+  post "/login/oauth/access_token", to: "oauth#access_token"
 
-  match "/auth/lti/setup",          to: "sessions#lti_setup",     via: %i[get post]
-  match "/auth/lti/launch",         to: "sessions#lti_launch",    via: %i[get post]
-  match "/auth/lti/failure",        to: "sessions#lti_failure",   via: %i[get post]
+  post "/auth/lti/launch",          to: "sessions#lti_launch"
+  get "/auth/lti/setup",            to: "sessions#lti_setup"
+  get "/auth/lti/failure",          to: "sessions#lti_failure"
   match "/auth/:provider/callback", to: "sessions#create",        via: %i[get post]
   match "/auth/failure",            to: "sessions#failure",       via: %i[get post]
 

--- a/spec/integration/lti_launch_spec.rb
+++ b/spec/integration/lti_launch_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe "LTI launch", type: :request do
 
   describe "sessions#lti_launch", :vcr do
     it "sets cached_launch_message_nonce on corresponding lti_configuration" do
-      get auth_lti_launch_path(oauth_consumer_key: consumer_key)
+      post auth_lti_launch_path(oauth_consumer_key: consumer_key)
       lti_configuration.reload
       expect(lti_configuration.cached_launch_message_nonce).to eql("mock_nonce")
     end
 
     it "renders lti_launch template" do
-      get auth_lti_launch_path(oauth_consumer_key: consumer_key)
+      post auth_lti_launch_path(oauth_consumer_key: consumer_key)
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:lti_launch)
     end
 
     context "unauthenticated request" do
       it "post_launch_url is set to sessions#new" do
-        get auth_lti_launch_path(oauth_consumer_key: consumer_key)
+        post auth_lti_launch_path(oauth_consumer_key: consumer_key)
         expect(assigns[:post_launch_url]).to eq(login_url) # /login
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe "LTI launch", type: :request do
       end
 
       it "post_launch_url is set to LtiConfigurations#complete" do
-        get auth_lti_launch_path(oauth_consumer_key: consumer_key)
+        post auth_lti_launch_path(oauth_consumer_key: consumer_key)
         expect(assigns[:post_launch_url]).to eq(complete_lti_configuration_url(id: organization.slug))
       end
     end


### PR DESCRIPTION
## What
As identified in #2166, `/auth/lti/launch` should only accept POST requests. 