### PR TITLE
Mention file size limit for templates in docs

### DIFF
--- a/docs/using-template-repos-for-assignments.md
+++ b/docs/using-template-repos-for-assignments.md
@@ -41,6 +41,7 @@ Template repositories are the best option in _most_ cases. You may not want to u
 
 * You plan on pushing updates to the starter code repository _after_ releasing the assignment.
 * You care about the full commit history of the starter code repository.
+* Your repository contains very large files (individual files greater than 10mb in size)
 
 ### Helpful links:
 * [Creating a template repository](https://help.github.com/en/articles/creating-a-template-repository)


### PR DESCRIPTION
## What
Currently, template repos have a file size limit of 10mb. If users try to clone a template repo with a file size >10mb, on classroom it will succeed but the github repo will not clone properly.
