### PR TITLE
remove linter rule for line limit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,12 +19,6 @@ TrailingBlankLines:
 Documentation:
   Enabled: false
 
-Metrics/ClassLength:
-  Max: 120
-
-Metrics/LineLength:
-  Max: 120
-
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,12 @@ TrailingBlankLines:
 Documentation:
   Enabled: false
 
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -38,7 +38,6 @@ class ApplicationController
   end
   helper_method :classroom_visibility_enabled?
 
-  # rubocop:disable Metrics/LineLength
   def onboarding_redesign_enabled?
     GitHubClassroom.flipper[:onboarding_redesign].enabled? || (logged_in? && current_user.feature_enabled?(:onboarding_redesign))
   end

--- a/app/controllers/assignment_invitations_controller.rb
+++ b/app/controllers/assignment_invitations_controller.rb
@@ -70,7 +70,6 @@ class AssignmentInvitationsController < ApplicationController
 
   def success; end
 
-  # rubocop:disable Metrics/LineLength
   def join_roster
     super
 
@@ -81,7 +80,6 @@ class AssignmentInvitationsController < ApplicationController
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "An error occurred, please try again!"
   end
-  # rubocop:enable Metrics/LineLength
 
   private
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class AssignmentsController < ApplicationController
   include OrganizationAuthorization
   include StarterCode
@@ -188,4 +187,3 @@ class AssignmentsController < ApplicationController
     GitHubClassroom.statsd.increment("deadline.create") if @assignment.deadline
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/concerns/starter_code.rb
+++ b/app/controllers/concerns/starter_code.rb
@@ -9,9 +9,7 @@ module StarterCode
   def starter_code_repository_id(repo_name)
     return if repo_name.blank?
 
-    # rubocop:disable Metrics/LineLength
     raise GitHub::Error, WRONG_FORMAT unless repo_name.match?(%r{^#{GitHub::USERNAME_REGEX}\/#{GitHub::REPOSITORY_REGEX}$})
-    # rubocop:enable Metrics/LineLength
 
     begin
       # rubocop:disable Rails/DynamicFindBy

--- a/app/controllers/group_assignment_invitations_controller.rb
+++ b/app/controllers/group_assignment_invitations_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class GroupAssignmentInvitationsController < ApplicationController
   class InvalidStatusForRouteError < StandardError; end
 
@@ -250,4 +249,3 @@ class GroupAssignmentInvitationsController < ApplicationController
     redirect_to group_assignment_invitation_path(invitation) if group.blank?
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/group_assignments_controller.rb
+++ b/app/controllers/group_assignments_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable ClassLength
 class GroupAssignmentsController < ApplicationController
   include OrganizationAuthorization
   include StarterCode
@@ -208,4 +207,3 @@ class GroupAssignmentsController < ApplicationController
   end
   # rubocop:enable MethodLength
 end
-# rubocop:enable ClassLength

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class OrganizationsController < Orgs::Controller
   before_action :ensure_team_management_flipper_is_enabled, only: [:show_groupings]
 

--- a/app/controllers/orgs/rosters_controller.rb
+++ b/app/controllers/orgs/rosters_controller.rb
@@ -2,7 +2,6 @@
 
 require "google/apis/classroom_v1"
 
-# rubocop:disable Metrics/ClassLength
 module Orgs
   class RostersController < Orgs::Controller
     before_action :ensure_current_roster, except: %i[

--- a/app/models/github_organization.rb
+++ b/app/models/github_organization.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class GitHubOrganization < GitHubResource
   def accept_membership(user_github_login)
     return if organization_member?(user_github_login)

--- a/app/models/github_repository.rb
+++ b/app/models/github_repository.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class GitHubRepository < GitHubResource
   depends_on :import
 
@@ -244,4 +243,3 @@ class GitHubRepository < GitHubResource
     %w[name full_name html_url node_id private]
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/create_github_repo_service.rb
+++ b/app/services/create_github_repo_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable ClassLength
 class CreateGitHubRepoService
   attr_reader :exercise, :stats_sender
   delegate :assignment, :collaborator, :organization, :invite_status, to: :exercise
@@ -275,4 +274,3 @@ class CreateGitHubRepoService
   end
   # rubocop:enable MethodLength
 end
-# rubocop:enable ClassLength

--- a/lib/docker_compose/parser.rb
+++ b/lib/docker_compose/parser.rb
@@ -6,7 +6,6 @@ module DockerCompose
     #
     # output - The String output results from `docker-compose ps`
     #
-    # rubocop:disable Metrics/LineLength
     # Examples:
     #
     #   output = `docker-compose ps`
@@ -27,7 +26,6 @@ module DockerCompose
     #            @ports="127.0.0.1:2345->5432/tcp",
     #            @state="Up">]>
     #
-    # rubocop:enable Metrics/LineLength
     #
     # Returns an instance of DockerCompose::Services.
     def self.parse(output)

--- a/lib/github_classroom/lti/models/membership_extension/message_response.rb
+++ b/lib/github_classroom/lti/models/membership_extension/message_response.rb
@@ -5,10 +5,8 @@ module GitHubClassroom::LTI::Models::MembershipExtension
   class MessageResponse < IMS::LTI::Models::LTIModel
     add_attribute :lti_message_type
 
-    # rubocop:disable LineLength
     add_attribute :membership, json_key: "members", relation: "GitHubClassroom::LTI::Models::MembershipExtension::Membership"
     add_attribute :status_info, json_key: "statusinfo", relation: "GitHubClassroom::LTI::Models::MembershipExtension::StatusInfo"
-    # rubocop:enable LineLength
   end
 end
 # rubocop:enable ClassAndModuleChildren

--- a/spec/lib/github_classroom/lti/membership_service_spec.rb
+++ b/spec/lib/github_classroom/lti/membership_service_spec.rb
@@ -92,10 +92,8 @@ describe GitHubClassroom::LTI::MembershipService do
   end
 
   describe "membership extension (LTI 1.0)", :vcr do
-    # rubocop:disable Metrics/LineLength
     let(:endpoint) { "https://trysakai.longsight.com/imsblis/service/" }
     let(:body_params) { { "id": "4d0a6e23e6902927ff0ad4e7869f7f5cb3c5b962cd7fbb796d87a4ceab90fadd:::ce59ead6-026b-4ba5-9464-568e131c0a77:::content:2586" } }
-    # rubocop:enable Metrics/LineLength
 
     context "valid authentication" do
       let(:instance) { subject.new(endpoint, consumer_key, shared_secret, lti_version: 1.0) }

--- a/spec/models/group_assignment_repo_spec.rb
+++ b/spec/models/group_assignment_repo_spec.rb
@@ -91,13 +91,11 @@ RSpec.describe GroupAssignmentRepo, type: :model do
     end
 
     describe "is sortable", :vcr do
-      # rubocop:disable Metrics/LineLength
       let(:github_team_id_two) { organization.github_organization.create_team(Faker::Team.name[0..39]).id }
       let(:group_two) { create(:group, grouping: grouping, github_team_id: github_team_id_two, repo_accesses: [repo_access]) }
 
       let(:group_assignment_repo_one) { create(:group_assignment_repo, group_assignment: group_assignment, group: group, github_repo_id: 1) }
       let(:group_assignment_repo_two) { create(:group_assignment_repo, group_assignment: group_assignment, group: group_two, github_repo_id: 2) }
-      # rubocop:enable Metrics/LineLength
 
       it "order_by_sort_mode sorts by 'Team name'" do
         expected_ordering = [group_assignment_repo_one, group_assignment_repo_two].sort_by { |repo| repo.group.title }
@@ -115,13 +113,11 @@ RSpec.describe GroupAssignmentRepo, type: :model do
     end
 
     describe "is searchable", :vcr do
-      # rubocop:disable Metrics/LineLength
       let(:github_team_id_two) { organization.github_organization.create_team(Faker::Team.name[0..39]).id }
       let(:group_two) { create(:group, grouping: grouping, github_team_id: github_team_id_two, repo_accesses: [repo_access]) }
 
       let(:group_assignment_repo_one) { create(:group_assignment_repo, group_assignment: group_assignment, group: group, github_repo_id: 1) }
       let(:group_assignment_repo_two) { create(:group_assignment_repo, group_assignment: group_assignment, group: group_two, github_repo_id: 2) }
-      # rubocop:enable Metrics/LineLength
 
       it "filter_by_sort_mode searches by 'Team name'" do
         query = group_assignment_repo_one.group.title

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe User, type: :model do
       user.assign_from_auth_hash(github_omniauth_hash)
       scopes = user.github_client_scopes
 
-      %w[write:org read:org admin:org_hook delete_repo repo:status repo_deployment public_repo repo:invite user:email].each do |s| # rubocop:disable Metrics/LineLength
+      %w[write:org read:org admin:org_hook delete_repo repo:status repo_deployment public_repo repo:invite user:email].each do |s|
         expect(scopes).to include(s)
       end
     end

--- a/spec/services/create_github_repo_service_spec.rb
+++ b/spec/services/create_github_repo_service_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CreateGitHubRepoService do
         expect { service.create_github_repository_from_template! }
           .to raise_error(
             subject::Result::Error,
-            "GitHub repository could not be created from template, please try again. (Could not created GitHub repository)" # rubocop:disable LineLength
+            "GitHub repository could not be created from template, please try again. (Could not created GitHub repository)"
           )
       end
     end

--- a/spec/services/create_github_repo_service_spec.rb
+++ b/spec/services/create_github_repo_service_spec.rb
@@ -597,7 +597,7 @@ RSpec.describe CreateGitHubRepoService do
         expect { service.create_github_repository_from_template! }
           .to raise_error(
             subject::Result::Error,
-            "GitHub repository could not be created from template, please try again. (Could not created GitHub repository)" # rubocop:disable LineLength
+            "GitHub repository could not be created from template, please try again. (Could not created GitHub repository)"
           )
       end
     end
@@ -655,7 +655,7 @@ RSpec.describe CreateGitHubRepoService do
         expect { service.push_starter_code!(assignment_repository) }
           .to raise_error(
             subject::Result::Error,
-            "We were not able to import you the starter code to your Group assignment, please try again. (GitHub::Error)" # rubocop:disable LineLength
+            "We were not able to import you the starter code to your Group assignment, please try again. (GitHub::Error)"
           )
       end
     end
@@ -848,7 +848,7 @@ RSpec.describe CreateGitHubRepoService do
             result = service.perform
             expect(result.failed?).to be_truthy
             expect(result.error)
-              .to start_with("We were not able to import you the starter code to your Group assignment, please try again.") # rubocop:disable LineLength
+              .to start_with("We were not able to import you the starter code to your Group assignment, please try again.")
             expect(WebMock).to have_requested(:put, import_regex)
           end
 


### PR DESCRIPTION
I've seen myself/others get CI failures for exceeding the 120 character line limit a few times, and my preference is to review line length on context rather than a hard rule. We're also disabling these metrics 20 times across the codebase already. I'm open to feedback if folks feel strongly that we should keep these though!