### PR TITLE
Remove Brightspace from supported LMSs

### DIFF
--- a/app/models/lti_configuration.rb
+++ b/app/models/lti_configuration.rb
@@ -15,7 +15,6 @@ class LtiConfiguration < ApplicationRecord
 
   enum lms_type: {
     canvas: "Canvas",
-    brightspace: "Brightspace",
     moodle: "Moodle",
     sakai: "Sakai",
     other: "other"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_27_174859) do
+ActiveRecord::Schema.define(version: 2019_08_05_192704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 2019_08_27_174859) do
     t.boolean "students_are_repo_admins", default: false, null: false
     t.boolean "invitations_enabled", default: true
     t.boolean "template_repos_enabled"
-    t.string "google_assignment_id"
     t.index ["deleted_at"], name: "index_assignments_on_deleted_at"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["slug"], name: "index_assignments_on_slug"
@@ -170,9 +169,9 @@ ActiveRecord::Schema.define(version: 2019_08_27_174859) do
     t.text "consumer_key", null: false
     t.text "shared_secret", null: false
     t.text "lms_link"
-    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "organization_id"
     t.string "context_membership_url"
     t.text "lms_type", default: "other", null: false
     t.string "cached_launch_message_nonce"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_192704) do
+ActiveRecord::Schema.define(version: 2019_08_27_174859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2019_08_05_192704) do
     t.boolean "students_are_repo_admins", default: false, null: false
     t.boolean "invitations_enabled", default: true
     t.boolean "template_repos_enabled"
+    t.string "google_assignment_id"
     t.index ["deleted_at"], name: "index_assignments_on_deleted_at"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["slug"], name: "index_assignments_on_slug"
@@ -169,9 +170,9 @@ ActiveRecord::Schema.define(version: 2019_08_05_192704) do
     t.text "consumer_key", null: false
     t.text "shared_secret", null: false
     t.text "lms_link"
+    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "organization_id"
     t.string "context_membership_url"
     t.text "lms_type", default: "other", null: false
     t.string "cached_launch_message_nonce"

--- a/docs/connect-to-lms.md
+++ b/docs/connect-to-lms.md
@@ -13,7 +13,7 @@ For the GitHub Classroom and LMS integration to work, we require that your LMS s
 - LTI version 1.0 and/or 1.1
 - LTI Names and Roles Provisioning 1.X
 
-**Note**: Blackboard and GitHub Classroom course rosters don't work together yet. We are working to support Blackboard in the near future!
+**Note**: Blackboard and Brightspace course rosters don't work together yet with GitHub Classroom. We are working to support Blackboard and Brightspace in the near future!
 {: class="warning"}
 
 ### Setup guide

--- a/docs/connect-to-lms.md
+++ b/docs/connect-to-lms.md
@@ -13,7 +13,7 @@ For the GitHub Classroom and LMS integration to work, we require that your LMS s
 - LTI version 1.0 and/or 1.1
 - LTI Names and Roles Provisioning 1.X
 
-**Note**: Blackboard and Brightspace course rosters don't work together yet with GitHub Classroom. We are working to support Blackboard and Brightspace in the near future!
+**Note**: Blackboard and Brightspace course rosters aren't compatible with GitHub Classroom yet. We are working to support Blackboard and Brightspace in the near future!
 {: class="warning"}
 
 ### Setup guide


### PR DESCRIPTION
## What
We currently do not support Brightspace with LTI 1.0/1.1 as they did not implement IMS names and provisioning service. So we are going to be removing Brightspace, as a supported LMS. 

### Updated Connect to LMS page
![image](https://user-images.githubusercontent.com/22784140/64553741-edd67f00-d307-11e9-8341-a7191b3614c4.png)

### Changes to the help docs 
![image](https://user-images.githubusercontent.com/22784140/64553592-a51ec600-d307-11e9-8728-d910ad91fb30.png)
