### PR TITLE
Fix GitHubClassroom.github_url when using Enterprise

### DIFF
--- a/config/initializers/github_client.rb
+++ b/config/initializers/github_client.rb
@@ -24,7 +24,7 @@ module GitHubClassroom
 
   def self.github_url
     if enterprise?
-      Rails.application.secrets.github_enterprise_url.present?
+      Rails.application.secrets.github_enterprise_url
     else
       "https://github.com"
     end


### PR DESCRIPTION
Sorry that I do not know how to create a regression test, but this is definitely a bug to fix.