### PR TITLE
move free private repo link to private repo radio button

### DIFF
--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -38,8 +38,17 @@
         </div>
         <div>
           Private
-          <span class="d-block f6 text-gray text-normal mt-1">Submit assignments using private repositories. Submissions will only be visible to the submitter and organization owners. Editing this after assignments are created will not retroactively change their visibility.
-          <% unless view.private_repos_available? %><strong>This organization does not have any private repositories available.</strong><% end %></span>
+          <span class="d-block f6 text-gray text-normal mt-1">
+            <p<%= " style=color: #6A737D" unless view.private_repos_available? %>">
+              Submit assignments using private repositories. Submissions will only be visible to the submitter and organization owners. Editing this after assignments are created will not retroactively change their visibility.
+            </p>
+            <% unless view.private_repos_available? %>
+              <strong>
+                <p>Private repositories aren't available for this organization. However, current faculty may be eligible for free, unlimited private repositories.</p>
+                <p><%= link_to "Apply for free private repositories", "https://education.github.com/discount_requests/new" %></p>
+              </strong>
+            <% end %>
+          </span>
         </div>
       </div>
     </label>

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -19,11 +19,6 @@
           <%= link_to 'Cancel', organization_path(@organization), class: 'btn', role: 'button' %>
         </div>
       </div>
-      <% unless GitHubClassroom.enterprise? %>
-        <div class="col-md-3">
-          <%= render partial: 'shared/unlimited_free_private_repositories_banner' %>
-        </div>
-      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/group_assignments/_group_assignment_form_options.html.erb
+++ b/app/views/group_assignments/_group_assignment_form_options.html.erb
@@ -38,8 +38,17 @@
         </div>
         <div>
           Private
-          <span class="d-block f6 text-gray text-normal mt-1">Submit assignments using private repositories. Submissions will only be visible to the submitter and organization owners. Editing this after assignments are created will not retroactively change their visibility.
-          <% unless view.private_repos_available? %><strong>This organization does not have any private repositories available.</strong><% end %></span></span>
+          <span class="d-block f6 text-gray text-normal mt-1">
+            <p<%= " style=color: #6A737D" unless view.private_repos_available? %>">
+              Submit assignments using private repositories. Submissions will only be visible to the submitter and organization owners. Editing this after assignments are created will not retroactively change their visibility.
+            </p>
+            <% unless view.private_repos_available? %>
+              <strong>
+                <p>Private repositories aren't available for this organization. However, current faculty may be eligible for free, unlimited private repositories.</p>
+                <p><%= link_to "Apply for free private repositories", "https://education.github.com/discount_requests/new" %></p>
+              </strong>
+            <% end %>
+          </span>
         </div>
       </div>
     </label>

--- a/app/views/group_assignments/new.html.erb
+++ b/app/views/group_assignments/new.html.erb
@@ -19,9 +19,6 @@
           <%= link_to 'Cancel', organization_path(@organization), class: 'btn', role: 'button' %>
         </div>
       </div>
-      <div class="col-md-3">
-        <%= render partial: 'shared/unlimited_free_private_repositories_banner' %>
-      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_unlimited_free_private_repositories_banner.html.erb
+++ b/app/views/shared/_unlimited_free_private_repositories_banner.html.erb
@@ -1,6 +1,0 @@
-<aside class="Box">
-  <div class="Box-body">
-    <h2 class="h4 mb-2">Unlimited free private repositories</h2>
-    <p class="text-gray">If you have not already, you may apply for unlimited free private repositories for this classroom organization <a href="https://education.github.com/discount_requests/new">here</a>.</p>
-  </div>
-</aside>


### PR DESCRIPTION
For https://github.com/education/classroom/issues/2281

This PR removes the "free private repos" notice from the assignment form and moves the link to the radio button for using private repos (only displayed when the classroom's org does not have any available private repos).

Before:
<img width="1086" alt="63529584-e2dfba00-c4d2-11e9-9ae1-d2e667cba852" src="https://user-images.githubusercontent.com/7772827/63978972-59edf300-ca7d-11e9-9343-e3ccf97f9eb3.png">

Radio buttons when org has no private repos:
![Screen Shot 2019-08-29 at 4 43 35 PM](https://user-images.githubusercontent.com/7772827/63978995-68d4a580-ca7d-11e9-82c2-6f7662e68c7f.png)

Radio buttons when the org does have private repos:
![Screen Shot 2019-08-29 at 4 46 07 PM](https://user-images.githubusercontent.com/7772827/63979002-6d995980-ca7d-11e9-99bb-3b8a540d467f.png)
