### PR TITLE
Center support doc images on safari

### DIFF
--- a/docs/generate-lms-credentials.md
+++ b/docs/generate-lms-credentials.md
@@ -17,7 +17,7 @@ click **Other learning management system**.
 
 1. Follow the prompts. At the end you'll see a screen which looks like this:
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/github-classroom-credentials.png" class="border" style="width: 75%;">
    </div>
    <br>
@@ -36,7 +36,7 @@ click **Other learning management system**.
 
 4. Follow the prompts. At the end you'll see a screen which looks like this:
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/github-classroom-credentials.png" class="border" style="width: 75%;">
    </div>
    <br>

--- a/docs/import-roster-from-lms.md
+++ b/docs/import-roster-from-lms.md
@@ -13,7 +13,7 @@ Importing a course roster from your learning management system will only work if
 
 To import a new course roster from your learning management system:
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/roster-import/import-roster.gif" class="border" style="width: 75%;">
    </div>
 
@@ -46,8 +46,8 @@ You have imported your roster into GitHub Classroom.
 
 After you've imported a roster, keep it up to date by syncing:
 
-   <div class="d-flex flex-justify-around">
-     <img src="/images/help/lms/roster-import/sync-roster.gif" class="border" style="width: 75%;">
+   <div class="text-center">
+     <img src="/images/help/lms/roster-import/sync-roster.gif" style="width: 75%;">
    </div>
 
 1. [Sign in to GitHub Classroom](https://classroom.github.com/login).

--- a/docs/import-roster-from-lms.md
+++ b/docs/import-roster-from-lms.md
@@ -46,9 +46,9 @@ You have imported your roster into GitHub Classroom.
 
 After you've imported a roster, keep it up to date by syncing:
 
-   <div class="text-center">
-     <img src="/images/help/lms/roster-import/sync-roster.gif" style="width: 75%;">
-   </div>
+  <div class="text-center">
+    <img src="/images/help/lms/roster-import/sync-roster.gif" class="border" style="width: 75%;">
+  </div>
 
 1. [Sign in to GitHub Classroom](https://classroom.github.com/login).
 

--- a/docs/probot-settings.md
+++ b/docs/probot-settings.md
@@ -10,9 +10,9 @@ Adding the Probot Settings app to your organization turns it on for any repo in 
 
 1. Add the Probot Settings app to the GitHub organization you use with Classroom. Go to [the Settings app page](https://github.com/apps/settings) and click **+ Add to GitHub**. When asked, make sure to give it access to all the repositories in the organization.
 
-   <div class="text-center">
-     <img src="/images/help/probot-settings.gif" style="width: 75%;">
-   </div>
+  <div class="text-center">
+    <img src="/images/help/probot-settings.gif" class="border" style="width: 75%;">
+  </div>
 
 2. Add a `.github/settings.yml` file to your starter repo. See the [probot/settings README](https://github.com/probot/settings#github-settings) for a complete list of settings.
 

--- a/docs/probot-settings.md
+++ b/docs/probot-settings.md
@@ -10,8 +10,8 @@ Adding the Probot Settings app to your organization turns it on for any repo in 
 
 1. Add the Probot Settings app to the GitHub organization you use with Classroom. Go to [the Settings app page](https://github.com/apps/settings) and click **+ Add to GitHub**. When asked, make sure to give it access to all the repositories in the organization.
 
-   <div class="d-flex flex-justify-around">
-     <img src="/images/help/probot-settings.gif" class="border" style="width: 75%;">
+   <div class="text-center">
+     <img src="/images/help/probot-settings.gif" style="width: 75%;">
    </div>
 
 2. Add a `.github/settings.yml` file to your starter repo. See the [probot/settings README](https://github.com/probot/settings#github-settings) for a complete list of settings.

--- a/docs/setup-canvas.md
+++ b/docs/setup-canvas.md
@@ -14,14 +14,14 @@ the configuration process)
 1. Select the Canvas course to integrate with GitHub Classroom.
 1. In the course sidebar, navigate to _Settings_, then _Apps_.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/canvas/step-4.png" class="border" style="width: 75%;">
    </div>
 
 1. Click **+ App** in the top right. A popup appears.
 1. In _Configuration Type_ dropdown, select **By URL**.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/canvas/step-6.png" class="border" style="width: 75%;">
    </div>
 
@@ -36,19 +36,19 @@ the configuration process)
 
     After entering that information, the form should look like:
 
-    <div class="d-flex flex-justify-around">
+    <div class="text-center">
       <img src="/images/help/lms/canvas/step-7.png" class="border" style="width: 75%;">
     </div>
 
 1. Click _Submit_ and navigate out of settings.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/canvas/step-9.png" class="border" style="width: 30%;">
    </div>
 
 1. Click _GitHub Classroom_ to finish linking GitHub Classroom. You should see following screen:
 
-    <div class="d-flex flex-justify-around">
+    <div class="text-center">
       <img src="/images/help/lms/canvas/success.png" class="border" style="width: 75%;">
     </div>
 
@@ -60,7 +60,7 @@ the configuration process)
 
 If you don’t see a checkbox in Canvas labeled _Allow this tool to access the IMS Names and Role Provisioning Service_, then you may have to ask your institution’s Canvas administrator to enable _Membership Service Configuration_ for your account.
 
-<div class="d-flex flex-justify-around">
+<div class="text-center">
   <img src="/images/help/lms/canvas/troubleshooting-1.png" class="border" style="width: 75%;">
 </div>
 

--- a/docs/setup-generic-lms.md
+++ b/docs/setup-generic-lms.md
@@ -23,7 +23,7 @@ While learning management systems differ, the main idea is the same across all v
 
 When you have successfully linked GitHub Classroom to your LMS, you should be directed the following screen:
 
-  <div class="d-flex flex-justify-around">
+  <div class="text-center">
     <img src="/images/help/lms/generic/success.png" class="border" style="width: 75%;">
   </div>
 

--- a/docs/setup-moodle.md
+++ b/docs/setup-moodle.md
@@ -15,25 +15,25 @@ the configuration process)
 1. Turn editing on.
 1. Wherever you’d like GitHub Classroom to be accessible from, click **Add an activity or resource**.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-4.png" class="border" style="width: 75%;">
    </div>
 
 1. From the dialog box that pops up, choose **External tool** and click **Add**.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-5.png" class="border" style="width: 75%;">
    </div>
 
 1. In the _Activity name_ field, enter <kbd>GitHub Classroom</kbd>.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-6.png" class="border" style="width: 75%;">
    </div>
 
 1. In the _Preconfigured tool_ field, click the **+** to the right of the dropdown menu. A screen appears which looks like this:
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-8.png" class="border" style="width: 75%;">
    </div>
 
@@ -52,19 +52,19 @@ the configuration process)
 
 1. Scroll to and click **Services**.
 
-    <div class="d-flex flex-justify-around">
+    <div class="text-center">
       <img src="/images/help/lms/moodle/step-10.png" class="border" style="width: 75%;">
     </div>
 
 1. In the _IMS LTI Names and Role Provisioning_ menu, select **Use this service**.
 
-    <div class="d-flex flex-justify-around">
+    <div class="text-center">
       <img src="/images/help/lms/moodle/step-11.png" class="border" style="width: 30%;">
     </div>
 
 1. Scroll down to the bottom of the page and click **Save changes**. You should retun to the page that looks like this:
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-13.png" class="border" style="width: 30%;">
    </div>
 
@@ -72,7 +72,7 @@ the configuration process)
 
 1. In the _Activity_ menu (under _Common module settings_), select **Hide from students**.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/lms/moodle/step-15.png" class="border" style="width: 30%;">
    </div>
 
@@ -80,7 +80,7 @@ the configuration process)
 
 1. You should now see a _GitHub Classroom_ activity wherever your chose to place it.
 
-    <div class="d-flex flex-justify-around">
+    <div class="text-center">
       <img src="/images/help/lms/moodle/step-17.png" class="border" style="width: 30%;">
     </div>
 
@@ -88,7 +88,7 @@ the configuration process)
 
 You should now be directed the following screen. You have successfully linked GitHub Classroom to your Moodle.
 
-<div class="d-flex flex-justify-around">
+<div class="text-center">
   <img src="/images/help/lms/moodle/success.png" class="border" style="width: 75%;">
 </div>
 

--- a/docs/upgrade-your-organization.md
+++ b/docs/upgrade-your-organization.md
@@ -3,10 +3,10 @@
 Verified faculty can now upgrade any GitHub organization being used for academic purposes to [GitHub Team](https://github.com/pricing) for free.
 
 1. Go to [GitHub Education Benefits](https://education.github.com/benefits).
-   
+
    Organizations you own are listed under _Upgrade your organization_.
 
-   <div class="d-flex flex-justify-around">
+   <div class="text-center">
      <img src="/images/help/upgrade-organization.png" class="border" style="width: 75%;">
    </div>
 


### PR DESCRIPTION
## What
Closes #2247. Fixes the weird centering issues on Safari with images in the docs caused by the `.d-flex` class and replaces them with the `.text-center` class. 

For reasons I could not diagnose even after playing around in the chrome dev tools for far too long ([how I feel rn](https://assets.website-files.com/5c7fdbdd4e3feeee8dd96dd2/5cf55c917b91f817a2be8637_cszhu.png)),  the `.mx-auto` margin-centering does not work, even though the image has a set width. 

Regardless, now support doc images are properly centered on Safari! 

<img width="956" alt="Screen Shot 2019-08-14 at 6 16 46 PM" src="https://user-images.githubusercontent.com/2936741/63066614-d7333880-bebf-11e9-9356-3adfbc9fff44.png">
