### PR TITLE
Classrooms page layout tweaks

### DIFF
--- a/app/views/organizations/_organization_card_layout.html.erb
+++ b/app/views/organizations/_organization_card_layout.html.erb
@@ -13,12 +13,12 @@
         <div class="px-4 pb-3 pt-2">
           <% if organization.assignments.present? || organization.group_assignments.present? %>
             <!-- <h2 class="h6 text-uppercase border-bottom pb-1">Latest Assignments</h2> -->
-            <ul class="border-top pt-2">
+            <ul class="border-top py-2">
               <% organization.all_assignments.sort_by(&:created_at).reverse.take(5).each do |assignment| %>
                 <li class="d-flex flex-items-center py-1">
-                  <span class="d-inline-block text-center text-gray mr-2" style="background-color:#d1d5da;border-radius: 50%;width:18px;height:18px;">
-                    <%= octicon 'person', height: 9, class: 'v-align-middle' if assignment.is_a? Assignment %>
-                    <%= octicon 'organization', height: 9, class: 'v-align-middle' if assignment.is_a? GroupAssignment %>
+                  <span class="d-inline-block text-center text-gray mr-2 bg-blue-light circle" style="width:22px; height:22px;">
+                    <%= octicon 'person', height: 9, class: 'v-align-baseline' if assignment.is_a? Assignment %>
+                    <%= octicon 'organization', height: 9, class: 'v-align-baseline' if assignment.is_a? GroupAssignment %>
                   </span>
                   <%= link_to(assignment.title, organization_assignment_path(organization, assignment), class: "text-gray-dark") if assignment.is_a? Assignment %>
                   <%= link_to(assignment.title, organization_group_assignment_path(organization, assignment), class: "text-gray-dark") if assignment.is_a? GroupAssignment %>


### PR DESCRIPTION
## What
Suggested layout update to improve the readability of classroom cards:
- changed to two columns for tablet/desktop view so typical long classroom names aren't truncated
- reduced the footprint of the pattern tile to a decorative strip so it still serves as a visual mnemonic without competing with the readability of the heading text
- small markup cleanup to remove custom inline CSS to Primer classes

### Before
![classrooms-3col-before](https://user-images.githubusercontent.com/471514/63878074-d3f77c80-c996-11e9-8c12-890ec5a4e03e.png)

### After
![classrooms-2col](https://user-images.githubusercontent.com/471514/63878073-d3f77c80-c996-11e9-8184-bb8a804af4c4.png)


