### PR TITLE
Add more logging for JSON::ParserError

### DIFF
--- a/lib/github_classroom/lti/membership_service.rb
+++ b/lib/github_classroom/lti/membership_service.rb
@@ -73,7 +73,7 @@ module GitHubClassroom
         begin
           json_membership = JSON.parse(raw_data)
         rescue
-          Rails.logger.error(raw_data)
+          Rails.logger.error("raw_data: #{raw_data}")
           raise JSON::ParserError
         end
 

--- a/spec/lib/github_classroom/lti/membership_service_spec.rb
+++ b/spec/lib/github_classroom/lti/membership_service_spec.rb
@@ -51,7 +51,7 @@ describe GitHubClassroom::LTI::MembershipService do
         it "raises error and logs" do
           allow(Rails.logger).to receive(:error)
           expect { instance.students }.to raise_error(JSON::ParserError)
-          expect(Rails.logger).to have_received(:error).with("sdfsdf")
+          expect(Rails.logger).to have_received(:error).with("raw_data: sdfsdf")
         end
       end
 


### PR DESCRIPTION
## What
This allows us to do more logging in the `JSON::ParserError` for debugging Canvas issues. 