### PR TITLE
fixed green link and used standard flash banner

### DIFF
--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -4,7 +4,7 @@
 
   a {
     font-weight: bold;
-    color: #58d984;
+    color: $blue-600;
   }
 
   .container-lg {

--- a/app/views/shared/_message_of_the_day.html.erb
+++ b/app/views/shared/_message_of_the_day.html.erb
@@ -1,7 +1,11 @@
 <% if ENV['MOTD'].present? %>
   <div class="message-of-the-day">
-    <div class="container-lg">
-      <p><%= ENV['MOTD'].html_safe %></p>
+    <div class="js-flash-container">
+      <div class="flash flash-full flash-notice">
+        <div class="container">
+          <p class="text-gray"><%= ENV['MOTD'].html_safe %></p>
+          </div>
+        </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
## What
Changed the non-standard green link to standard blue; also used standard Primer flash banner  :sparkles:

### Before

<img width="1679" alt="Screen Shot 2019-08-13 at 10 43 19 AM" src="https://user-images.githubusercontent.com/471514/62979971-43943600-bdf3-11e9-8573-aa44a631acae.png">

### After

![screencapture-localhost-5000-classrooms-2019-08-13-17_50_27](https://user-images.githubusercontent.com/471514/62979988-4ee76180-bdf3-11e9-95c2-1e088293a355.png)

