### PR TITLE
Rename Assignment::RepositoryVisibilityJob to a single class

### DIFF
--- a/app/jobs/assignment/repository_visibility_job.rb
+++ b/app/jobs/assignment/repository_visibility_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This is deprecated and will be removed in a subsequent deploy
+# Please see AssignmentRepositoryVisibilityJob
 class Assignment
   class RepositoryVisibilityJob < ApplicationJob
     queue_as :assignment

--- a/app/jobs/assignment_repository_visibility_job.rb
+++ b/app/jobs/assignment_repository_visibility_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AssignmentRepositoryVisibilityJob < ApplicationJob
+  queue_as :assignment
+
+  rescue_from ActiveJob::DeserializationError do |_exception|
+    # Assignment no longer exists. No point in running this job anymore.
+    # Just swallow the error so we don't retry
+  end
+
+  def perform(assignment, change:)
+    assignment.repos.each do |assignment_repo|
+      assignment_repo.github_repository.public = change.last
+    end
+  end
+end

--- a/app/models/assignment/editor.rb
+++ b/app/models/assignment/editor.rb
@@ -94,7 +94,7 @@ class Assignment
     def update_attribute_for_all_assignment_repos(attribute:, change:)
       case attribute
       when "public_repo"
-        Assignment::RepositoryVisibilityJob.perform_later(@assignment, change: change)
+        AssignmentRepositoryVisibilityJob.perform_later(@assignment, change: change)
       end
     end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
         allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
 
-        assert_enqueued_jobs 1, only: Assignment::RepositoryVisibilityJob do
+        assert_enqueued_jobs 1, only: AssignmentRepositoryVisibilityJob do
           patch :update, params: { id: assignment.slug, organization_id: organization.slug, assignment: options }
         end
       end
@@ -300,7 +300,7 @@ RSpec.describe AssignmentsController, type: :controller do
       it "will not kick off an AssignmentVisibility job" do
         options = { title: "Ruby on Rails" }
 
-        assert_no_enqueued_jobs only: Assignment::RepositoryVisibilityJob do
+        assert_no_enqueued_jobs only: AssignmentRepositoryVisibilityJob do
           patch :update, params: { id: assignment.slug, organization_id: organization.slug, assignment: options }
         end
       end

--- a/spec/controllers/group_assignments_controller_spec.rb
+++ b/spec/controllers/group_assignments_controller_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe GroupAssignmentsController, type: :controller do
 
         allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
 
-        assert_enqueued_jobs 1, only: Assignment::RepositoryVisibilityJob do
+        assert_enqueued_jobs 1, only: AssignmentRepositoryVisibilityJob do
           patch :update, params: {
             id:               group_assignment.slug,
             organization_id:  organization.slug,
@@ -219,7 +219,7 @@ RSpec.describe GroupAssignmentsController, type: :controller do
       it "will not kick off an AssignmentVisibility background job" do
         options = { title: "JavaScript Calculator" }
 
-        assert_no_enqueued_jobs only: Assignment::RepositoryVisibilityJob do
+        assert_no_enqueued_jobs only: AssignmentRepositoryVisibilityJob do
           patch :update, params: {
             id:               group_assignment.slug,
             organization_id:  organization.slug,

--- a/spec/jobs/repository_visibility_job_spec.rb
+++ b/spec/jobs/repository_visibility_job_spec.rb
@@ -10,8 +10,8 @@ module ActiveJob
   end
 end
 
-RSpec.describe Assignment::RepositoryVisibilityJob, type: :job do
-  subject { Assignment::RepositoryVisibilityJob }
+RSpec.describe AssignmentRepositoryVisibilityJob, type: :job do
+  subject { AssignmentRepositoryVisibilityJob }
 
   context "when a serialization error is thrown" do
     it "does not crash the test" do

--- a/spec/models/assignment/editor_spec.rb
+++ b/spec/models/assignment/editor_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Assignment::Editor do
 
           expect do
             subject.perform(assignment: assignment, options: { public_repo: false })
-          end.to_not have_enqueued_job(Assignment::RepositoryVisibilityJob)
+          end.to_not have_enqueued_job(AssignmentRepositoryVisibilityJob)
         end
 
         it "returns failed result" do
@@ -163,7 +163,7 @@ RSpec.describe Assignment::Editor do
 
           expect do
             subject.perform(assignment: assignment, options: { public_repo: false })
-          end.to have_enqueued_job(Assignment::RepositoryVisibilityJob)
+          end.to have_enqueued_job(AssignmentRepositoryVisibilityJob)
         end
 
         it "returns success result" do


### PR DESCRIPTION
Currently we have two definitions of the `Assignment` class and this tends to break auto-loading in unexpected ways. This PR renames `Assignment::RepositoryVisibilityJob` to `AssignmentRepositoryVisibilityJob` making it no-longer-nested. This keeps the concerns of Jobs and Models separate.

Because this PR renames a Job we need to deploy the fix in multiple steps:

1. Duplicate the job with the new name and start using that new job only
2. Deploy that change
2. Wait until the old jobs are out of the queue (and only new jobs are being enqueued)
3. Remove the old job and deploy 

This should fix the `Assignment` errors which led to today's maintenance mode. 