### PR TITLE
updated assignment empty state messaging + UI tweaks to URL copy functionality

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -58,7 +58,7 @@
                 <%= render partial: 'assignments/filterable_assignment_roster_list', locals: { list_type: :roster_entries } %>
               <% else %>
                 <div class="blankslate">
-                  <h3>"<%= @assignment.title %>" does not have any repositories.</h3>
+                  <h3>No students have accepted "<%= @assignment.title %>".</h3>
                   <p>Share the invitation link with your students to get started.</p>
                 </div>
               <% end %>
@@ -83,7 +83,7 @@
         <%= render partial: 'assignments/filterable_assignment_roster_list', locals: { list_type: :assignment_repos } %>
       <% else %>
         <div class="blankslate">
-          <h3>"<%= @assignment.title %>" does not have any repositories.</h3>
+          <h3>No students have accepted "<%= @assignment.title %>"</h3>
           <p>Share the invitation link with your students to get started.</p>
         </div>
       <% end %>

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -59,7 +59,7 @@
               <%= render partial: 'group_assignments/filterable_group_assignment_repo_list', locals: { param_name: :teams_page } %>
             <% else %>
               <div class="blankslate">
-                <h3>"<%= @group_assignment.title %>" does not have any repositories.</h3>
+                <h3>No students have accepted "<%= @group_assignment.title %>".</h3>
                 <p>Share the invitation link with your students to get started.</p>
               </div>
             <% end %>
@@ -88,7 +88,7 @@
         <%= render partial: 'group_assignments/filterable_group_assignment_repo_list', locals: { param_name: :page } %>
       <% else %>
         <div class="blankslate">
-          <h3>"<%= @group_assignment.title %>" does not have any repositories.</h3>
+          <h3>No students have accepted "<%= @group_assignment.title %>".</h3>
           <p>Share the invitation link with your students to get started.</p>
         </div>
       <% end %>

--- a/app/views/shared/_invitation.html.erb
+++ b/app/views/shared/_invitation.html.erb
@@ -9,7 +9,10 @@
   <label>Enable assignment invitation URL</label>
   <span style="color: green"><%= octicon 'check', height: 16, id: "checkmark", style: "display: none; padding-bottom: 3px;" %></span>
   <%= image_tag 'octocat-spinner-128.gif', width: 13, height: 13, class: 'spinner', id: "loading-indicator", style: "display:none" %>
-  <div class="input-group input-block py-2">
+  <div class="input-group input-block pt-2 pb-1">
     <%= render partial: "shared/invitations/clipboard_form", locals: local_assigns %>
   </div>
-<%= t('views.shared.share_invite_url') %></dt>
+  <p class="note mb-3">
+    <%= t('views.shared.share_invite_url') %>
+  </p>
+</dt>

--- a/app/views/shared/invitations/_clipboard_form.html.erb
+++ b/app/views/shared/invitations/_clipboard_form.html.erb
@@ -1,9 +1,8 @@
 <div class="input-group">
-  <%= content_tag :input, '', type: 'text', class: "form-control input-sm",id: "#{type}-#{key}", value: url, readonly: 'readonly' %>
+  <%= content_tag :input, '', type: 'text', class: "form-control input-sm text-mono",id: "#{type}-#{key}", value: url, readonly: 'readonly' %>
   <span class="input-group-button">
     <button aria-label="<%= t('views.shared.copy_to_clipboard') %>" data-clipboard-target=<%= "##{type}-#{key}" %> class="js-clipboard btn btn-sm tooltipped tooltipped-s" type="button">
       <%= octicon 'clippy' %>
-      <%= t('views.shared.copy_invitation_link') %>
     </button>
   </span>
 </div>


### PR DESCRIPTION
## What 
- Changed the assignment empty state messaging from “[assignment name] does not have any repositories” to "No students have accepted  [assignment name]." The former message read as though it was prompting the teacher to create a repo or associate the assignment with a starter code repo.
- Added a bit of vertical space between the copy widget and the empty state box since it was sitting on top of it (see Before screenshot).
- Made a few UI tweaks to the URL copy widget:
  - Added `.note` to the explanatory text to make it less prominent
  - Removed the `Copy invitation link` button label. Since the checkbox label already clearly identifies the URL as an invitation link, the button label was redundant. Teachers are also already familiar with the copy functionality from GitHub's clone/download widget. 
  - Changed the font to mono to make it easier to distinguish similar characters like 0 from O, or I from l `0 from O, or I from l`. 

## Before
![screencapture-localhost-5000-classrooms-53626532-femmebot-classroom-org-classroom-1-assignments-week-01-2019-08-16-13_02_44](https://user-images.githubusercontent.com/471514/63188575-b5f15a00-c02f-11e9-9a87-e856474f92c3.png)


## After
![screencapture-localhost-5000-classrooms-53626532-femmebot-classroom-org-classroom-1-assignments-week-01-2019-08-16-13_53_06](https://user-images.githubusercontent.com/471514/63188557-b0940f80-c02f-11e9-9807-e34e1774101b.png)

![screencapture-localhost-5000-classrooms-53626532-femmebot-classroom-org-classroom-1-group-assignments-week-03-2019-08-16-13_51_49](https://user-images.githubusercontent.com/471514/63188572-b558c380-c02f-11e9-9390-1bdfcd539432.png)

![screencapture-localhost-5000-classrooms-53626532-femmebot-classroom-org-classroom-1-2019-08-16-13_51_28](https://user-images.githubusercontent.com/471514/63188573-b5f15a00-c02f-11e9-998d-317ef6fe67f5.png)

![screencapture-localhost-5000-classrooms-53626532-femmebot-classroom-org-classroom-1-assignments-week-01-2019-08-16-13_51_08](https://user-images.githubusercontent.com/471514/63188574-b5f15a00-c02f-11e9-8037-61cf56eb78dc.png)

