### PR TITLE
Update classroom administrators sidebar text

### DIFF
--- a/app/views/organizations/_side_menu.html.erb
+++ b/app/views/organizations/_side_menu.html.erb
@@ -11,7 +11,7 @@
                 class: "menu-item #{'selected' if current_page?(settings_teams_organization_path(organization))}" %>
   <% end %>
 
-  <%= link_to t('views.organizations.invite_other_admin'),
+  <%= link_to t('views.organizations.classroom_admins'),
               settings_invitations_organization_path(organization),
               class: "menu-item #{'selected' if current_page?(settings_invitations_organization_path(organization))}" %>
 

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -56,7 +56,7 @@ en:
       classroom_profile: 'Classroom profile'
       student_identifiers: 'Student identifiers'
       team_management: 'Team management'
-      invite_other_admin: 'Invite other administrators'
+      classroom_admins: 'Administrators'
       profile_information: 'Profile information'
       save_changes: 'Save changes'
       theres_no_going_back: 'Once you reset this classroom, there is no going back. Please be certain.'


### PR DESCRIPTION
## What
The sidebar in classroom settings currently says `Invite other administrators` but the page is really used to manage administrators (invite and/or remove admins).

This PR updates that text to just `Administrators` so that it's clear that this page is for administrator settings, not just invitations.

**Before**
![image](https://user-images.githubusercontent.com/1490434/63790875-39306c80-c8c8-11e9-9993-c4a09783d294.png)


**After**
![image](https://user-images.githubusercontent.com/1490434/63790880-3cc3f380-c8c8-11e9-94ea-d3302be250aa.png)
