### PR TITLE
Adding unzip of gzip responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "dalli", "~> 2.7", ">= 2.7.6"
 
 gem "failbot_rails",      "~> 0.5.0"
 gem "faraday-http-cache", "~> 2.0"
+gem "faraday_middleware", "~> 0.13.1"
 gem "flipper",            "~> 0.10.2"
 gem "flipper-redis",      "~> 0.10.2"
 gem "flipper-ui",         "~> 0.10.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,7 @@ DEPENDENCIES
   failbot_rails (~> 0.5.0)
   faker (~> 1.8, >= 1.8.4)
   faraday-http-cache (~> 2.0)
+  faraday_middleware (~> 0.13.1)
   flipper (~> 0.10.2)
   flipper-redis (~> 0.10.2)
   flipper-ui (~> 0.10.2)

--- a/lib/github_classroom/lti/mixins/request_signing.rb
+++ b/lib/github_classroom/lti/mixins/request_signing.rb
@@ -27,6 +27,7 @@ module GitHubClassroom
           connection = Faraday.new(url: req.uri, headers: request_headers) do |conn|
             conn.response :raise_error
             conn.adapter Faraday.default_adapter
+            conn.use :gzip 
           end
 
           method = req.method.downcase

--- a/lib/github_classroom/lti/mixins/request_signing.rb
+++ b/lib/github_classroom/lti/mixins/request_signing.rb
@@ -27,7 +27,7 @@ module GitHubClassroom
           connection = Faraday.new(url: req.uri, headers: request_headers) do |conn|
             conn.response :raise_error
             conn.adapter Faraday.default_adapter
-            conn.use :gzip 
+            conn.use :gzip
           end
 
           method = req.method.downcase

--- a/spec/lib/github_classroom/lti/membership_service_spec.rb
+++ b/spec/lib/github_classroom/lti/membership_service_spec.rb
@@ -41,20 +41,6 @@ describe GitHubClassroom::LTI::MembershipService do
         end
       end
 
-      context "json is gzipped" do
-        let!(:students) { Zlib.gzip("{test: \"asad\"}") }
-        before do
-          instance.stub(:fetch_raw_membership) do
-            students
-          end
-        end
-
-        it "succesfully unzip" do
-          students = instance.students
-          expect(students).to_not be_empty
-        end
-      end
-
       context "invalid json is given" do
         before do
           instance.stub(:fetch_raw_membership) do

--- a/spec/lib/github_classroom/lti/membership_service_spec.rb
+++ b/spec/lib/github_classroom/lti/membership_service_spec.rb
@@ -41,6 +41,20 @@ describe GitHubClassroom::LTI::MembershipService do
         end
       end
 
+      context "json is gzipped" do
+        let!(:students) { Zlib.gzip("{test: \"asad\"}") }
+        before do
+          instance.stub(:fetch_raw_membership) do
+            students
+          end
+        end
+
+        it "succesfully unzip" do
+          students = instance.students
+          expect(students).to_not be_empty
+        end
+      end
+
       context "invalid json is given" do
         before do
           instance.stub(:fetch_raw_membership) do


### PR DESCRIPTION
Canvas hosted on Instructure, gzips their response. So this PR allows us to unzip the response, therefore fixing the importing students issue with Canvas 😄 
