### PR TITLE
Fix object name for starter code repo field in assignment forms

### DIFF
--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -56,7 +56,7 @@
     <dl class="form-group mt-0 <%= view.form_class_for(:starter_code_repository) %>">
       <dt><label>Add your starter code from GitHub</label></dt>
       <dd>
-        <%= f.text_field :title,
+        <%= f.text_field :starter_code_repository,
           class: "textfield js-autocomplete-textfield form-control input-contrast input-block",
           name: "repo_name",
           type: "text",

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -75,7 +75,7 @@
     <dl class="<%= view.form_class_for(:starter_code_repository) %>">
       <dt><label>Add your starter code from GitHub</label></dt>
       <dd>
-        <%= f.text_field :title,
+        <%= f.text_field :starter_code_repository,
           class: "textfield js-autocomplete-textfield form-control input-contrast input-block",
           name: "repo_name",
           type: "text",


### PR DESCRIPTION
## What
Just noticed that #2290 had the object name for the starter code repo form helper as `:title` when it should've been `:starter_code_repository`. 

https://github.com/education/classroom/pull/2290/files#diff-addecbb36a5dac12ef1fc5440d5048faR59

This doesn't cause any issues, but it's best we change it to the appropriate name.