### PR TITLE
Moves RosterEntry creation to background job

### DIFF
--- a/app/assets/javascripts/channels/add_students_to_roster.js
+++ b/app/assets/javascripts/channels/add_students_to_roster.js
@@ -1,0 +1,97 @@
+(function(){
+  var PROGRESS_HALF_LIFE = 1000;
+  var setup_roster_update_cable,
+  progress_asymptotically,
+  display_message,
+  set_progress,
+  display_progress_bar,
+  initialize_progress;
+
+  setup_roster_update_cable = function(){
+    var roster_id = $("#roster_id").val();
+    var user_id = $("#user_id").val();
+    App.add_students_to_roster = App.cable.subscriptions.create({
+      channel: "AddStudentsToRosterChannel",
+      roster_id: roster_id,
+      user_id: user_id
+    },
+    {
+      connected: function() {
+        // Called when the subscription is ready for use on the server
+      },
+
+      disconnected: function() {
+        // Called when the subscription has been terminated by the server
+      },
+
+      received: function(data) {
+        // Called when there's incoming data on the websocket for this channel
+        initialize_progress(data);
+
+      }
+    });
+  };
+
+  progress_asymptotically = function() {
+    recursive_progress_asymptotically = function(recursive_callback, counter) {
+      var progress;
+      var remaining = 100/counter;
+      if(remaining == 1){
+        progress = 99;
+      }else{
+        progress = 100 - (100/counter);
+      }
+      $(document)
+      .find(".roster-update-progress-bar")
+      .animate(
+        { width: progress.toFixed() + "%" },
+        { duration: PROGRESS_HALF_LIFE * counter }
+      );
+      setTimeout(function() {
+        recursive_callback(recursive_callback, counter + 1);
+      },
+      PROGRESS_HALF_LIFE * counter
+    );
+  };
+  recursive_progress_asymptotically(recursive_progress_asymptotically, 1);
+};
+
+display_message = function(message){
+  $(".roster-update-message").removeAttr("hidden");
+  $("#roster-progress").text(message);
+};
+
+set_progress = function(percent) {
+  $(".roster-update-progress-bar").stop(true, false);
+  if (percent === 0) {
+    $(".roster-update-progress-bar").css("width", 0);
+  } else if (percent) {
+    $(".roster-update-progress-bar").animate({width: percent + "%"});
+  }
+};
+
+display_progress_bar = function(){
+  $('.roster-update-progress').removeAttr("hidden");
+};
+
+
+initialize_progress = function(data){
+  switch(data.status){
+    case "update_started":
+      display_progress_bar();
+      progress_asymptotically();
+      break;
+    case "completed":
+      set_progress(100);
+      display_message(data.message);
+      break;
+  }
+};
+
+ready = (function(){
+  setup_roster_update_cable();
+});
+
+$(document).ready(ready);
+
+}).call(this);

--- a/app/channels/add_students_to_roster_channel.rb
+++ b/app/channels/add_students_to_roster_channel.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddStudentsToRosterChannel < ApplicationCable::Channel
+  def self.channel(user_id:, roster_id:)
+    "#{channel_name}_#{user_id}_#{roster_id}"
+  end
+
+  def subscribed
+    stream_from self.class.channel(roster_id: params[:roster_id], user_id: current_user.id)
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/jobs/add_students_to_roster_job.rb
+++ b/app/jobs/add_students_to_roster_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class AddStudentsToRosterJob < ApplicationJob
+  queue_as :roster
+
+  ROSTER_UPDATE_SUCCESSFUL = "Roster successfully updated."
+  ROSTER_UPDATE_FAILED     = "Could not add any students to roster, please try again."
+  ROSTER_UPDATE_PARTIAL_SUCCESS = "Could not add following students: "
+
+  # Takes an array of identifiers and creates a
+  # roster entry for each. Omits duplicates, and
+  #
+  # rubocop:disable AbcSize
+  def perform(identifiers, roster, user, lms_user_ids = [])
+    channel = AddStudentsToRosterChannel.channel(roster_id: roster.id, user_id: user.id)
+    ActionCable.server.broadcast(channel, status: "update_started")
+
+    identifiers = add_suffix_to_duplicates!(identifiers)
+    invalid_roster_entries =
+      identifiers.zip(lms_user_ids).map do |identifier, lms_user_id|
+        roster_entry = RosterEntry.create(identifier: identifier, roster: roster, lms_user_id: lms_user_id)
+        roster_entry if roster_entry.errors.include?(:identifier)
+      end
+
+    message = build_message(invalid_roster_entries.compact, identifiers)
+
+    ActionCable.server.broadcast(channel, message: message, status: "completed")
+  end
+  # rubocop:enable AbcSize
+
+  def add_suffix_to_duplicates!(identifiers)
+    existing_roster_entries = RosterEntry.where(roster: roster).pluck(:identifier)
+    RosterEntry.add_suffix_to_duplicates(
+      identifiers: identifiers,
+      existing_roster_entries: existing_roster_entries
+    )
+  end
+
+  # rubocop:disable MethodLength
+  def build_message(invalid_roster_entries, identifiers)
+    if invalid_roster_entries.empty?
+      ROSTER_UPDATE_SUCCESSFUL
+    elsif invalid_roster_entries.size == identifiers.size
+      ROSTER_UPDATE_FAILED
+    else
+      formatted_students =
+        invalid_roster_entries.map do |invalid_roster_entry|
+          "#{invalid_roster_entry.identifier} \n"
+        end.join("")
+      "#{ROSTER_UPDATE_PARTIAL_SUCCESS} \n#{formatted_students}"
+    end
+  end
+  # rubocop:enable MethodLength
+end

--- a/app/models/roster_entry.rb
+++ b/app/models/roster_entry.rb
@@ -92,35 +92,4 @@ class RosterEntry < ApplicationRecord
       .uniq
     where(user_id: nil).or(where.not(user_id: students_on_team))
   end
-
-  # Takes an array of identifiers and creates a
-  # roster entry for each. Omits duplicates, and
-  # raises IdentifierCreationError if there is an
-  # error.
-  #
-  # Returns the created entries.
-
-  # rubocop:disable Metrics/MethodLength
-  def self.create_entries(identifiers:, roster:, lms_user_ids: [])
-    created_entries = []
-    RosterEntry.transaction do
-      identifiers = add_suffix_to_duplicates(
-        identifiers: identifiers,
-        existing_roster_entries: RosterEntry.where(roster: roster).pluck(:identifier)
-      )
-
-      identifiers.zip(lms_user_ids).each do |identifier, lms_user_id|
-        roster_entry = RosterEntry.create(identifier: identifier, roster: roster, lms_user_id: lms_user_id)
-
-        if !roster_entry.persisted?
-          raise IdentifierCreationError unless roster_entry.errors.include?(:identifier)
-        else
-          created_entries << roster_entry
-        end
-      end
-    end
-
-    created_entries
-  end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 end

--- a/app/views/orgs/rosters/show.html.erb
+++ b/app/views/orgs/rosters/show.html.erb
@@ -26,6 +26,23 @@
           </div>
         </h3>
 
+        <div class="flex-justify-between roster-update-progress" hidden>
+          <div class="Box Box--blue">
+            <div class="flash flash-full roster-update-message" hidden>
+              <button class="flash-close js-flash-close"><%= octicon "x" %></button>
+              <p id="roster-progress"></p>
+            </div>
+            <div class="Box-body">
+              <div class="Subhead border-bottom-0">
+                <h4 class="Subhead-heading Subhead-heading--blue">Adding students to Roster</h4>
+              </div>
+              <span class="Progress Progress">
+                <span class="bg-green roster-update-progress-bar" style="width: 0%;"></span>
+              </span>
+            </div>
+          </div>
+        </div>
+
         <div class="site-content-body tabnav-body clearfix">
           <div class="tabnav">
             <nav class="tabnav-tabs">

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,3 +14,4 @@
   - [boom,              3]
   - [create_repository, 3]
   - [porter_status,     3]
+  - [roster,            3]


### PR DESCRIPTION
## What

Fixes #2210 

- Setup `AddStudentsToRosterChannel` to send progress
- channel is called from `AddStudentsToRosterJob`
- progress via action cable is handled by `add_students_to_roster.js`
- removes the old `create_entries` method from model

TODO:

- [ ] Add specs
- [ ] Iterate on UIUX

I'll put up a few screenshots of this soon, 