### PR TITLE
Remove google_classroom_roster_import feature flag and helper methods

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -9,15 +9,6 @@ class ApplicationController
     not_found unless lti_launch_enabled?
   end
 
-  def ensure_google_classroom_roster_import_is_enabled
-    not_found unless google_classroom_roster_import_enabled?
-  end
-
-  def google_classroom_roster_import_enabled?
-    logged_in? && current_user.feature_enabled?(:google_classroom_roster_import)
-  end
-  helper_method :google_classroom_roster_import_enabled?
-
   def team_management_enabled?
     logged_in? && current_user.feature_enabled?(:team_management)
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -91,9 +91,7 @@ class OrganizationsController < Orgs::Controller
 
   def new_assignment; end
 
-  def link_lms
-    not_found unless lti_launch_enabled? || google_classroom_roster_import_enabled?
-  end
+  def link_lms; end
 
   def invite; end
 

--- a/app/controllers/orgs/google_classroom_configurations_controller.rb
+++ b/app/controllers/orgs/google_classroom_configurations_controller.rb
@@ -4,7 +4,6 @@ require "google/apis/classroom_v1"
 
 module Orgs
   class GoogleClassroomConfigurationsController < Orgs::Controller
-    before_action :ensure_google_classroom_roster_import_is_enabled, only: %i[create search index]
     before_action :authorize_google_classroom, only: %i[create search index]
     before_action :ensure_no_lti_configuration, only: %i[create index]
     before_action :ensure_no_roster, only: %i[create index]

--- a/app/controllers/orgs/rosters_controller/google_classroom_dependency.rb
+++ b/app/controllers/orgs/rosters_controller/google_classroom_dependency.rb
@@ -2,10 +2,6 @@
 
 module Orgs
   class RostersController
-    before_action :ensure_google_classroom_roster_import_is_enabled, only: %i[
-      import_from_google_classroom
-      sync_google_classroom
-    ]
     before_action :authorize_google_classroom, only: %i[import_from_google_classroom sync_google_classroom]
     before_action :ensure_google_classroom_is_linked, only: %i[import_from_google_classroom sync_google_classroom]
     before_action :set_google_classroom, only: %i[import_from_google_classroom sync_google_classroom]

--- a/app/views/organizations/_invite_users.html.erb
+++ b/app/views/organizations/_invite_users.html.erb
@@ -19,12 +19,7 @@
 </div>
 
 <% if action_name == 'invite' %>
-      <div class="form-actions">
-        <% next_step = new_roster_path(current_organization) %>
-        <% if lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-          <% next_step = link_lms_organization_path(current_organization) %>
-        <% end %>
-
-        <%= button_to t('views.organizations.continue'), next_step, class: 'btn btn-primary right', method: :get %>
-      </div>
-    <% end %>
+  <div class="form-actions">
+    <%= button_to t('views.organizations.continue'), link_lms_organization_path(current_organization), class: 'btn btn-primary right', method: :get %>
+  </div>
+<% end %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -20,31 +20,29 @@
         <%= f.submit t('views.organizations.save_changes'), class: 'btn btn-primary' %>
       <% end %>
 
-      <% if lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-        <div class="Box Box--condensed mt-5">
-          <div class="Box-header">
-            <h2 class="Box-title"><%= "Learning management system" %></h2>
-          </div>
-
-          <div class="Box-body">
-            <% if lti_launch_enabled? && current_organization.lti_configuration %>
-              <% lms_name = current_organization.lti_configuration.lms_name(default_name: "a learning management system") %>
-              You are currently connected to <%= lms_name %>.
-              <%= link_to "Connection Settings", lti_configuration_path(current_organization) %>
-            <% elsif google_classroom_roster_import_enabled? && current_organization.google_course_id %>
-              You are currently connected to Google Classroom.
-            <% else lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-              <p>You are currently not connected to a learning management system. Integrating GitHub Classroom
-              with your institution will unlock new capabilities and enhance your experience.</p>
-              <%= link_to "Connect to a learning management system",
-                link_lms_organization_path(current_organization),
-                class: "btn btn-sm btn-secondary d-inline-flex flex-items-center mb-2 mr-1"
-              %>
-              <%= link_to "Learn more", help_path(article_name: "connect-to-lms") %>
-            <% end %>
-          </div>
+      <div class="Box Box--condensed mt-5">
+        <div class="Box-header">
+          <h2 class="Box-title"><%= "Learning management system" %></h2>
         </div>
-      <% end %>
+
+        <div class="Box-body">
+          <% if lti_launch_enabled? && current_organization.lti_configuration %>
+            <% lms_name = current_organization.lti_configuration.lms_name(default_name: "a learning management system") %>
+            You are currently connected to <%= lms_name %>.
+            <%= link_to "Connection Settings", lti_configuration_path(current_organization) %>
+          <% elsif current_organization.google_course_id %>
+            You are currently connected to Google Classroom.
+          <% else %>
+            <p>You are currently not connected to a learning management system. Integrating GitHub Classroom
+            with your institution will unlock new capabilities and enhance your experience.</p>
+            <%= link_to "Connect to a learning management system",
+              link_lms_organization_path(current_organization),
+              class: "btn btn-sm btn-secondary d-inline-flex flex-items-center mb-2 mr-1"
+            %>
+            <%= link_to "Learn more", help_path(article_name: "connect-to-lms") %>
+          <% end %>
+        </div>
+      </div>
 
       <div class="Box Box--condensed mt-5">
         <div class="Box-header bg-red">

--- a/app/views/organizations/link_lms.html.erb
+++ b/app/views/organizations/link_lms.html.erb
@@ -9,14 +9,12 @@
     <%= link_to "Learn more", help_path(article_name: "connect-to-lms") %>.
     </p>
     <div class="d-flex flex-wrap gutter">
-      <% if google_classroom_roster_import_enabled? %>
-        <div class="col-6 col-md-4 col-lg-4">
-          <%= button_to google_classrooms_index_organization_path(current_organization), method: :get, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
-            <%= image_tag "google-classroom-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
-            <span class="css-truncate-target" title="Google Classroom">Google Classroom</span>
-          <% end %>
-        </div>
-      <% end %>
+      <div class="col-6 col-md-4 col-lg-4">
+        <%= button_to google_classrooms_index_organization_path(current_organization), method: :get, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
+          <%= image_tag "google-classroom-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
+          <span class="css-truncate-target" title="Google Classroom">Google Classroom</span>
+        <% end %>
+      </div>
       <% if lti_launch_enabled? %>
         <% LtiConfiguration.lms_types.each_pair do |lms_type, lms_name| %>
           <% lms_name = "Other LMS" if lms_type == "other" %>

--- a/app/views/orgs/rosters/_new_student_modal.html.erb
+++ b/app/views/orgs/rosters/_new_student_modal.html.erb
@@ -6,15 +6,13 @@
 
     <div class="my-3">
       <h2 class="h4 mb-2">Import students from your institution</h2>
-      <% if google_classroom_roster_import_enabled? || lti_launch_enabled? %>
-        <p>GitHub Classroom is able to automatically import your roster from your institution. If you
-        would rather manage your roster manually, you can still do that, too.</p>
+      <p>GitHub Classroom is able to automatically import your roster from your institution. If you
+      would rather manage your roster manually, you can still do that, too.</p>
 
-        <%= link_to "Sync from a learning management system",
-          link_lms_organization_path,
-          class: "btn btn-block btn-sm"
-        %>
-      <% end %>
+      <%= link_to "Sync from a learning management system",
+        link_lms_organization_path,
+        class: "btn btn-block btn-sm"
+      %>
     </div>
 
     <div class="my-3">

--- a/app/views/orgs/rosters/new.html.erb
+++ b/app/views/orgs/rosters/new.html.erb
@@ -11,32 +11,30 @@
       <p>Let's set up a roster so you can easily track student progress on your dashboard. You can always come back and complete this step later.</p>
     </div>
     <div class="my-3">
-      <% if google_classroom_roster_import_enabled? || lti_launch_enabled? %>
-        <h2 class="h3 mb-2">Import students from your institution</h2>
-        <% if current_organization.lti_configuration %>
-          <% lms_name = current_organization.lti_configuration.lms_name(default_name: "your learning management system") %>
-          <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import your roster for you!</p>
+      <h2 class="h3 mb-2">Import students from your institution</h2>
+      <% if current_organization.lti_configuration %>
+        <% lms_name = current_organization.lti_configuration.lms_name(default_name: "your learning management system") %>
+        <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import your roster for you!</p>
 
-          <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from #{lms_name}",
-            import_from_lms_roster_path,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% elsif current_organization.google_course_id %>
-          <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import your roster for you!</p>
-          <%= link_to image_tag('google-classroom-logo.png', size: "25", class:"mr-2") + "Import from Google Classroom",
-            import_from_google_classroom_roster_path(current_organization),
-            method: :patch,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% else %>
-          <p>GitHub Classroom is able to automatically import your roster from your institution. If you
-          would rather manage your roster manually, you can still do that, too.</p>
+        <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from #{lms_name}",
+          import_from_lms_roster_path,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
+      <% elsif current_organization.google_course_id %>
+        <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import your roster for you!</p>
+        <%= link_to image_tag('google-classroom-logo.png', size: "25", class:"mr-2") + "Import from Google Classroom",
+          import_from_google_classroom_roster_path(current_organization),
+          method: :patch,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
+      <% else %>
+        <p>GitHub Classroom is able to automatically import your roster from your institution. If you
+        would rather manage your roster manually, you can still do that, too.</p>
 
-          <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from a learning management system",
-            link_lms_organization_path,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% end %>
+        <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from a learning management system",
+          link_lms_organization_path,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
       <% end %>
     </div>
 

--- a/app/views/orgs/rosters/show.html.erb
+++ b/app/views/orgs/rosters/show.html.erb
@@ -12,7 +12,7 @@
             Classroom roster
           </span>
           <div class='flex-justify-between'>
-            <% if google_classroom_roster_import_enabled? && current_organization.google_course_id %>
+            <% if current_organization.google_course_id %>
               <span class="btn btn-primary btn-sm", role="button" data-remodal-target="sync-google-roster-modal"><%= octicon "sync" %>  Sync from Google Classroom</span>
             <% elsif lti_launch_enabled? && current_organization.lti_configuration %>
               <% lms_name = current_organization.lti_configuration.lms_name(default_name: "learning management system") %>

--- a/lib/tasks/enable_features.rake
+++ b/lib/tasks/enable_features.rake
@@ -2,7 +2,6 @@
 
 task enable_features: :environment do
   GitHubClassroom.flipper[:team_management].enable_group :staff
-  GitHubClassroom.flipper[:google_classroom_roster_import].enable_group :staff
   GitHubClassroom.flipper[:archive_classrooms].enable_group :staff
   GitHubClassroom.flipper[:lti_launch].enable_group :staff
   GitHubClassroom.flipper[:classroom_visibility].enable_group :staff

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -354,9 +354,6 @@ RSpec.describe OrganizationsController, type: :controller do
     end
 
     context "with google classroom disabled" do
-      before(:each) { GitHubClassroom.flipper[:google_classroom_roster_import].enable }
-      after(:each)  { GitHubClassroom.flipper[:google_classroom_roster_import].disable }
-
       it "renders the LMS selection page" do
         get :link_lms, params: { id: organization.slug }
         expect(response).to have_http_status(:ok)
@@ -364,10 +361,9 @@ RSpec.describe OrganizationsController, type: :controller do
       end
     end
 
-    context "with lti launch or google classroom disabled" do
+    context "with lti launch disabled" do
       before(:each) do
         GitHubClassroom.flipper[:lti_launch].disable
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
       end
 
       it "returns not found" do

--- a/spec/controllers/orgs/google_classroom_configurations_controller_spec.rb
+++ b/spec/controllers/orgs/google_classroom_configurations_controller_spec.rb
@@ -14,341 +14,270 @@ RSpec.describe Orgs::GoogleClassroomConfigurationsController, type: :controller 
   end
 
   describe "#index", :vcr do
-    context "with flipper on" do
-      before(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].enable
+    context "when the user is authorized" do
+      before do
+        client = Signet::OAuth2::Client.new
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(client)
+
+        response = GoogleAPI::ListCoursesResponse.new
+        allow_any_instance_of(GoogleAPI::ClassroomService)
+          .to receive(:list_courses)
+          .and_return(response)
       end
 
-      context "when the user is authorized" do
-        before do
-          client = Signet::OAuth2::Client.new
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(client)
+      it "succeeds" do
+        get :index, params: {
+          id: organization.slug
+        }
 
-          response = GoogleAPI::ListCoursesResponse.new
+        expect(response).to have_http_status(:success)
+      end
+
+      context "there is a LTI configuration" do
+        before(:each) do
+          @lti_configuration = create(:lti_configuration,
+            organization: organization,
+            consumer_key: "hi",
+            shared_secret: "hi")
+
+          get :index, params: {
+            id: organization.slug
+          }
+        end
+
+        it "flashes error message" do
+          lms_name = @lti_configuration.lms_name(default_name: "a learning management system")
+          expect(flash[:alert]).to eq("This classroom is already connected to #{lms_name}. "\
+            "Please disconnect from #{lms_name} before connecting to Google Classroom.")
+        end
+
+        it "redirects to settings page" do
+          expect(response).to redirect_to(edit_organization_path(organization))
+        end
+
+        after(:each) do
+          organization.lti_configuration = nil
+          organization.save!
+          organization.reload
+        end
+      end
+
+      context "there is a roster" do
+        before(:each) do
+          organization.roster = create(:roster)
+          organization.save!
+          organization.reload
+
+          get :index, params: {
+            id: organization.slug
+          }
+        end
+
+        it "flashes error message" do
+          message = "We are unable to link your classroom organization to Google Classroom "\
+            "because a roster already exists. Please delete your current roster and try again."
+          expect(flash[:alert]).to eq(message)
+        end
+
+        it "redirects to settings page" do
+          expect(response).to redirect_to(edit_organization_path(organization))
+        end
+
+        after(:each) do
+          organization.roster = nil
+          organization.save!
+          organization.reload
+        end
+      end
+
+      context "when there is an error fetching classes" do
+        before do
           allow_any_instance_of(GoogleAPI::ClassroomService)
             .to receive(:list_courses)
-            .and_return(response)
-        end
+            .and_raise(Google::Apis::ServerError.new("boom"))
 
-        it "succeeds" do
-          get :index, params: {
-            id: organization.slug
-          }
-
-          expect(response).to have_http_status(:success)
-        end
-
-        context "there is a LTI configuration" do
-          before(:each) do
-            @lti_configuration = create(:lti_configuration,
-              organization: organization,
-              consumer_key: "hi",
-              shared_secret: "hi")
-
-            get :index, params: {
-              id: organization.slug
-            }
-          end
-
-          it "flashes error message" do
-            lms_name = @lti_configuration.lms_name(default_name: "a learning management system")
-            expect(flash[:alert]).to eq("This classroom is already connected to #{lms_name}. "\
-              "Please disconnect from #{lms_name} before connecting to Google Classroom.")
-          end
-
-          it "redirects to settings page" do
-            expect(response).to redirect_to(edit_organization_path(organization))
-          end
-
-          after(:each) do
-            organization.lti_configuration = nil
-            organization.save!
-            organization.reload
-          end
-        end
-
-        context "there is a roster" do
-          before(:each) do
-            organization.roster = create(:roster)
-            organization.save!
-            organization.reload
-
-            get :index, params: {
-              id: organization.slug
-            }
-          end
-
-          it "flashes error message" do
-            message = "We are unable to link your classroom organization to Google Classroom "\
-              "because a roster already exists. Please delete your current roster and try again."
-            expect(flash[:alert]).to eq(message)
-          end
-
-          it "redirects to settings page" do
-            expect(response).to redirect_to(edit_organization_path(organization))
-          end
-
-          after(:each) do
-            organization.roster = nil
-            organization.save!
-            organization.reload
-          end
-        end
-
-        context "when there is an error fetching classes" do
-          before do
-            allow_any_instance_of(GoogleAPI::ClassroomService)
-              .to receive(:list_courses)
-              .and_raise(Google::Apis::ServerError.new("boom"))
-
-            patch :index, params: {
-              id: organization.slug
-            }
-          end
-
-          it "sets error message" do
-            expect(flash[:error]).to eq("Failed to fetch classroom from Google Classroom. Please try again.")
-          end
-        end
-      end
-
-      context "when user is not authorized" do
-        before do
-          # Stub google authentication again
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(nil)
-
-          get :index, params: {
+          patch :index, params: {
             id: organization.slug
           }
         end
 
-        it "redirects to authorization url" do
-          expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
+        it "sets error message" do
+          expect(flash[:error]).to eq("Failed to fetch classroom from Google Classroom. Please try again.")
         end
-      end
-
-      after(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
       end
     end
 
-    context "with flipper off" do
+    context "when user is not authorized" do
       before do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
+        # Stub google authentication again
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(nil)
+
         get :index, params: {
           id: organization.slug
         }
       end
 
-      it "404s" do
-        expect(response).to have_http_status(:not_found)
+      it "redirects to authorization url" do
+        expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
       end
     end
   end
 
   describe "#create", :vcr do
-    context "with flipper on" do
+    context "when the user is authorized" do
       before(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].enable
+        # Stub google authentication again
+        client = Signet::OAuth2::Client.new
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(client)
       end
 
-      context "when the user is authorized" do
-        before(:each) do
-          # Stub google authentication again
-          client = Signet::OAuth2::Client.new
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(client)
-        end
+      it "creates a statsd event" do
+        expect(GitHubClassroom.statsd).to receive(:increment).with("google_classroom.create")
 
-        it "creates a statsd event" do
-          expect(GitHubClassroom.statsd).to receive(:increment).with("google_classroom.create")
-
-          post :create, params: {
-            id: organization.slug,
-            course_id: 6464
-          }
-        end
-
-        context "creates configuration" do
-          before do
-            post :create, params: {
-              id: organization.slug,
-              course_id: 6464
-            }
-          end
-
-          it "suceeds" do
-            expect(Organization.first.google_course_id).to eq("6464")
-            expect(flash[:success]).to eq("Google Classroom integration was succesfully configured.")
-          end
-        end
-
-        context "there is a LTI configuration" do
-          before(:each) do
-            @lti_configuration = create(:lti_configuration,
-              organization: organization,
-              consumer_key: "hi",
-              shared_secret: "hi")
-
-            post :create, params: {
-              id: organization.slug,
-              course_id: 6464
-            }
-          end
-
-          it "flashes error message" do
-            lms_name = @lti_configuration.lms_name(default_name: "a learning management system")
-            expect(flash[:alert]).to eq("This classroom is already connected to #{lms_name}. "\
-              "Please disconnect from #{lms_name} before connecting to Google Classroom.")
-          end
-
-          it "redirects to settings page" do
-            expect(response).to redirect_to(edit_organization_path(organization))
-          end
-
-          after(:each) do
-            organization.lti_configuration = nil
-            organization.save!
-            organization.reload
-          end
-        end
-
-        context "there is a roster" do
-          before(:each) do
-            organization.roster = create(:roster)
-            organization.save!
-            organization.reload
-
-            post :create, params: {
-              id: organization.slug,
-              course_id: 6464
-            }
-          end
-
-          it "flashes error message" do
-            message = "We are unable to link your classroom organization to Google Classroom "\
-              "because a roster already exists. Please delete your current roster and try again."
-            expect(flash[:alert]).to eq(message)
-          end
-
-          it "redirects to settings page" do
-            expect(response).to redirect_to(edit_organization_path(organization))
-          end
-
-          after(:each) do
-            organization.roster = nil
-            organization.save!
-            organization.reload
-          end
-        end
-      end
-
-      context "when user is not authorized" do
-        before do
-          # Stub google authentication again
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(nil)
-
-          post :create, params: {
-            id: organization.slug,
-            course_id: 6464
-          }
-        end
-
-        it "redirects to authorization url" do
-          expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
-        end
-      end
-
-      after(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
-      end
-    end
-
-    context "with flipper off" do
-      before do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
         post :create, params: {
           id: organization.slug,
           course_id: 6464
         }
       end
 
-      it "404s" do
-        expect(response).to have_http_status(:not_found)
+      context "creates configuration" do
+        before do
+          post :create, params: {
+            id: organization.slug,
+            course_id: 6464
+          }
+        end
+
+        it "suceeds" do
+          expect(Organization.first.google_course_id).to eq("6464")
+          expect(flash[:success]).to eq("Google Classroom integration was succesfully configured.")
+        end
+      end
+
+      context "there is a LTI configuration" do
+        before(:each) do
+          @lti_configuration = create(:lti_configuration,
+            organization: organization,
+            consumer_key: "hi",
+            shared_secret: "hi")
+
+          post :create, params: {
+            id: organization.slug,
+            course_id: 6464
+          }
+        end
+
+        it "flashes error message" do
+          lms_name = @lti_configuration.lms_name(default_name: "a learning management system")
+          expect(flash[:alert]).to eq("This classroom is already connected to #{lms_name}. "\
+            "Please disconnect from #{lms_name} before connecting to Google Classroom.")
+        end
+
+        it "redirects to settings page" do
+          expect(response).to redirect_to(edit_organization_path(organization))
+        end
+
+        after(:each) do
+          organization.lti_configuration = nil
+          organization.save!
+          organization.reload
+        end
+      end
+
+      context "there is a roster" do
+        before(:each) do
+          organization.roster = create(:roster)
+          organization.save!
+          organization.reload
+
+          post :create, params: {
+            id: organization.slug,
+            course_id: 6464
+          }
+        end
+
+        it "flashes error message" do
+          message = "We are unable to link your classroom organization to Google Classroom "\
+            "because a roster already exists. Please delete your current roster and try again."
+          expect(flash[:alert]).to eq(message)
+        end
+
+        it "redirects to settings page" do
+          expect(response).to redirect_to(edit_organization_path(organization))
+        end
+
+        after(:each) do
+          organization.roster = nil
+          organization.save!
+          organization.reload
+        end
+      end
+    end
+
+    context "when user is not authorized" do
+      before do
+        # Stub google authentication again
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(nil)
+
+        post :create, params: {
+          id: organization.slug,
+          course_id: 6464
+        }
+      end
+
+      it "redirects to authorization url" do
+        expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
       end
     end
   end
 
   describe "#search", :vcr do
-    context "with flipper on" do
-      before(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].enable
-      end
-
-      context "when the user is authorized" do
-        before do
-          # Stub google authentication again
-          client = Signet::OAuth2::Client.new
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(client)
-
-          response = GoogleAPI::ListCoursesResponse.new
-          allow_any_instance_of(GoogleAPI::ClassroomService)
-            .to receive(:list_courses)
-            .and_return(response)
-
-          get :search, params: {
-            id: organization.slug,
-            query: ""
-          }
-        end
-
-        it "succeeds" do
-          expect(response).to have_http_status(200)
-        end
-      end
-
-      context "when user is not authorized with google" do
-        before do
-          allow_any_instance_of(ApplicationController)
-            .to receive(:user_google_classroom_credentials)
-            .and_return(nil)
-
-          get :search, params: {
-            id: organization.slug,
-            query: ""
-          }
-        end
-
-        it "redirects to authorization url" do
-          expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
-        end
-      end
-
-      after(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
-      end
-    end
-
-    context "with flipper off" do
+    context "when the user is authorized" do
       before do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
+        # Stub google authentication again
+        client = Signet::OAuth2::Client.new
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(client)
+
+        response = GoogleAPI::ListCoursesResponse.new
+        allow_any_instance_of(GoogleAPI::ClassroomService)
+          .to receive(:list_courses)
+          .and_return(response)
+
         get :search, params: {
           id: organization.slug,
           query: ""
         }
       end
 
-      it "404s" do
-        expect(response).to have_http_status(:not_found)
+      it "succeeds" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when user is not authorized with google" do
+      before do
+        allow_any_instance_of(ApplicationController)
+          .to receive(:user_google_classroom_credentials)
+          .and_return(nil)
+
+        get :search, params: {
+          id: organization.slug,
+          query: ""
+        }
+      end
+
+      it "redirects to authorization url" do
+        expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
       end
     end
   end

--- a/spec/controllers/orgs/rosters_controller_spec.rb
+++ b/spec/controllers/orgs/rosters_controller_spec.rb
@@ -796,131 +796,120 @@ RSpec.describe Orgs::RostersController, type: :controller do
       GoogleAPI = Google::Apis::ClassroomV1
     end
 
-    context "with google classroom flipper enabled" do
+    context "when google classroom course is linked" do
       before do
-        GitHubClassroom.flipper[:google_classroom_roster_import].enable
+        organization.update_attributes(google_course_id: "1234")
       end
 
-      context "when google classroom course is linked" do
+      context "when user is authorized with google" do
         before do
-          organization.update_attributes(google_course_id: "1234")
+          # Stub google authentication
+          client = Signet::OAuth2::Client.new
+          allow_any_instance_of(ApplicationController)
+            .to receive(:user_google_classroom_credentials)
+            .and_return(client)
         end
 
-        context "when user is authorized with google" do
+        context "when course has multiple students" do
           before do
-            # Stub google authentication
-            client = Signet::OAuth2::Client.new
-            allow_any_instance_of(ApplicationController)
-              .to receive(:user_google_classroom_credentials)
-              .and_return(client)
+            valid_response = GoogleAPI::ListStudentsResponse.new
+
+            student_names = ["Student 1", "Student 2"]
+            student_profiles = student_names.map do |name|
+              GoogleAPI::UserProfile.new(name: GoogleAPI::Name.new(full_name: name))
+            end
+            students = student_profiles.map { |prof| GoogleAPI::Student.new(profile: prof) }
+
+            valid_response.students = students
+            allow_any_instance_of(GoogleAPI::ClassroomService)
+              .to receive(:list_course_students)
+              .and_return(valid_response)
           end
 
-          context "when course has multiple students" do
+          context "when organization has no roster" do
             before do
-              valid_response = GoogleAPI::ListStudentsResponse.new
-
-              student_names = ["Student 1", "Student 2"]
-              student_profiles = student_names.map do |name|
-                GoogleAPI::UserProfile.new(name: GoogleAPI::Name.new(full_name: name))
-              end
-              students = student_profiles.map { |prof| GoogleAPI::Student.new(profile: prof) }
-
-              valid_response.students = students
-              allow_any_instance_of(GoogleAPI::ClassroomService)
-                .to receive(:list_course_students)
-                .and_return(valid_response)
+              organization.update_attributes(roster_id: nil)
             end
 
-            context "when organization has no roster" do
-              before do
-                organization.update_attributes(roster_id: nil)
-              end
+            it "sends statsd" do
+              allow(GitHubClassroom.statsd).to receive(:increment)
+              patch :import_from_google_classroom, params: {
+                id: organization.slug
+              }
+              expect(GitHubClassroom.statsd).to have_received(:increment).with("google_classroom.import")
+              expect(GitHubClassroom.statsd).to have_received(:increment).with("roster_entries.lms_imported", by: 2)
+            end
 
-              it "sends statsd" do
-                allow(GitHubClassroom.statsd).to receive(:increment)
+            context "when students are fetched succesfully" do
+              before do
                 patch :import_from_google_classroom, params: {
                   id: organization.slug
                 }
-                expect(GitHubClassroom.statsd).to have_received(:increment).with("google_classroom.import")
-                expect(GitHubClassroom.statsd).to have_received(:increment).with("roster_entries.lms_imported", by: 2)
               end
 
-              context "when students are fetched succesfully" do
-                before do
-                  patch :import_from_google_classroom, params: {
-                    id: organization.slug
-                  }
-                end
-
-                it "sets success message" do
-                  expect(flash[:success]).to start_with("Your classroom roster has been saved! Manage it")
-                end
-
-                it "has correct number of students" do
-                  expect(organization.reload.roster.roster_entries.count).to eq(2)
-                end
-
-                it "has students with correct names" do
-                  expect(organization.reload.roster.roster_entries[0]).to have_attributes(identifier: "Student 1")
-                  expect(organization.reload.roster.roster_entries[1]).to have_attributes(identifier: "Student 2")
-                end
-
-                it "links the google classroom to the organization" do
-                  expect(organization.reload.google_course_id).to eq("1234")
-                end
+              it "sets success message" do
+                expect(flash[:success]).to start_with("Your classroom roster has been saved! Manage it")
               end
 
-              context "when there is an error fetching students" do
-                before do
-                  allow_any_instance_of(GoogleAPI::ClassroomService)
-                    .to receive(:list_course_students)
-                    .and_raise(Google::Apis::ServerError.new("boom"))
+              it "has correct number of students" do
+                expect(organization.reload.roster.roster_entries.count).to eq(2)
+              end
 
-                  patch :import_from_google_classroom, params: {
-                    id: organization.slug
-                  }
-                end
+              it "has students with correct names" do
+                expect(organization.reload.roster.roster_entries[0]).to have_attributes(identifier: "Student 1")
+                expect(organization.reload.roster.roster_entries[1]).to have_attributes(identifier: "Student 2")
+              end
 
-                it "sets error message" do
-                  expect(flash[:error]).to eq("Failed to fetch students from Google Classroom. Please try again later.")
-                end
+              it "links the google classroom to the organization" do
+                expect(organization.reload.google_course_id).to eq("1234")
+              end
+            end
+
+            context "when there is an error fetching students" do
+              before do
+                allow_any_instance_of(GoogleAPI::ClassroomService)
+                  .to receive(:list_course_students)
+                  .and_raise(Google::Apis::ServerError.new("boom"))
+
+                patch :import_from_google_classroom, params: {
+                  id: organization.slug
+                }
+              end
+
+              it "sets error message" do
+                expect(flash[:error]).to eq("Failed to fetch students from Google Classroom. Please try again later.")
               end
             end
           end
         end
       end
+    end
 
-      context "when there is no google classroom course linked" do
-        context "when user is authorized with google" do
-          before do
-            # Stub google authentication
-            client = Signet::OAuth2::Client.new
-            allow_any_instance_of(ApplicationController)
-              .to receive(:user_google_classroom_credentials)
-              .and_return(client)
-          end
-
-          it "redirects to google classroom selection route" do
-            patch :import_from_google_classroom, params: {
-              id: organization.slug
-            }
-            expect(response).to redirect_to(google_classrooms_index_organization_path(organization))
-          end
-
-          it "sets flash message" do
-            patch :import_from_google_classroom, params: {
-              id: organization.slug
-            }
-            expect(flash[:alert]).to eq(
-              "Please link a Google Classroom before syncing a roster."
-            )
-          end
+    context "when there is no google classroom course linked" do
+      context "when user is authorized with google" do
+        before do
+          # Stub google authentication
+          client = Signet::OAuth2::Client.new
+          allow_any_instance_of(ApplicationController)
+            .to receive(:user_google_classroom_credentials)
+            .and_return(client)
         end
-      end
 
-      # TODO: with google classroom not linked
-      after do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
+        it "redirects to google classroom selection route" do
+          patch :import_from_google_classroom, params: {
+            id: organization.slug
+          }
+          expect(response).to redirect_to(google_classrooms_index_organization_path(organization))
+        end
+
+        it "sets flash message" do
+          patch :import_from_google_classroom, params: {
+            id: organization.slug
+          }
+          expect(flash[:alert]).to eq(
+            "Please link a Google Classroom before syncing a roster."
+          )
+        end
       end
     end
 
@@ -948,92 +937,82 @@ RSpec.describe Orgs::RostersController, type: :controller do
         GitHubClassroom.flipper[:student_identifier].enable
       end
 
-      context "with google classroom flipper enabled" do
+      context "when user is authorized with google" do
         before do
-          GitHubClassroom.flipper[:google_classroom_roster_import].enable
+          # Stub google authentication again
+          client = Signet::OAuth2::Client.new
+          allow_any_instance_of(ApplicationController)
+            .to receive(:user_google_classroom_credentials)
+            .and_return(client)
         end
 
-        context "when user is authorized with google" do
+        context "classroom has a linked google course" do
           before do
-            # Stub google authentication again
-            client = Signet::OAuth2::Client.new
+            organization.update_attributes(google_course_id: "1234")
+
+            student_names = ["Student 1", "Student 2"]
+            student_profiles = student_names.map do |name|
+              GoogleAPI::UserProfile.new(name: GoogleAPI::Name.new(full_name: name))
+            end
+            @students = student_profiles.map do |prof|
+              GoogleAPI::Student.new(profile: prof, user_id: SecureRandom.uuid)
+            end
+
+            allow_any_instance_of(GoogleClassroomCourse)
+              .to receive(:students)
+              .and_return(@students)
+
+            patch :sync_google_classroom, params: { id: organization.slug }
+          end
+
+          it "adds the new student to the roster" do
+            expect(organization.roster.roster_entries.count).to eq(3)
+          end
+
+          it "does not add duplicate students that were already added to roster" do
+            patch :sync_google_classroom, params: { id: organization.slug }
+            expect(organization.roster.roster_entries.count).to eq(3)
+          end
+
+          it "does not remove students deleted from google classroom" do
+            allow_any_instance_of(GoogleClassroomCourse)
+              .to receive(:students)
+              .and_return([])
+
+            patch :sync_google_classroom, params: { id: organization.slug }
+            expect(organization.roster.roster_entries.count).to eq(3)
+          end
+        end
+
+        context "when there is no google classroom course linked" do
+          before do
+            patch :import_from_google_classroom, params: {
+              id: organization.slug
+            }
+          end
+
+          it "redirects to google classroom selection route" do
+            expect(response).to redirect_to(google_classrooms_index_organization_path(organization))
+          end
+
+          it "sets flash message" do
+            expect(flash[:alert]).to eq(
+              "Please link a Google Classroom before syncing a roster."
+            )
+          end
+        end
+
+        context "when user is not authorized with google" do
+          before do
             allow_any_instance_of(ApplicationController)
               .to receive(:user_google_classroom_credentials)
-              .and_return(client)
+              .and_return(nil)
+
+            patch :sync_google_classroom, params: { id: organization.slug }
           end
 
-          context "classroom has a linked google course" do
-            before do
-              organization.update_attributes(google_course_id: "1234")
-
-              student_names = ["Student 1", "Student 2"]
-              student_profiles = student_names.map do |name|
-                GoogleAPI::UserProfile.new(name: GoogleAPI::Name.new(full_name: name))
-              end
-              @students = student_profiles.map do |prof|
-                GoogleAPI::Student.new(profile: prof, user_id: SecureRandom.uuid)
-              end
-
-              allow_any_instance_of(GoogleClassroomCourse)
-                .to receive(:students)
-                .and_return(@students)
-
-              patch :sync_google_classroom, params: { id: organization.slug }
-            end
-
-            it "adds the new student to the roster" do
-              expect(organization.roster.roster_entries.count).to eq(3)
-            end
-
-            it "does not add duplicate students that were already added to roster" do
-              patch :sync_google_classroom, params: { id: organization.slug }
-              expect(organization.roster.roster_entries.count).to eq(3)
-            end
-
-            it "does not remove students deleted from google classroom" do
-              allow_any_instance_of(GoogleClassroomCourse)
-                .to receive(:students)
-                .and_return([])
-
-              patch :sync_google_classroom, params: { id: organization.slug }
-              expect(organization.roster.roster_entries.count).to eq(3)
-            end
-          end
-
-          context "when there is no google classroom course linked" do
-            before do
-              patch :import_from_google_classroom, params: {
-                id: organization.slug
-              }
-            end
-
-            it "redirects to google classroom selection route" do
-              expect(response).to redirect_to(google_classrooms_index_organization_path(organization))
-            end
-
-            it "sets flash message" do
-              expect(flash[:alert]).to eq(
-                "Please link a Google Classroom before syncing a roster."
-              )
-            end
-          end
-
-          context "when user is not authorized with google" do
-            before do
-              allow_any_instance_of(ApplicationController)
-                .to receive(:user_google_classroom_credentials)
-                .and_return(nil)
-
-              patch :sync_google_classroom, params: { id: organization.slug }
-            end
-
-            it "redirects to authorization url" do
-              expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
-            end
-          end
-
-          after do
-            GitHubClassroom.flipper[:google_classroom_roster_import].disable
+          it "redirects to authorization url" do
+            expect(response).to redirect_to %r{\Ahttps://accounts.google.com/o/oauth2}
           end
         end
       end


### PR DESCRIPTION
Now that the classroom importer has been enabled globally, it's time to remove the feature flag!

This PR removes the `google_classroom_roster_import` feature flag and all related helper methods.