### PR TITLE
Update Canvas help page

### DIFF
--- a/docs/setup-canvas.md
+++ b/docs/setup-canvas.md
@@ -2,6 +2,9 @@
 
 These steps will walk you through the process of configuring GitHub Classroom as an external tool within Canvas.
 
+**Note**: We currently do not support free teacher accounts on Canvas
+{: class="warning"}
+
 ### Prerequisites
 
 1. An up-to-date version of Canvas

--- a/docs/setup-canvas.md
+++ b/docs/setup-canvas.md
@@ -2,7 +2,7 @@
 
 These steps will walk you through the process of configuring GitHub Classroom as an external tool within Canvas.
 
-**Note**: We currently do not support free teacher accounts due to the [limitations of features available](https://learn.canvas.net/courses/1233/pages/canvas-free-for-teachers-account-registration-and-login)
+**Note**: Canvas does not support adding external apps for free accounts and cannot be used with GitHub Classroom at this time. See more about the restrictions [here](https://learn.canvas.net/courses/1233/pages/canvas-free-for-teachers-account-registration-and-login).
 {: class="warning"}
 
 ### Prerequisites

--- a/docs/setup-canvas.md
+++ b/docs/setup-canvas.md
@@ -2,7 +2,7 @@
 
 These steps will walk you through the process of configuring GitHub Classroom as an external tool within Canvas.
 
-**Note**: We currently do not support free teacher accounts on Canvas
+**Note**: We currently do not support free teacher accounts due to the [limitations of features available](https://learn.canvas.net/courses/1233/pages/canvas-free-for-teachers-account-registration-and-login)
 {: class="warning"}
 
 ### Prerequisites


### PR DESCRIPTION
## What
This updates Canvas' help page, to say that we do not support free teacher accounts. This is primarily due to the fact that Canvas does not allow the membership service setting to be turned on for free accounts.
