### PR TITLE
Make MOTD responsive

### DIFF
--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -2,6 +2,8 @@
   color: #fff;
   background-color: $blue;
 
+  width: 100%;
+
   a {
     font-weight: bold;
     color: $blue-600;

--- a/app/assets/stylesheets/components/message-of-the-day.scss
+++ b/app/assets/stylesheets/components/message-of-the-day.scss
@@ -2,8 +2,6 @@
   color: #fff;
   background-color: $blue;
 
-  width: 100%;
-
   a {
     font-weight: bold;
     color: $blue-600;

--- a/app/views/shared/_message_of_the_day.html.erb
+++ b/app/views/shared/_message_of_the_day.html.erb
@@ -2,7 +2,7 @@
   <div class="message-of-the-day">
     <div class="js-flash-container">
       <div class="flash flash-full flash-notice">
-        <div class="container">
+        <div class="container-lg">
           <p class="text-gray"><%= ENV['MOTD'].html_safe %></p>
           </div>
         </div>


### PR DESCRIPTION
## What
Closes https://github.com/education/classroom/issues/2257
Fixes the MOTD so it is responsive. Uses primer container to fix it. 

### After
![8Nrtojmni3](https://user-images.githubusercontent.com/22784140/63187932-ea0b5180-c014-11e9-9425-d32cec6710db.gif)

### Before
![ikGO37Pgr4](https://user-images.githubusercontent.com/22784140/63187762-86812400-c014-11e9-9fe4-834f07567447.gif)

