### PR TITLE
Small visual tweaks

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -7,7 +7,6 @@ body {
   font-size: 13px;
   line-height: 1.4;
   background-color: $gray-000;
-  // background-color: #f3f4f6;
 
   &.site {
     display: flex;
@@ -357,13 +356,6 @@ main.bg-gray-light, .help main {
     border-top: 1px solid $gray-200;
   }
 }
-
-
-// .help {
-//   &+footer {
-//     border-top: 1px solid $gray-200;
-//   }
-// }
 
 footer {
     background-color: #fff;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -6,7 +6,8 @@ body {
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 13px;
   line-height: 1.4;
-  background-color: #f3f4f6;
+  background-color: $gray-000;
+  // background-color: #f3f4f6;
 
   &.site {
     display: flex;
@@ -350,14 +351,19 @@ hr {
   }
 }
 
-main {
-  &.bg-gray-light {
-    padding-bottom: $spacer-10;
-    &+footer {
-      border-top: 1px solid $gray-200;
-    }
+main.bg-gray-light, .help main {
+  padding-bottom: $spacer-10;
+  &+footer {
+    border-top: 1px solid $gray-200;
   }
 }
+
+
+// .help {
+//   &+footer {
+//     border-top: 1px solid $gray-200;
+//   }
+// }
 
 footer {
     background-color: #fff;


### PR DESCRIPTION
## Small design improvements for /help :sparkles:
- Added padding between the main content and the footer
- Changed the background color to a lighter grey to improve text contrast/readability

### Before
![screencapture-classroom-github-help-2019-09-05-19_32_43](https://user-images.githubusercontent.com/471514/64390895-a359b780-d014-11e9-8e09-218f1c39c1ee.png)


### After
![screencapture-localhost-5000-help-2019-09-05-19_39_04](https://user-images.githubusercontent.com/471514/64390977-ec117080-d014-11e9-9d62-b584acb9d315.png)

