### PR TITLE
[WIP] show a warning message when a starter repo is private and user-owned

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -13,6 +13,15 @@
   update_textfield = function(list_element) {
     $(list_element).removeClass('suggestion-focused');
     $('.js-autocomplete-textfield').val($(list_element).data('res-name'));
+    if (list_element.dataset.resPrivateOwnedByUser == "true") {
+      if ($('.private-user-owned-repo-message').hasClass('hidden-tab')) {
+        $('.private-user-owned-repo-message').removeClass('hidden-tab');
+      }
+    } else {
+      if (!$('.private-user-owned-repo-message').hasClass('hidden-tab')) {
+        $('.private-user-owned-repo-message').addClass('hidden-tab');
+      }
+    }
     return $('.js-autocomplete-resource-id').val($(list_element).data('res-id'));
   };
 

--- a/app/views/assignments/_assignment_form_options.html.erb
+++ b/app/views/assignments/_assignment_form_options.html.erb
@@ -77,6 +77,7 @@
             oninput: "importOptions(this.value);removeErrorBox(this);",
             data: { "autocomplete-search-endpoint": "github_repos" }
           %>
+          <span class="private-user-owned-repo-message hidden-tab">We will soon only be allowing starter code repositories that belong to your classroom organization to be used for assignments. If you have any feedback about this change, let us know at [an issue url]</span>
         </dd>
         <dd class="dd-autocomplete-suggestions"><%= render_autocomplete_suggestions_container %></dd>
         <input class="js-autocomplete-resource-id" type="hidden" name="repo_id" />

--- a/app/views/autocomplete/_repository_suggestions.html.erb
+++ b/app/views/autocomplete/_repository_suggestions.html.erb
@@ -8,7 +8,8 @@
       <% repos.each do |repo| %>
         <li class="js-autocomplete-suggestion-item"
           data-res-id="<%= repo[:id] %>"
-          data-res-name="<%= repo[:full_name] %>">
+          data-res-name="<%= repo[:full_name] %>"
+          data-res-private-owned-by-user="<%= repo[:private] && repo[:owner][:type] == "User" %>">
           <%= repo[:private] ? octicon('lock') : octicon('repo') %>
           <strong><%= repo[:full_name] %></strong>
           <span><%= repo[:description] %></span>


### PR DESCRIPTION
For https://github.com/education/classroom/issues/2222

To encourage users to start moving towards keeping all private starter code repos in organizations rather than personal accounts, we will be displaying a warning message saying that we will soon no longer allow personal private repos to be used.

Looks like this for now, styling and wording are in progress:
![Screen Shot 2019-09-13 at 5 38 51 PM](https://user-images.githubusercontent.com/7772827/64898685-b0e2f300-d64d-11e9-9e2f-cbd3535efaef.png)
