### PR TITLE
[WIP] Move rosters to a new tab and rename to students

### DIFF
--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -62,7 +62,7 @@ module Orgs
         create_statsd(lms_user_ids: params[:lms_user_ids])
         imported_students_lms_statsd(lms_user_ids: params[:lms_user_ids])
         flash[:success] = \
-          "Your classroom roster has been saved! Manage it <a href='#{roster_url(current_organization)}'>here</a>."
+          "Students have been added to your classroom! Manage students <a href='#{roster_url(current_organization)}'>here</a>."
 
         redirect_to organization_path(current_organization)
       else

--- a/app/views/organizations/_navigation.html.erb
+++ b/app/views/organizations/_navigation.html.erb
@@ -1,6 +1,7 @@
 <div class="tabnav organization-nav">
   <nav class="tabnav-tabs" aria-label="Classroom menu">
     <%= link_to 'Assignments', organization, class: "tabnav-tab #{'selected' if current_page?(organization_path(organization)) || request.path_info.include?('assignment')}" %>
+    <%= link_to 'Students', roster_path(organization), class: "tabnav-tab #{'selected' if current_page?(roster_path(organization)) || request.path_info.include?('roster')}" %>
     <%= link_to edit_organization_path(organization), class: "tabnav-tab #{'selected' if settings_view == true || request.path_info.include?('invite')}" do %>
       <%= octicon 'gear', class: 'mr-1' %>
       Settings

--- a/app/views/organizations/_organization_banner.html.erb
+++ b/app/views/organizations/_organization_banner.html.erb
@@ -17,7 +17,11 @@
         </div>
         <% if organization.archived? %><br><span class="Label v-align-middle" style="background-color: red;">Archived</span><% end %>
         <div class="mt-3">
-          <%= render 'organizations/navigation', organization: organization, settings_view: local_assigns[:settings] %>
+          <%= render 'organizations/navigation',
+            organization: organization,
+            roster_view: local_assigns[:students],
+            settings_view: local_assigns[:settings]
+          %>
         </div>
       </div>
     </div>

--- a/app/views/organizations/_side_menu.html.erb
+++ b/app/views/organizations/_side_menu.html.erb
@@ -14,7 +14,4 @@
   <%= link_to t('views.organizations.invite_other_admin'),
               settings_invitations_organization_path(organization),
               class: "menu-item #{'selected' if current_page?(settings_invitations_organization_path(organization))}" %>
-
-  <%= link_to 'Roster management', roster_path(organization),
-              class: "menu-item #{'selected' if current_page?(roster_path(organization))}" %>
 </nav>

--- a/app/views/orgs/rosters/_new_student_modal.html.erb
+++ b/app/views/orgs/rosters/_new_student_modal.html.erb
@@ -35,7 +35,7 @@
         </div>
 
           <div class="d-flex flex-items-center border-top pt-5">
-            <%= submit_tag 'Add roster entries', class: 'btn btn-primary mr-3' %>
+            <%= submit_tag 'Add students', class: 'btn btn-primary mr-3' %>
           </div>
         <% end %>
       </div>

--- a/app/views/orgs/rosters/_remove_roster_modal.html.erb
+++ b/app/views/orgs/rosters/_remove_roster_modal.html.erb
@@ -1,18 +1,17 @@
 <div class="remodal text-left" data-remodal-id="remove-roster">
   <button data-remodal-action="close" class="remodal-close"><%= octicon 'x' %></button>
-  <h2 class="remodal-header text-left">Are you sure you want to delete this roster?</h2>
+  <h2 class="remodal-header text-left">Are you sure you want to delete all students?</h2>
 
   <div class="remodal-warning">
     Unexpected things will happen if you don't read this!
   </div>
 
   <div class="remodal-description">
-    Deleting the roster will delete all students.
     This will not delete assignments, assignment repos, or submissions.
-    After deleting your roster, repos and submissions will be identified by GitHub handle instead of your roster identifier.
+    After deleting all students, repos and submissions will be identified by GitHub handle instead of your their identifier.
   </div>
 
   <%= form_tag({ controller: :rosters, action: :remove_organization }, method: :patch) do %>
-    <%= submit_tag 'Delete roster', class: 'btn btn-danger btn-block js-submit' %>
+    <%= submit_tag 'Delete all students', class: 'btn btn-danger btn-block js-submit' %>
   <% end %>
 </div>

--- a/app/views/orgs/rosters/_select_identifier_modal.html.erb
+++ b/app/views/orgs/rosters/_select_identifier_modal.html.erb
@@ -26,7 +26,7 @@
             <%= render('shared/form_error', errors: view.error_message_for(:roster_entries)) if view.errors_for?(:roster_entries) %>
           </div>
           <div class="d-flex flex-items-center border-top pt-5">
-            <%= submit_tag 'Import roster entries', class: 'btn btn-primary mr-3' %>
+            <%= submit_tag 'Import students', class: 'btn btn-primary mr-3' %>
           </div>
         <% end %>
       <% else %>

--- a/app/views/orgs/rosters/new.html.erb
+++ b/app/views/orgs/rosters/new.html.erb
@@ -1,6 +1,6 @@
 <% view = FormView.new(subject: @roster) %>
 
-<%= render 'organizations/organization_banner', settings: true %>
+<%= render 'organizations/organization_banner', students: true %>
 
 <div class="site-content">
   <div class="site-content-cap">
@@ -15,22 +15,22 @@
         <h2 class="h3 mb-2">Import students from your institution</h2>
         <% if current_organization.lti_configuration %>
           <% lms_name = current_organization.lti_configuration.lms_name(default_name: "your learning management system") %>
-          <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import your roster for you!</p>
+          <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import students for you!</p>
 
           <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from #{lms_name}",
             import_from_lms_roster_path,
             class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
           %>
         <% elsif current_organization.google_course_id %>
-          <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import your roster for you!</p>
+          <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import students for you!</p>
           <%= link_to image_tag('google-classroom-logo.png', size: "25", class:"mr-2") + "Import from Google Classroom",
             import_from_google_classroom_roster_path(current_organization),
             method: :patch,
             class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
           %>
         <% else %>
-          <p>GitHub Classroom is able to automatically import your roster from your institution. If you
-          would rather manage your roster manually, you can still do that, too.</p>
+          <p>GitHub Classroom is able to automatically import students from your institution. If you
+          would rather manage students manually, you can still do that, too.</p>
 
           <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from a learning management system",
             link_lms_organization_path,
@@ -59,7 +59,7 @@
             </div>
 
             <div class="d-flex flex-items-center border-top pt-5">
-              <%= submit_tag 'Create roster', class: 'btn btn-primary mr-3' %>
+              <%= submit_tag 'Add students', class: 'btn btn-primary mr-3' %>
               <%= link_to 'Skip', organization_path(current_organization), class: 'btn-link' %>
             </div>
           <% end %>

--- a/app/views/orgs/rosters/show.html.erb
+++ b/app/views/orgs/rosters/show.html.erb
@@ -67,7 +67,7 @@
           After deleting all your students, repos and submissions will be identified by GitHub handle instead of your roster identifier.
         </p>
         <p>
-          <a data-remodal-target="remove-roster" class="btn btn-danger">Delete roster</a>
+          <a data-remodal-target="remove-roster" class="btn btn-danger">Delete all students</a>
         </p>
       </div>
     </div>

--- a/app/views/orgs/rosters/show.html.erb
+++ b/app/views/orgs/rosters/show.html.erb
@@ -1,82 +1,74 @@
 <div class="remodal-bg">
-  <%= render 'organizations/organization_banner', settings: true %>
+  <%= render 'organizations/organization_banner', students: true %>
 
-  <div class="columns">
-    <div class="one-fourth column">
-      <%= render partial: 'organizations/side_menu' %>
-    </div>
-    <div class="three-fourths column">
-      <div class="boxed-group">
-        <h3 class='d-flex flex-justify-between flex-items-center'>
-          <span>
-            Classroom roster
-          </span>
-          <div class='flex-justify-between'>
-            <% if google_classroom_roster_import_enabled? && current_organization.google_course_id %>
-              <span class="btn btn-primary btn-sm", role="button" data-remodal-target="sync-google-roster-modal"><%= octicon "sync" %>  Sync from Google Classroom</span>
-            <% elsif lti_launch_enabled? && current_organization.lti_configuration %>
-              <% lms_name = current_organization.lti_configuration.lms_name(default_name: "learning management system") %>
-              <%= link_to import_from_lms_roster_path, remote: true, method: :get, class: "btn btn-primary btn-sm" do %>
-                <%= octicon "sync" %>  Sync from <%= lms_name %>
-              <% end %>
-            <% else %>
-              <span class="btn btn-primary btn-sm", role="button" data-remodal-target="new-student-modal">Update students</span>
+  <div class="container-lg">
+    <div class="boxed-group">
+      <h3 class='d-flex flex-justify-between flex-items-center'>
+        <span>
+          Students
+        </span>
+        <div class='flex-justify-between'>
+          <% if google_classroom_roster_import_enabled? && current_organization.google_course_id %>
+            <span class="btn btn-primary btn-sm", role="button" data-remodal-target="sync-google-roster-modal"><%= octicon "sync" %>  Sync from Google Classroom</span>
+          <% elsif lti_launch_enabled? && current_organization.lti_configuration %>
+            <% lms_name = current_organization.lti_configuration.lms_name(default_name: "learning management system") %>
+            <%= link_to import_from_lms_roster_path, remote: true, method: :get, class: "btn btn-primary btn-sm" do %>
+              <%= octicon "sync" %>  Sync from <%= lms_name %>
             <% end %>
-            <span class="btn btn-primary btn-sm", role="button" data-remodal-target="download-csv-modal">Download</span>
-          </div>
-        </h3>
+          <% else %>
+            <span class="btn btn-primary btn-sm", role="button" data-remodal-target="new-student-modal">Update students</span>
+          <% end %>
+          <span class="btn btn-primary btn-sm", role="button" data-remodal-target="download-csv-modal">Download</span>
+        </div>
+      </h3>
 
-        <div class="site-content-body tabnav-body clearfix">
-          <div class="tabnav">
-            <nav class="tabnav-tabs">
-              <span id='students-tab' onclick="selectTab(this)" class="tabnav-tab selected tabnav-link" aria-current="page">All students</span>
-              <span id='unlinked-tab' onclick="selectTab(this)" class="tabnav-tab tabnav-link">Unlinked GitHub accounts</span>
-            </nav>
+      <div class="site-content-body tabnav-body clearfix">
+        <div class="tabnav">
+          <nav class="tabnav-tabs">
+            <span id='students-tab' onclick="selectTab(this)" class="tabnav-tab selected tabnav-link" aria-current="page">All students</span>
+            <span id='unlinked-tab' onclick="selectTab(this)" class="tabnav-tab tabnav-link">Unlinked GitHub accounts</span>
+          </nav>
+        </div>
+        <span id='students-span'>
+          <div class="assignment-list-items">
+            <% @roster_entries.each do |roster_entry| %>
+              <%= render 'roster_entry', roster_entry: roster_entry, roster_entries_page: @roster_entries.current_page %>
+            <% end %>
+
+            <div class="d-flex col-12">
+              <%= render partial: 'shared/pagination', locals: { collection: @roster_entries, param_name: :roster_entries_page } %>
+            </div>
           </div>
-          <span id='students-span'>
-            <div class="assignment-list-items">
-              <% @roster_entries.each do |roster_entry| %>
-                <%= render 'roster_entry', roster_entry: roster_entry, roster_entries_page: @roster_entries.current_page %>
+        </span>
+        <span id='unlinked-span' class='hidden-tab'>
+          <div class="assignment-list-items">
+            <% if unlinked_users.empty? %>
+              <%= render 'shared/unlinked_blank_slate' %>
+            <% else %>
+              <% @current_unlinked_users.each do |user| %>
+                <%= render 'unlinked_user', unlinked_user: user %>
               <% end %>
 
               <div class="d-flex col-12">
-                <%= render partial: 'shared/pagination', locals: { collection: @roster_entries, param_name: :roster_entries_page } %>
+                <%= render partial: 'shared/pagination', locals: { collection: @current_unlinked_users, param_name: :unlinked_users_page } %>
               </div>
-            </div>
-          </span>
-          <span id='unlinked-span' class='hidden-tab'>
-            <div class="assignment-list-items">
-              <% if unlinked_users.empty? %>
-                <%= render 'shared/unlinked_blank_slate' %>
-              <% else %>
-                <% @current_unlinked_users.each do |user| %>
-                  <%= render 'unlinked_user', unlinked_user: user %>
-                <% end %>
-
-                <div class="d-flex col-12">
-                  <%= render partial: 'shared/pagination', locals: { collection: @current_unlinked_users, param_name: :unlinked_users_page } %>
-                </div>
-              <% end %>
-            </div>
-          </span>
-        </div>
+            <% end %>
+          </div>
+        </span>
       </div>
+    </div>
 
-      <div class="boxed-group dangerzone pb-3">
-        <h3>Delete this roster</h3>
-        <div class="boxed-group-inner pt-2 clearfix">
-          <p>
-            Deleting the roster will delete all students.
-          </p>
-          <p>
-            This will not delete assignments, assignment repos, or submissions.
-          </p>
-            After deleting your roster, repos and submissions will be identified by GitHub handle instead of your roster identifier.
-          </p>
-          <p>
-            <a data-remodal-target="remove-roster" class="btn btn-danger">Delete roster</a>
-          </p>
-        </div>
+    <div class="boxed-group dangerzone pb-3">
+      <h3>Delete all students</h3>
+      <div class="boxed-group-inner pt-2 clearfix">
+        <p>
+          This will not delete assignments, assignment repos, or submissions.
+        </p>
+          After deleting all your students, repos and submissions will be identified by GitHub handle instead of your roster identifier.
+        </p>
+        <p>
+          <a data-remodal-target="remove-roster" class="btn btn-danger">Delete roster</a>
+        </p>
       </div>
     </div>
   </div>

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -831,7 +831,7 @@ RSpec.describe Orgs::RostersController, type: :controller do
                 end
 
                 it "sets success message" do
-                  expect(flash[:success]).to start_with("Your classroom roster has been saved! Manage it")
+                  expect(flash[:success]).to start_with("Students have been added to your classroom! Manage students")
                 end
 
                 it "has correct number of students" do


### PR DESCRIPTION
## What
Part of https://github.com/education/classroom/issues/2268
This PR moves rosters for ease of access. We also renamed rosters to students so that it is more clear. Rosters used to live in the settings tab. 

| Action | Screenshot |
|--------|------------|
| View of all students in classroom | ![image](https://user-images.githubusercontent.com/22784140/63466626-a4de8980-c431-11e9-9c36-fda2a0eee9d1.png) |
| Creating a new roster | ![image](https://user-images.githubusercontent.com/22784140/63466539-73fe5480-c431-11e9-81fa-c503580afacf.png) |
| Deleting roster | ![image](https://user-images.githubusercontent.com/22784140/63466648-b45dd280-c431-11e9-8d5c-ce883f658e3d.png) |



