### PR TITLE
Add `onboarding_redesign` feature flag helper method

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -38,8 +38,8 @@ class ApplicationController
   end
   helper_method :classroom_visibility_enabled?
 
-  def redesign_enabled?
-    GitHubClassroom.flipper[:redesign].enabled? || (logged_in? && current_user.feature_enabled?(:redesign))
+  def onboarding_redesign_enabled?
+    GitHubClassroom.flipper[:onboarding_redesign].enabled? || (logged_in? && current_user.feature_enabled?(:onboarding_redesign))
   end
-  helper_method :redesign_enabled?
+  helper_method :onboarding_redesign_enabled?
 end

--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -37,4 +37,9 @@ class ApplicationController
     logged_in? && current_user.feature_enabled?(:classroom_visibility)
   end
   helper_method :classroom_visibility_enabled?
+
+  def redesign_enabled?
+    GitHubClassroom.flipper[:redesign].enabled? || (logged_in? && current_user.feature_enabled?(:redesign))
+  end
+  helper_method :redesign_enabled?
 end

--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -38,6 +38,7 @@ class ApplicationController
   end
   helper_method :classroom_visibility_enabled?
 
+  # rubocop:disable Metrics/LineLength
   def onboarding_redesign_enabled?
     GitHubClassroom.flipper[:onboarding_redesign].enabled? || (logged_in? && current_user.feature_enabled?(:onboarding_redesign))
   end


### PR DESCRIPTION
Closes #2349

This adds the `onboarding_redesign_enabled?` feature flag helper method. I've also created the feature flag in devtools so it will be available in production.

This will enable us to easily check if the flag is enabled in future development as we work on the onboarding redesign.

Because onboarding can start before a person is logged in, I've set this up to check for global enablement or enablement for a specific user. This will make local dev easier since you can enable globally in order to get the updated version even if your local user is logged out.