### PR TITLE
Rescue only JSON::ParserError

### DIFF
--- a/lib/github_classroom/lti/membership_service.rb
+++ b/lib/github_classroom/lti/membership_service.rb
@@ -74,6 +74,7 @@ module GitHubClassroom
           json_membership = JSON.parse(raw_data)
         rescue JSON::ParserError
           Rails.logger.error("raw_data: #{raw_data}")
+          # raising new error as the encoded raw_data may be causing failbot issues
           raise JSON::ParserError
         end
 

--- a/lib/github_classroom/lti/membership_service.rb
+++ b/lib/github_classroom/lti/membership_service.rb
@@ -70,9 +70,9 @@ module GitHubClassroom
       # LTI 1.1 (and up) responses
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def parse_membership_service(raw_data)
-        begin JSON::ParserError
+        begin
           json_membership = JSON.parse(raw_data)
-        rescue
+        rescue JSON::ParserError
           Rails.logger.error("raw_data: #{raw_data}")
           raise JSON::ParserError
         end

--- a/lib/github_classroom/lti/membership_service.rb
+++ b/lib/github_classroom/lti/membership_service.rb
@@ -70,7 +70,7 @@ module GitHubClassroom
       # LTI 1.1 (and up) responses
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       def parse_membership_service(raw_data)
-        begin
+        begin JSON::ParserError
           json_membership = JSON.parse(raw_data)
         rescue
           Rails.logger.error("raw_data: #{raw_data}")


### PR DESCRIPTION
## What
@spinecone brought up a really good point. We should only be rescuing the `JSON::ParserError` error so that we aren't swallowing other errors. 
