### PR TITLE
Remove lti_launch feature flag and related helper methods

### DIFF
--- a/app/controllers/application_controller/feature_flags_dependency.rb
+++ b/app/controllers/application_controller/feature_flags_dependency.rb
@@ -5,10 +5,6 @@ class ApplicationController
     not_found unless team_management_enabled?
   end
 
-  def ensure_lti_launch_flipper_is_enabled
-    not_found unless lti_launch_enabled?
-  end
-
   def ensure_google_classroom_roster_import_is_enabled
     not_found unless google_classroom_roster_import_enabled?
   end
@@ -27,11 +23,6 @@ class ApplicationController
     logged_in? && current_user.feature_enabled?(:archive_classrooms)
   end
   helper_method :archive_classrooms_enabled?
-
-  def lti_launch_enabled?
-    GitHubClassroom.flipper[:lti_launch].enabled? || (logged_in? && current_user.feature_enabled?(:lti_launch))
-  end
-  helper_method :lti_launch_enabled?
 
   def classroom_visibility_enabled?
     logged_in? && current_user.feature_enabled?(:classroom_visibility)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -92,7 +92,7 @@ class OrganizationsController < Orgs::Controller
   def new_assignment; end
 
   def link_lms
-    not_found unless lti_launch_enabled? || google_classroom_roster_import_enabled?
+    not_found unless true || google_classroom_roster_import_enabled?
   end
 
   def invite; end

--- a/app/controllers/orgs/lti_configurations_controller.rb
+++ b/app/controllers/orgs/lti_configurations_controller.rb
@@ -2,14 +2,12 @@
 
 module Orgs
   class LtiConfigurationsController < Orgs::Controller
-    before_action :ensure_lti_launch_flipper_is_enabled
     before_action :ensure_current_lti_configuration, except: %i[info new create]
     before_action :ensure_no_google_classroom, only: %i[new create]
     before_action :ensure_no_roster, only: %i[new create]
     before_action :ensure_lms_type, only: %i[create]
 
     skip_before_action :authenticate_user!, only: :autoconfigure
-    skip_before_action :ensure_lti_launch_flipper_is_enabled, only: :autoconfigure
     skip_before_action :ensure_current_organization_visible_to_current_user, only: :autoconfigure
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/controllers/orgs/rosters_controller/lti_dependency.rb
+++ b/app/controllers/orgs/rosters_controller/lti_dependency.rb
@@ -5,7 +5,6 @@ module Orgs
     class LtiImportError < StandardError; end
 
     skip_before_action :ensure_current_roster, only: [:import_from_lms]
-    before_action :ensure_lti_launch_flipper_is_enabled, only: [:import_from_lms]
     before_action :ensure_lti_configuration, only: [:import_from_lms]
 
     rescue_from LtiImportError, with: :handle_lms_import_error

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,8 +46,4 @@ class SessionsController < ApplicationController
   def allow_in_iframe
     response.headers.delete "X-Frame-Options"
   end
-
-  def verify_lti_launch_enabled
-    return not_found unless lti_launch_enabled?
-  end
 end

--- a/app/controllers/sessions_controller/lti_dependency.rb
+++ b/app/controllers/sessions_controller/lti_dependency.rb
@@ -11,7 +11,6 @@ class SessionsController < ApplicationController
   end
 
   skip_before_action :verify_authenticity_token,  only: %i[lti_launch]
-  before_action      :verify_lti_launch_enabled,  only: %i[lti_setup lti_launch]
   before_action      :allow_in_iframe,            only: %i[lti_launch]
 
   rescue_from LtiLaunchError, with: :handle_lti_launch_error

--- a/app/views/organizations/_invite_users.html.erb
+++ b/app/views/organizations/_invite_users.html.erb
@@ -19,12 +19,7 @@
 </div>
 
 <% if action_name == 'invite' %>
-      <div class="form-actions">
-        <% next_step = new_roster_path(current_organization) %>
-        <% if lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-          <% next_step = link_lms_organization_path(current_organization) %>
-        <% end %>
-
-        <%= button_to t('views.organizations.continue'), next_step, class: 'btn btn-primary right', method: :get %>
-      </div>
-    <% end %>
+  <div class="form-actions">
+    <%= button_to t('views.organizations.continue'), link_lms_organization_path(current_organization), class: 'btn btn-primary right', method: :get %>
+  </div>
+<% end %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -20,31 +20,29 @@
         <%= f.submit t('views.organizations.save_changes'), class: 'btn btn-primary' %>
       <% end %>
 
-      <% if lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-        <div class="Box Box--condensed mt-5">
-          <div class="Box-header">
-            <h2 class="Box-title"><%= "Learning management system" %></h2>
-          </div>
-
-          <div class="Box-body">
-            <% if lti_launch_enabled? && current_organization.lti_configuration %>
-              <% lms_name = current_organization.lti_configuration.lms_name(default_name: "a learning management system") %>
-              You are currently connected to <%= lms_name %>.
-              <%= link_to "Connection Settings", lti_configuration_path(current_organization) %>
-            <% elsif google_classroom_roster_import_enabled? && current_organization.google_course_id %>
-              You are currently connected to Google Classroom.
-            <% else lti_launch_enabled? || google_classroom_roster_import_enabled? %>
-              <p>You are currently not connected to a learning management system. Integrating GitHub Classroom
-              with your institution will unlock new capabilities and enhance your experience.</p>
-              <%= link_to "Connect to a learning management system",
-                link_lms_organization_path(current_organization),
-                class: "btn btn-sm btn-secondary d-inline-flex flex-items-center mb-2 mr-1"
-              %>
-              <%= link_to "Learn more", help_path(article_name: "connect-to-lms") %>
-            <% end %>
-          </div>
+      <div class="Box Box--condensed mt-5">
+        <div class="Box-header">
+          <h2 class="Box-title"><%= "Learning management system" %></h2>
         </div>
-      <% end %>
+
+        <div class="Box-body">
+          <% if current_organization.lti_configuration %>
+            <% lms_name = current_organization.lti_configuration.lms_name(default_name: "a learning management system") %>
+            You are currently connected to <%= lms_name %>.
+            <%= link_to "Connection Settings", lti_configuration_path(current_organization) %>
+          <% elsif google_classroom_roster_import_enabled? && current_organization.google_course_id %>
+            You are currently connected to Google Classroom.
+          <% else %>
+            <p>You are currently not connected to a learning management system. Integrating GitHub Classroom
+            with your institution will unlock new capabilities and enhance your experience.</p>
+            <%= link_to "Connect to a learning management system",
+              link_lms_organization_path(current_organization),
+              class: "btn btn-sm btn-secondary d-inline-flex flex-items-center mb-2 mr-1"
+            %>
+            <%= link_to "Learn more", help_path(article_name: "connect-to-lms") %>
+          <% end %>
+        </div>
+      </div>
 
       <div class="Box Box--condensed mt-5">
         <div class="Box-header bg-red">

--- a/app/views/organizations/link_lms.html.erb
+++ b/app/views/organizations/link_lms.html.erb
@@ -17,16 +17,14 @@
           <% end %>
         </div>
       <% end %>
-      <% if lti_launch_enabled? %>
-        <% LtiConfiguration.lms_types.each_pair do |lms_type, lms_name| %>
-          <% lms_name = "Other LMS" if lms_type == "other" %>
-          <div class="col-6 col-md-4 col-lg-4">
-            <%= button_to info_lti_configuration_path(current_organization), method: :get, params: { lms_type: lms_type }, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
-              <%= image_tag "#{lms_type}-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
-              <span class="css-truncate css-truncate-target" title=<%= lms_name %>><%= lms_name %></span>
-            <% end %>
-          </div>
-        <% end %>
+      <% LtiConfiguration.lms_types.each_pair do |lms_type, lms_name| %>
+        <% lms_name = "Other LMS" if lms_type == "other" %>
+        <div class="col-6 col-md-4 col-lg-4">
+          <%= button_to info_lti_configuration_path(current_organization), method: :get, params: { lms_type: lms_type }, class: 'd-block width-full text-center hover-grow border rounded-2 box-shadow-medium bg-white p-3 mb-4' do %>
+            <%= image_tag "#{lms_type}-logo.png", class: 'avatar d-block mx-auto mb-2', height: 25 %>
+            <span class="css-truncate css-truncate-target" title=<%= lms_name %>><%= lms_name %></span>
+          <% end %>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/orgs/rosters/_new_student_modal.html.erb
+++ b/app/views/orgs/rosters/_new_student_modal.html.erb
@@ -6,15 +6,13 @@
 
     <div class="my-3">
       <h2 class="h4 mb-2">Import students from your institution</h2>
-      <% if google_classroom_roster_import_enabled? || lti_launch_enabled? %>
-        <p>GitHub Classroom is able to automatically import your roster from your institution. If you
-        would rather manage your roster manually, you can still do that, too.</p>
+      <p>GitHub Classroom is able to automatically import your roster from your institution. If you
+      would rather manage your roster manually, you can still do that, too.</p>
 
-        <%= link_to "Sync from a learning management system",
-          link_lms_organization_path,
-          class: "btn btn-block btn-sm"
-        %>
-      <% end %>
+      <%= link_to "Sync from a learning management system",
+        link_lms_organization_path,
+        class: "btn btn-block btn-sm"
+      %>
     </div>
 
     <div class="my-3">

--- a/app/views/orgs/rosters/new.html.erb
+++ b/app/views/orgs/rosters/new.html.erb
@@ -11,32 +11,30 @@
       <p>Let's set up a roster so you can easily track student progress on your dashboard. You can always come back and complete this step later.</p>
     </div>
     <div class="my-3">
-      <% if google_classroom_roster_import_enabled? || lti_launch_enabled? %>
-        <h2 class="h3 mb-2">Import students from your institution</h2>
-        <% if current_organization.lti_configuration %>
-          <% lms_name = current_organization.lti_configuration.lms_name(default_name: "your learning management system") %>
-          <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import your roster for you!</p>
+      <h2 class="h3 mb-2">Import students from your institution</h2>
+      <% if current_organization.lti_configuration %>
+        <% lms_name = current_organization.lti_configuration.lms_name(default_name: "your learning management system") %>
+        <p>It looks like you are connected to <%= lms_name %>. GitHub Classroom can automatically import your roster for you!</p>
 
-          <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from #{lms_name}",
-            import_from_lms_roster_path,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% elsif current_organization.google_course_id %>
-          <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import your roster for you!</p>
-          <%= link_to image_tag('google-classroom-logo.png', size: "25", class:"mr-2") + "Import from Google Classroom",
-            import_from_google_classroom_roster_path(current_organization),
-            method: :patch,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% else %>
-          <p>GitHub Classroom is able to automatically import your roster from your institution. If you
-          would rather manage your roster manually, you can still do that, too.</p>
+        <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from #{lms_name}",
+          import_from_lms_roster_path,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
+      <% elsif current_organization.google_course_id %>
+        <p>It looks like you are connected to Google Classroom. GitHub Classroom can automatically import your roster for you!</p>
+        <%= link_to image_tag('google-classroom-logo.png', size: "25", class:"mr-2") + "Import from Google Classroom",
+          import_from_google_classroom_roster_path(current_organization),
+          method: :patch,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
+      <% else %>
+        <p>GitHub Classroom is able to automatically import your roster from your institution. If you
+        would rather manage your roster manually, you can still do that, too.</p>
 
-          <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from a learning management system",
-            link_lms_organization_path,
-            class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
-          %>
-        <% end %>
+        <%= link_to image_tag('other-logo.png', size: "25", class:"mr-2") + "Import from a learning management system",
+          link_lms_organization_path,
+          class: "btn btn-secondary d-inline-flex flex-items-center mb-3"
+        %>
       <% end %>
     </div>
 

--- a/app/views/orgs/rosters/show.html.erb
+++ b/app/views/orgs/rosters/show.html.erb
@@ -14,7 +14,7 @@
           <div class='flex-justify-between'>
             <% if google_classroom_roster_import_enabled? && current_organization.google_course_id %>
               <span class="btn btn-primary btn-sm", role="button" data-remodal-target="sync-google-roster-modal"><%= octicon "sync" %>  Sync from Google Classroom</span>
-            <% elsif lti_launch_enabled? && current_organization.lti_configuration %>
+            <% elsif current_organization.lti_configuration %>
               <% lms_name = current_organization.lti_configuration.lms_name(default_name: "learning management system") %>
               <%= link_to import_from_lms_roster_path, remote: true, method: :get, class: "btn btn-primary btn-sm" do %>
                 <%= octicon "sync" %>  Sync from <%= lms_name %>

--- a/lib/tasks/enable_features.rake
+++ b/lib/tasks/enable_features.rake
@@ -4,7 +4,6 @@ task enable_features: :environment do
   GitHubClassroom.flipper[:team_management].enable_group :staff
   GitHubClassroom.flipper[:google_classroom_roster_import].enable_group :staff
   GitHubClassroom.flipper[:archive_classrooms].enable_group :staff
-  GitHubClassroom.flipper[:lti_launch].enable_group :staff
   GitHubClassroom.flipper[:classroom_visibility].enable_group :staff
   GitHubClassroom.flipper[:student_identifier].enable_group :staff
 end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -342,15 +342,10 @@ RSpec.describe OrganizationsController, type: :controller do
   end
 
   describe "GET #link_lms", :vcr do
-    context "with lti launch enabled" do
-      before(:each) { GitHubClassroom.flipper[:lti_launch].enable }
-      after(:each)  { GitHubClassroom.flipper[:lti_launch].disable }
-
-      it "renders the LMS selection page" do
-        get :link_lms, params: { id: organization.slug }
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:link_lms)
-      end
+    it "renders the LMS selection page" do
+      get :link_lms, params: { id: organization.slug }
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:link_lms)
     end
 
     context "with google classroom disabled" do
@@ -366,7 +361,6 @@ RSpec.describe OrganizationsController, type: :controller do
 
     context "with lti launch or google classroom disabled" do
       before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
         GitHubClassroom.flipper[:google_classroom_roster_import].disable
       end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -358,17 +358,6 @@ RSpec.describe OrganizationsController, type: :controller do
         expect(response).to render_template(:link_lms)
       end
     end
-
-    context "with lti launch or google classroom disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:google_classroom_roster_import].disable
-      end
-
-      it "returns not found" do
-        get :link_lms, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
-      end
-    end
   end
 
   describe "GET #invite", :vcr do

--- a/spec/controllers/orgs/lti_configurations_controller_spec.rb
+++ b/spec/controllers/orgs/lti_configurations_controller_spec.rb
@@ -11,250 +11,153 @@ RSpec.describe Orgs::LtiConfigurationsController, type: :controller do
   end
 
   describe "GET #new", :vcr do
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
-      end
-
-      it "returns not_found" do
-        get :new, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
-      end
+    before(:each) do
+      get :new, params: { id: organization.slug }
     end
 
-    context "with flipper enabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
-        get :new, params: { id: organization.slug }
-      end
+    it "returns success status" do
+      expect(response).to have_http_status(200)
+    end
 
-      it "returns success status" do
-        expect(response).to have_http_status(200)
-      end
-
-      it "renders new template" do
-        expect(response).to render_template(:new)
-      end
+    it "renders new template" do
+      expect(response).to render_template(:new)
     end
   end
 
   describe "GET #info", :vcr do
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
-      end
-
-      it "returns not_found" do
-        get :info, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
-      end
+    before(:each) do
+      get :info, params: { id: organization.slug }
     end
 
-    context "with flipper enabled" do
+    it "returns success status" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "renders new template" do
+      expect(response).to render_template(:info)
+    end
+  end
+
+  describe "GET #show", :vcr do
+    context "with lti_configuration present" do
       before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
-        get :info, params: { id: organization.slug }
+        create(:lti_configuration, organization: organization)
+        get :show, params: { id: organization.slug }
       end
 
       it "returns success status" do
         expect(response).to have_http_status(200)
       end
 
-      it "renders new template" do
-        expect(response).to render_template(:info)
+      it "renders show template" do
+        expect(response).to render_template(:show)
       end
     end
-  end
 
-  describe "GET #show", :vcr do
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
-      end
-
-      it "returns not_found" do
+    context "with no existing lti_configuration" do
+      it "redirects to new" do
         get :show, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "with flipper enabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
-      end
-
-      context "with lti_configuration present" do
-        before(:each) do
-          create(:lti_configuration, organization: organization)
-          get :show, params: { id: organization.slug }
-        end
-
-        it "returns success status" do
-          expect(response).to have_http_status(200)
-        end
-
-        it "renders show template" do
-          expect(response).to render_template(:show)
-        end
-      end
-
-      context "with no existing lti_configuration" do
-        it "redirects to new" do
-          get :show, params: { id: organization.slug }
-          expect(response).to redirect_to(info_lti_configuration_path(organization))
-        end
+        expect(response).to redirect_to(info_lti_configuration_path(organization))
       end
     end
   end
 
   describe "POST #create", :vcr do
-    context "with flipper enabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
+    it "sends statsd" do
+      expect(GitHubClassroom.statsd).to receive(:increment).with("lti_configuration.create")
+      post :create, params: { id: organization.slug, lti_configuration: { lms_type: :other } }
+    end
+
+    it "creates lti_configuration if lms_type is set" do
+      post :create, params: { id: organization.slug, lti_configuration: { lms_type: :other } }
+      expect(organization.lti_configuration).to_not be_nil
+      expect(response).to redirect_to(lti_configuration_path(organization))
+    end
+
+    it "redirects to :new if lms_type is unset" do
+      post :create, params: { id: organization.slug }
+      expect(organization.lti_configuration).to be_nil
+      expect(response).to redirect_to(new_lti_configuration_path(organization))
+    end
+
+    context "with existing google classroom" do
+      before do
+        organization.update_attributes(google_course_id: "1234")
       end
 
-      it "sends statsd" do
-        expect(GitHubClassroom.statsd).to receive(:increment).with("lti_configuration.create")
-        post :create, params: { id: organization.slug, lti_configuration: { lms_type: :other } }
-      end
-
-      it "creates lti_configuration if lms_type is set" do
-        post :create, params: { id: organization.slug, lti_configuration: { lms_type: :other } }
-        expect(organization.lti_configuration).to_not be_nil
-        expect(response).to redirect_to(lti_configuration_path(organization))
-      end
-
-      it "redirects to :new if lms_type is unset" do
-        post :create, params: { id: organization.slug }
-        expect(organization.lti_configuration).to be_nil
-        expect(response).to redirect_to(new_lti_configuration_path(organization))
-      end
-
-      context "with existing google classroom" do
-        before do
-          organization.update_attributes(google_course_id: "1234")
-        end
-
-        it "alerts user about existing configuration" do
-          get :create, params: { id: organization.slug }
-          expect(response).to redirect_to(edit_organization_path(organization))
-          expect(flash[:alert]).to eq(
-            "This classroom is already connected to Google Classroom. Please disconnect from Google Classroom "\
-            "before connecting to another learning management system."
-          )
-        end
-      end
-
-      context "with an existing roster" do
-        before do
-          organization.roster = create(:roster)
-          organization.save!
-          organization.reload
-        end
-
-        it "alerts user that there is an existing roster" do
-          post :create, params: { id: organization.slug }
-          expect(response).to redirect_to(edit_organization_path(organization))
-          expect(flash[:alert]).to eq(
-            "We are unable to link your classroom organization to a learning management system "\
-            "because a roster already exists. Please delete your current roster and try again."
-          )
-        end
+      it "alerts user about existing configuration" do
+        get :create, params: { id: organization.slug }
+        expect(response).to redirect_to(edit_organization_path(organization))
+        expect(flash[:alert]).to eq(
+          "This classroom is already connected to Google Classroom. Please disconnect from Google Classroom "\
+          "before connecting to another learning management system."
+        )
       end
     end
 
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
+    context "with an existing roster" do
+      before do
+        organization.roster = create(:roster)
+        organization.save!
+        organization.reload
       end
 
-      it "does not create lti_configuration" do
+      it "alerts user that there is an existing roster" do
         post :create, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to(edit_organization_path(organization))
+        expect(flash[:alert]).to eq(
+          "We are unable to link your classroom organization to a learning management system "\
+          "because a roster already exists. Please delete your current roster and try again."
+        )
       end
     end
   end
 
   describe "DELETE #destroy", :vcr do
-    context "with flipper enabled" do
+    context "with lti configuration present" do
       before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
+        create(:lti_configuration, organization: organization)
+        get :show, params: { id: organization.slug }
       end
 
-      context "with lti configuration present" do
-        before(:each) do
-          create(:lti_configuration, organization: organization)
-          get :show, params: { id: organization.slug }
-        end
-
-        it "sends statsd" do
-          expect(GitHubClassroom.statsd).to receive(:increment).with("lti_configuration.destroy")
-          delete :destroy, params: { id: organization.slug }
-        end
-
-        it "deletes lti_configuration" do
-          delete :destroy, params: { id: organization.slug }
-          organization.reload
-          expect(organization.lti_configuration).to be_nil
-          expect(response).to redirect_to(edit_organization_path(id: organization))
-          expect(flash[:alert]).to be_present
-        end
-      end
-    end
-
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
+      it "sends statsd" do
+        expect(GitHubClassroom.statsd).to receive(:increment).with("lti_configuration.destroy")
+        delete :destroy, params: { id: organization.slug }
       end
 
-      it "does not create lti_configuration" do
-        post :create, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
+      it "deletes lti_configuration" do
+        delete :destroy, params: { id: organization.slug }
+        organization.reload
+        expect(organization.lti_configuration).to be_nil
+        expect(response).to redirect_to(edit_organization_path(id: organization))
+        expect(flash[:alert]).to be_present
       end
     end
   end
 
   describe "PATCH #update", :vcr do
-    context "with flipper on" do
+    context "with existing lti_configuration" do
       before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
+        create(:lti_configuration, organization: organization)
       end
 
-      context "with existing lti_configuration" do
-        before(:each) do
-          create(:lti_configuration, organization: organization)
-        end
+      it "updates with new LMS url" do
+        options = { lms_link: "https://github.com" }
+        patch :update, params: { id: organization.slug, lti_configuration: options }
 
-        it "updates with new LMS url" do
-          options = { lms_link: "https://github.com" }
-          patch :update, params: { id: organization.slug, lti_configuration: options }
-
-          organization.lti_configuration.reload
-          expect(organization.lti_configuration.lms_link).to eq("https://github.com")
-          expect(flash[:success]).to eq("The configuration was successfully updated.")
-          expect(response).to redirect_to(lti_configuration_path(organization))
-        end
-      end
-
-      context "with no existing lti_configuration" do
-        it "does not update or create" do
-          options = { lms_link: "https://github.com" }
-          patch :update, params: { id: organization.slug, lti_configuration: options }
-          expect(response).to redirect_to(info_lti_configuration_path(organization))
-          expect(organization.lti_configuration).to be_nil
-        end
+        organization.lti_configuration.reload
+        expect(organization.lti_configuration.lms_link).to eq("https://github.com")
+        expect(flash[:success]).to eq("The configuration was successfully updated.")
+        expect(response).to redirect_to(lti_configuration_path(organization))
       end
     end
 
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
-      end
-
-      it "returns a not_found" do
+    context "with no existing lti_configuration" do
+      it "does not update or create" do
         options = { lms_link: "https://github.com" }
         patch :update, params: { id: organization.slug, lti_configuration: options }
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to(info_lti_configuration_path(organization))
+        expect(organization.lti_configuration).to be_nil
       end
     end
   end
@@ -295,33 +198,16 @@ RSpec.describe Orgs::LtiConfigurationsController, type: :controller do
   end
 
   describe "GET #complete", :vcr do
-    context "with flipper on" do
+    context "with existing lti_configuration" do
       before(:each) do
-        GitHubClassroom.flipper[:lti_launch].enable
+        create(:lti_configuration, organization: organization)
       end
 
-      context "with existing lti_configuration" do
-        before(:each) do
-          create(:lti_configuration, organization: organization)
+      context "with user who is an instructor" do
+        it "returns success page" do
+          get :complete, params: { id: organization.slug }
+          expect(response).to have_http_status(200)
         end
-
-        context "with user who is an instructor" do
-          it "returns success page" do
-            get :complete, params: { id: organization.slug }
-            expect(response).to have_http_status(200)
-          end
-        end
-      end
-    end
-
-    context "with flipper disabled" do
-      before(:each) do
-        GitHubClassroom.flipper[:lti_launch].disable
-      end
-
-      it "returns a not_found" do
-        get :complete, params: { id: organization.slug }
-        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe SessionsController, type: :controller do
   end
   let(:consumer_key) { lti_configuration.consumer_key }
 
-  before do
-    GitHubClassroom.flipper[:lti_launch].enable
-  end
-
-  after do
-    GitHubClassroom.flipper[:lti_launch].disable
-  end
-
   describe "sessions#failure", :vcr do
     it "redirects to lti_failure and curries request parameters when strategy is lti" do
       get :failure, params: { strategy: "lti" }

--- a/spec/integration/lti_launch_spec.rb
+++ b/spec/integration/lti_launch_spec.rb
@@ -21,11 +21,9 @@ RSpec.describe "LTI launch", type: :request do
 
   before(:each) do
     redis_store.flushdb
-    GitHubClassroom.flipper[:lti_launch].enable
   end
 
   after(:each) do
-    GitHubClassroom.flipper[:lti_launch].disable
     redis_store.quit
   end
 


### PR DESCRIPTION
This is a clean up PR to remove the feature flag and related helper methods for the `lti_launch` flag.

This removes direct references to the `lti_launch` feature flag and the following helper methods that existed to check whether or not the flag was enabled:

`ensure_lti_launch_flipper_is_enabled`
`lti_launch_enabled?`
`verify_lti_launch_enabled`

I removed all tests that tested the feature with the flag disabled.

I updated the 'flag enabled' tests to indicate it is expected behavior and not feature flag related now.

There were a few places where `||` was used to test whether this flag or another were true. In those cases, since removing the flag is the equivalent of it always being true, I removed the entire check (even though the other flag still exists).