### PR TITLE
Remove feature flags that only appear in the rake task

### DIFF
--- a/lib/tasks/enable_features.rake
+++ b/lib/tasks/enable_features.rake
@@ -3,11 +3,8 @@
 task enable_features: :environment do
   GitHubClassroom.flipper[:team_management].enable_group :staff
   GitHubClassroom.flipper[:google_classroom_roster_import].enable_group :staff
-  GitHubClassroom.flipper[:multiple_classrooms_per_org].enable_group :staff
-  GitHubClassroom.flipper[:search_assignments].enable_group :staff
   GitHubClassroom.flipper[:archive_classrooms].enable_group :staff
   GitHubClassroom.flipper[:lti_launch].enable_group :staff
-  GitHubClassroom.flipper[:unified_repo_creators].enable_group :staff
   GitHubClassroom.flipper[:classroom_visibility].enable_group :staff
   GitHubClassroom.flipper[:student_identifier].enable_group :staff
 end


### PR DESCRIPTION
These three feature flags only appear in this rake task.

I'm removing them as part of a cleanup task to make sure the only feature flags that remain in the codebase are flags for features that are actively under development.

There are some others here that can potentially be removed; however, they also have other code tied to the feature flag so I'll pull them out separately in a PR related to just that feature flag.