### PR TITLE
Use form helper instead of HTML for starter code repo field

### DIFF
--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -55,7 +55,19 @@
   <div class="Box-body">
     <dl class="form-group mt-0 <%= view.form_class_for(:starter_code_repository) %>">
       <dt><label>Add your starter code from GitHub</label></dt>
-      <dd><input class="textfield js-autocomplete-textfield form-control input-contrast input-block" type="text" name="repo_name" value="<%= @assignment.starter_code_repository.try(:full_name) %>" placeholder="<%= @assignment.starter_code_repository.try(:full_name) || 'Search repositories'%>" autocomplete="off" data-autocomplete-search-endpoint="github_repos" oninput=<%= "importOptions(this.value);removeErrorBox(this);" if @organization.feature_enabled?(:template_repos) %>></dd>
+      <dd>
+        <%= f.text_field :title,
+          class: "textfield js-autocomplete-textfield form-control input-contrast input-block",
+          name: "repo_name",
+          type: "text",
+          value: @assignment.starter_code_repository.try(:full_name),
+          placeholder: @assignment.starter_code_repository.try(:full_name) ||
+              'Search repositories',
+          autocomplete: "off",
+          oninput: "importOptions(this.value);removeErrorBox(this);",
+          data: { "autocomplete-search-endpoint": "github_repos" }
+        %>
+      </dd>
       <dd class="dd-autocomplete-suggestions"><%= render_autocomplete_suggestions_container %></dd>
       <input class="js-autocomplete-resource-id" type="hidden" name="repo_id" />
 

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -74,7 +74,19 @@
   <div class="Box-body">
     <dl class="<%= view.form_class_for(:starter_code_repository) %>">
       <dt><label>Add your starter code from GitHub</label></dt>
-      <dd><input class="textfield js-autocomplete-textfield form-control input-contrast input-block" type="text" name="repo_name" value="<%= @group_assignment.starter_code_repository.try(:full_name) %>" placeholder="<%= @group_assignment.starter_code_repository.try(:full_name) || 'Search repositories'%>" autocomplete="off" data-autocomplete-search-endpoint="github_repos" oninput=<%= "importOptions(this.value);removeErrorBox();" if @organization.feature_enabled?(:template_repos) %>></dd>
+      <dd>
+        <%= f.text_field :title,
+          class: "textfield js-autocomplete-textfield form-control input-contrast input-block",
+          name: "repo_name",
+          type: "text",
+          value: @group_assignment.starter_code_repository.try(:full_name),
+          placeholder: @group_assignment.starter_code_repository.try(:full_name) ||
+              'Search repositories',
+          autocomplete: "off",
+          oninput: "importOptions(this.value);removeErrorBox(this);",
+          data: { "autocomplete-search-endpoint": "github_repos" }
+        %>
+      </dd>
       <dd class="dd-autocomplete-suggestions"><%= render_autocomplete_suggestions_container %></dd>
       <input class="js-autocomplete-resource-id form-control input-contrast input-block" type="hidden" name="repo_id" />
 


### PR DESCRIPTION
## What
We currently have a giant mess of HTML as our starter code repo field in the assignment forms.

This PR switches it over to the rails form helper format, keeping it consistent, clean, and easier to read.

The form looks/operates exactly the same on the client-side.
