### PR TITLE
fix default public_repo

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -111,7 +111,7 @@ class AssignmentsController < ApplicationController
   def new_assignment_params
     params
       .require(:assignment)
-      .permit(:title, :slug, :public_repo, :students_are_repo_admins, :invitations_enabled, :template_repos_enabled)
+      .permit(:title, :slug, :visibility, :students_are_repo_admins, :invitations_enabled, :template_repos_enabled)
       .merge(creator: current_user,
              organization: @organization,
              starter_code_repo_id: starter_code_repo_id_param,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -175,7 +175,7 @@ class AssignmentsController < ApplicationController
       .permit(
         :title,
         :slug,
-        :public_repo,
+        :visibility,
         :students_are_repo_admins,
         :deadline, :invitations_enabled,
         :template_repos_enabled

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -120,7 +120,7 @@ class GroupAssignmentsController < ApplicationController
       .permit(
         :title,
         :slug,
-        :public_repo,
+        :visibility,
         :grouping_id,
         :max_members,
         :students_are_repo_admins,
@@ -196,7 +196,7 @@ class GroupAssignmentsController < ApplicationController
       .permit(
         :title,
         :slug,
-        :public_repo,
+        :visibility,
         :max_members,
         :students_are_repo_admins,
         :deadline,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -45,6 +45,10 @@ class Assignment < ApplicationRecord
   alias_attribute :repos, :assignment_repos
   alias_attribute :template_repos_enabled?, :template_repos_enabled
 
+  def visibility=(visibility)
+    self.public_repo = visibility != "private"
+  end
+
   def private?
     !public_repo
   end

--- a/app/models/group_assignment.rb
+++ b/app/models/group_assignment.rb
@@ -56,6 +56,10 @@ class GroupAssignment < ApplicationRecord
     public_repo
   end
 
+  def visibility=(visibility)
+    self.public_repo = visibility != "private"
+  end
+
   def to_param
     slug
   end

--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -16,7 +16,7 @@
 <dl class="<%= view.form_class_for(:public_repo) %> my-4">
   <div class="form-checkbox">
     <label>
-      <%= f.radio_button :public_repo, true %>
+      <%= f.radio_button :visibility, "public", checked: !view.private_repos_available? %>
       <div class="d-flex">
         <div>
           <%= octicon 'repo', height: 32, class: "text-gray mr-2" %>
@@ -31,7 +31,7 @@
 
   <div class="form-checkbox">
     <label>
-      <%= f.radio_button :public_repo, false, disabled: !view.private_repos_available? %>
+      <%= f.radio_button :visibility, "private", checked: view.private_repos_available?, disabled: !view.private_repos_available? %>
       <div class="d-flex">
         <div>
           <%= octicon 'lock', height: 32, class: "text-orange mr-2" %>

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -16,7 +16,7 @@
 <dl class="<%= view.form_class_for(:public_repo) %> my-4">
   <div class="form-checkbox">
     <label>
-      <%= f.radio_button :public_repo, true %>
+      <%= f.radio_button :visibility, "public", checked: !view.private_repos_available? %>
       <div class="d-flex">
         <div>
           <%= octicon 'repo', height: 32, class: "text-gray mr-2" %>
@@ -31,7 +31,7 @@
 
   <div class="form-checkbox">
     <label>
-      <%= f.radio_button :public_repo, false, disabled: !view.private_repos_available? %>
+      <%= f.radio_button :visibility, "private", checked: view.private_repos_available?, disabled: !view.private_repos_available? %>
       <div class="d-flex">
         <div>
           <%= octicon 'lock', height: 32, class: "text-orange mr-2" %>

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -21,34 +21,6 @@ RSpec.describe AssignmentsController, type: :controller do
       get :new, params: { organization_id: organization.slug }
       expect(assigns(:assignment)).to_not be_nil
     end
-
-    context "public_repo defaults", type: :view do
-      it "defaults public_repo to true if the organization does not have private repos" do
-        no_private_repos_plan = { owned_private_repos: 0, private_repos: 0 }
-        allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(no_private_repos_plan)
-        allow_any_instance_of(Organization).to receive(:plan).and_return(no_private_repos_plan)
-        stub_template("organizations/_organization_banner.html.erb" => "")
-
-        @assignment = Assignment.new
-        @organization = organization
-        render template: "assignments/new"
-        expect(response.body).to include("value=\"public\" checked=\"checked\" name=\"assignment[visibility]\"")
-        expect(response.body).to include("disabled=\"disabled\" type=\"radio\" value=\"private\" name=\"assignment[visibility]\"")
-      end
-
-      it "defaults public_repo to false if the organization has private repos" do
-        private_repos_plan = { owned_private_repos: 0, private_repos: 100 }
-        allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
-        allow_any_instance_of(Organization).to receive(:plan).and_return(private_repos_plan)
-        stub_template("organizations/_organization_banner.html.erb" => "")
-
-        @assignment = Assignment.new
-        @organization = organization
-        render template: "assignments/new"
-        expect(response.body).to include("value=\"public\" name=\"assignment[visibility]\"")
-        expect(response.body).to include("value=\"private\" checked=\"checked\" name=\"assignment[visibility]\"")
-      end
-    end
   end
 
   describe "POST #create", :vcr do

--- a/spec/controllers/group_assignments_controller_spec.rb
+++ b/spec/controllers/group_assignments_controller_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe GroupAssignmentsController, type: :controller do
     context "public_repo attribute is changed" do
       it "calls the AssignmentVisibility background job" do
         private_repos_plan = { owned_private_repos: 0, private_repos: 2 }
-        options = { title: "JavaScript Calculator", public_repo: !group_assignment.public? }
+        options = { title: "JavaScript Calculator", visibility: "private" }
 
         allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
 

--- a/spec/views/assignments/edit.html.erb_spec.rb
+++ b/spec/views/assignments/edit.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "default public_repo", type: :view do
+  let(:organization) { classroom_org }
+
+  it "defaults public_repo to true if the organization does not have private repos" do
+    no_private_repos_plan = { owned_private_repos: 0, private_repos: 0 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(no_private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(no_private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+    stub_template("assignments/_delete_assignment_modal.html" => "")
+
+    @assignment = Assignment.new
+    @organization = organization
+    render template: "assignments/edit"
+    expect(response.body).to include("value=\"public\" checked=\"checked\" name=\"assignment[visibility]\"")
+    expect(response.body).to include("disabled=\"disabled\" type=\"radio\" value=\"private\" name=\"assignment[visibility]\"")
+  end
+
+  it "defaults public_repo to false if the organization has private repos" do
+    private_repos_plan = { owned_private_repos: 0, private_repos: 100 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+    stub_template("assignments/_delete_assignment_modal.html" => "")
+
+    @assignment = Assignment.new
+    @organization = organization
+    render template: "assignments/edit"
+    expect(response.body).to include("value=\"public\" name=\"assignment[visibility]\"")
+    expect(response.body).to include("value=\"private\" checked=\"checked\" name=\"assignment[visibility]\"")
+  end
+end

--- a/spec/views/assignments/new.html.erb_spec.rb
+++ b/spec/views/assignments/new.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "default public_repo", type: :view do
+  let(:organization) { classroom_org }
+
+  it "defaults public_repo to true if the organization does not have private repos" do
+    no_private_repos_plan = { owned_private_repos: 0, private_repos: 0 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(no_private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(no_private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+
+    @assignment = Assignment.new
+    @organization = organization
+    render template: "assignments/new"
+    expect(response.body).to include("value=\"public\" checked=\"checked\" name=\"assignment[visibility]\"")
+    expect(response.body).to include("disabled=\"disabled\" type=\"radio\" value=\"private\" name=\"assignment[visibility]\"")
+  end
+
+  it "defaults public_repo to false if the organization has private repos" do
+    private_repos_plan = { owned_private_repos: 0, private_repos: 100 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+
+    @assignment = Assignment.new
+    @organization = organization
+    render template: "assignments/new"
+    expect(response.body).to include("value=\"public\" name=\"assignment[visibility]\"")
+    expect(response.body).to include("value=\"private\" checked=\"checked\" name=\"assignment[visibility]\"")
+  end
+end

--- a/spec/views/group_assignments/edit.html.erb_spec.rb
+++ b/spec/views/group_assignments/edit.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "default public_repo", type: :view do
+  let(:organization) { classroom_org }
+
+  it "defaults public_repo to true if the organization does not have private repos" do
+    no_private_repos_plan = { owned_private_repos: 0, private_repos: 0 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(no_private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(no_private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+    stub_template("group_assignments/_delete_group_assignment_modal.html" => "")
+
+    @group_assignment = GroupAssignment.new
+    @organization = organization
+    render template: "group_assignments/edit"
+    expect(response.body).to include("value=\"public\" checked=\"checked\" name=\"group_assignment[visibility]\"")
+    expect(response.body).to include("disabled=\"disabled\" type=\"radio\" value=\"private\" name=\"group_assignment[visibility]\"")
+  end
+
+  it "defaults public_repo to false if the organization has private repos" do
+    private_repos_plan = { owned_private_repos: 0, private_repos: 100 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+    stub_template("group_assignments/_delete_group_assignment_modal.html" => "")
+
+    @group_assignment = GroupAssignment.new
+    @organization = organization
+    render template: "group_assignments/edit"
+    expect(response.body).to include("value=\"public\" name=\"group_assignment[visibility]\"")
+    expect(response.body).to include("value=\"private\" checked=\"checked\" name=\"group_assignment[visibility]\"")
+  end
+end

--- a/spec/views/group_assignments/new.html.erb_spec.rb
+++ b/spec/views/group_assignments/new.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "default public_repo", type: :view do
+  let(:organization) { classroom_org }
+
+  it "defaults public_repo to true if the organization does not have private repos" do
+    no_private_repos_plan = { owned_private_repos: 0, private_repos: 0 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(no_private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(no_private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+
+    @group_assignment = GroupAssignment.new
+    @organization = organization
+    render template: "group_assignments/new"
+    expect(response.body).to include("value=\"public\" checked=\"checked\" name=\"group_assignment[visibility]\"")
+    expect(response.body).to include("disabled=\"disabled\" type=\"radio\" value=\"private\" name=\"group_assignment[visibility]\"")
+  end
+
+  it "defaults public_repo to false if the organization has private repos" do
+    private_repos_plan = { owned_private_repos: 0, private_repos: 100 }
+    allow_any_instance_of(GitHubOrganization).to receive(:plan).and_return(private_repos_plan)
+    allow_any_instance_of(Organization).to receive(:plan).and_return(private_repos_plan)
+    stub_template("organizations/_organization_banner.html.erb" => "")
+
+    @group_assignment = GroupAssignment.new
+    @organization = organization
+    render template: "group_assignments/new"
+    expect(response.body).to include("value=\"public\" name=\"group_assignment[visibility]\"")
+    expect(response.body).to include("value=\"private\" checked=\"checked\" name=\"group_assignment[visibility]\"")
+  end
+end


### PR DESCRIPTION
Followup to https://github.com/education/classroom/pull/2269 (original PR) and https://github.com/education/classroom/pull/2280 (bug fix for when the original PR turned out to be reversing the value of public_repo in assignment forms).

I paired with @jeffrafter on redoing these radio buttons and writing tests for them. We differentiated between the `checked` and `value` parameters on the radio buttons to fix the original bug that was caused by https://github.com/education/classroom/pull/2269 , and I added a `views` directory to specs so that we could test that the radio buttons are rendered correctly.