### PR TITLE
Added Assignment::Creator class

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -37,4 +37,9 @@ class ApplicationController
     logged_in? && current_user.feature_enabled?(:classroom_visibility)
   end
   helper_method :classroom_visibility_enabled?
+
+  def assignment_creator_enabled?
+    logged_in? && current_user.feature_enabled?(:assignment_creator)
+  end
+  helper_method :assignment_creator_enabled?
 end

--- a/app/models/assignment/creator.rb
+++ b/app/models/assignment/creator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Assignment
+  class Creator
+    attr_reader :assignment, :options
+
+    class Result
+      class Error < StandardError; end
+
+      def self.success(assignment)
+        new(:success, assignment: assignment)
+      end
+
+      def self.failed(assignment, error)
+        new(:failed, assignment: assignment, error: error)
+      end
+
+      attr_reader :assignment, :error
+
+      def initialize(status, assignment: nil, error: nil)
+        @status     = status
+        @assignment = assignment
+        @error      = error
+      end
+
+      def success?
+        @status == :success
+      end
+
+      def failed?
+        @status == :failed
+      end
+    end
+
+    # Public: Create an Assignment.
+    #
+    # options - The Hash of attributes used to create the assignment.
+    #
+    # Returns a Assignment::Creator::Result.
+    def self.perform(options:)
+      new(options: options).perform
+    end
+
+    def initialize(options:)
+      @options = options
+    end
+
+    def perform
+      assignment = Assignment.new(@options)
+      assignment.build_assignment_invitation
+      assignment.save!
+      assignment.deadline&.create_job
+
+      send_create_assignment_statsd_events(assignment)
+      Result.success(assignment)
+    rescue ActiveRecord::RecordInvalid => error
+      Result.failed(assignment, error.message)
+    end
+
+    private
+
+    def send_create_assignment_statsd_events(assignment)
+      GitHubClassroom.statsd.increment("exercise.create")
+      GitHubClassroom.statsd.increment("deadline.create") if assignment.deadline
+    end
+  end
+end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe AssignmentsController, type: :controller do
   end
 
   describe "POST #create", :vcr do
+    before(:each) do
+      GitHubClassroom.flipper[:assignment_creator].disable
+    end
+
     it "creates a new Assignment" do
       expect do
         post :create, params: {

--- a/spec/models/assignment/creator_spec.rb
+++ b/spec/models/assignment/creator_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Assignment::Creator do
+  subject { Assignment::Creator }
+
+  before(:each) do
+    GitHubClassroom.flipper[:assignment_creator].disable
+  end
+
+  describe "#perform" do
+    let(:organization)  { classroom_org }
+    let(:user)          { classroom_teacher }
+    let(:options) do
+      {
+        title: "Assignment 1",
+        slug: "assignment-1",
+        public_repo: true,
+        students_are_repo_admins: 0,
+        invitations_enabled: 1,
+        template_repos_enabled: true,
+        creator: user,
+        organization: organization
+      }
+    end
+
+    context "success" do
+      it "returns success" do
+        result = subject.perform(options: options)
+        expect(result.success?).to be true
+      end
+
+      it "returns the persisted assignment" do
+        result = subject.perform(options: options)
+        expect(result.assignment).not_to be_nil
+        expect(result.assignment.persisted?).to be true
+      end
+    end
+
+    context "failure" do
+      before(:each) do
+        options[:title] = ""
+      end
+
+      it "returns failure" do
+        result = subject.perform(options: options)
+        expect(result.failed?).to be true
+        expect(result.error).to eql("Validation failed: Your assignment title must be present")
+      end
+
+      it "returns result containing unsaved assignment" do
+        result = subject.perform(options: options)
+        expect(result.assignment.persisted?).to be false
+      end
+    end
+  end
+
+  context "deadlines" do
+    let(:organization)  { classroom_org }
+    let(:user)          { classroom_teacher }
+    let(:assignment)   { create(:assignment, organization: organization) }
+
+    it "sends an event to statsd" do
+      expect(GitHubClassroom.statsd).to receive(:increment).with("exercise.create")
+      expect(GitHubClassroom.statsd).to receive(:increment).with("deadline.create")
+
+      deadline = Deadline::Factory.build_from_string(deadline_at: "05/25/2100 13:17-0800")
+      subject.perform(options: attributes_for(:assignment, organization: organization)
+        .merge(deadline: deadline, organization: organization))
+    end
+
+    context "valid datetime for deadline is passed" do
+      before do
+        deadline = Deadline::Factory.build_from_string(deadline_at: "05/25/2100 13:17-0800")
+        subject.perform(options: attributes_for(:assignment, organization: organization)
+          .merge(deadline: deadline, organization: organization))
+      end
+
+      it "creates a new assignment" do
+        expect(Assignment.count).to eq(1)
+      end
+
+      it "sets deadline" do
+        expect(Assignment.first.deadline).to be_truthy
+      end
+    end
+
+    context "invalid datetime for deadline passed" do
+      before do
+        deadline = Deadline::Factory.build_from_string(deadline_at: "I am not a datetime")
+        options = attributes_for(:assignment, organization: organization)
+          .merge(deadline: deadline, organization: organization)
+        subject.perform(options: options)
+      end
+
+      it "creates a new assignment" do
+        expect(Assignment.count).to eq(1)
+      end
+
+      it "sets deadline to nil" do
+        expect(Assignment.first.deadline).to be_nil
+      end
+    end
+
+    context "no deadline passed" do
+      before do
+        options = attributes_for(:assignment, organization: organization).merge(organization: organization)
+        subject.perform(options: options)
+      end
+
+      it "creates a new assignment" do
+        expect(Assignment.count).to eq(1)
+      end
+
+      it "sets deadline to nil" do
+        expect(Assignment.first.deadline).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
This PR adds a `Creator` class for `Assignment` so that we can isolate everything related to assignment creation outside of the controller. We'll be adding a lot more logic to assignment creation with #2241.

We already have an `Assignment::Editor` class and this is similar to `Organization::Creator`, `Group::Creator`, and `Roster::Creator`.

## Notes
- This is under a feature flag and will be gradually rolled out
- Old logic/tests inside the controller will be removed once we're 100% with this Creator
- I plan to merge group assignment creation into this creator, unifying `GroupAssignment` and `Assignment` creation under one creator class