### PR TITLE
Remove unnecessary import for github-markdown-css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,6 @@
 
 @import "variables";
 @import "primer/index";
-@import "github-markdown-css/github-markdown.css";
 
 @import "include-fragment-element/include-fragment-element";
 @import "components/*";


### PR DESCRIPTION
Closes #2248 

This removes `@import "github-markdown-css/github-markdown.css";` from our `application.scss`.

We use the css provided by this file. However, that CSS is included through npm/yarn and has never been directly in the codebase (which is what is causing the 404 in console).

This clears up the 404 but still leaves the styles available (through the inclusion in npm/yarn).

As you can see from the 3 screenshots below, we definitely have specific styles for `markdown-body` class and removing this line does not prevent us from getting that style info:

How a page using `markdown-body` looks with that line removed locally:
![image](https://user-images.githubusercontent.com/6540763/63899139-6e57c000-c997-11e9-948b-d1fd432096ca.png)

How that same page looks on production (where the line is present):
![image](https://user-images.githubusercontent.com/6540763/63899170-8cbdbb80-c997-11e9-9a58-9438059e711b.png)

How that page looks if I remove the `markdown-body` class:
![image](https://user-images.githubusercontent.com/6540763/63899226-cee6fd00-c997-11e9-85a4-10a8470c6b41.png)
