### PR TITLE
allow longer organization titles and display logins better

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -26,7 +26,7 @@ class Organization < ApplicationRecord
   validates :github_id, presence: true
 
   validates :title, presence: true
-  validates :title, length: { maximum: 60 }
+  validates :title, length: { maximum: 255 }
   validates :title, uniqueness: { scope: :github_id }
 
   validates :slug, uniqueness: true

--- a/app/views/organizations/_disabled_organization_select.html.erb
+++ b/app/views/organizations/_disabled_organization_select.html.erb
@@ -1,5 +1,5 @@
 <% aria_label = org[:role] != 'admin' ? t('views.organizations.you_are_not_owner') : t('views.organizations.already_added', owner: org[:owner_login]) %>
 <div class="d-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-gray p-3 tooltipped tooltipped-s" aria-label="<%= aria_label %>">
-  <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar d-block mx-auto mb-2', width: 100, height: 100, alt: "@#{org[:login]}" %>
-  <span class="css-truncate css-truncate-target" title=<%= "@#{org[:login]}" %>><%= "@#{org[:login]}" %></span>
+  <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar d-block mx-auto mb-2', width: 100, height: 100, alt: "#{org[:login]}" %>
+  <span title=<%= "#{org[:login]}" %>><%= "#{org[:login]}" %></span>
 </div>

--- a/app/views/organizations/_organization_select.html.erb
+++ b/app/views/organizations/_organization_select.html.erb
@@ -1,4 +1,4 @@
 <%= button_tag type: 'submit', name: "organization[github_id]", class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3', value: org[:github_id] do %>
-  <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar d-block mx-auto mb-2', width: 100, height: 100, alt: "@#{org[:login]}" %>
-  <span class="css-truncate css-truncate-target" title=<%= "@#{org[:login]}" %>><%= "@#{org[:login]}" %></span>
+  <%= image_tag "https://avatars.githubusercontent.com/u/#{org[:github_id]}?v=3&size=200", class: 'avatar d-block mx-auto mb-2', width: 100, height: 100, alt: "#{org[:login]}" %>
+  <span title=<%= "#{org[:login]}" %>><%= "#{org[:login]}" %></span>
 <% end %>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -13,9 +13,9 @@
     <%= form_for @organization do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
 
-      <div class="d-flex flex-wrap gutter-spacious">
+      <div class="d-flex flex-wrap gutter-condensed">
         <% @users_github_organizations.each do |org| %>
-          <div class="col-6 col-md-4 col-lg-3 mb-6">
+          <div class="col-6 col-md-4 mb-6">
             <% if org[:role] == 'admin' %>
               <%= render partial: 'organization_select', locals: { org: org } %>
             <% else %>
@@ -23,7 +23,7 @@
             <% end %>
           </div>
         <% end %>
-        <div class="col-6 col-md-4 col-lg-3 mb-6">
+        <div class="col-6 col-md-4 mb-6">
           <a href="<%= "#{GitHubClassroom.github_url}/settings/connections/applications/#{Rails.application.secrets.github_client_id}" %>" target="_blank" class="d-flex flex-column flex-justify-center height-full border text-center text-bold p-5">
             <span class="organization-grant-access-text"><%= t('views.organizations.grant_organization_access').html_safe %></span>
           </a>


### PR DESCRIPTION
For https://github.com/education/classroom/issues/2337

- Changes the organization title maximum length from 60 to 255 characters (to match the limit on github.com organization profile names)
- Removes the `@` from the organization login on the new classroom form
- Changes the organizations on the new classroom form to be displayed 3 per row rather than 4 per row
- No longer truncating the organization login, which can be up to 40 characters

The new classroom form now looks like this:
![Screen Shot 2019-09-05 at 10 37 41 AM](https://user-images.githubusercontent.com/7772827/64357138-b4c9a200-cfc9-11e9-9599-0a4bfb194f51.png)
