### PR TITLE
convert deadline to local time in assignment display

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -19,7 +19,7 @@
                 <% if @assignment.deadline.passed? %>
                   - Deadline Passed
                 <% else %>
-                  <%= "- Deadline in #{distance_of_time_in_words(Time.zone.now, @assignment.deadline.deadline_at)}" %>
+                  <%= render partial: "shared/deadline_with_local_time", locals: { deadline: @assignment.deadline.deadline_at } %>
                 <% end %>
               <% end %>
             </p>

--- a/app/views/group_assignments/_banner.html.erb
+++ b/app/views/group_assignments/_banner.html.erb
@@ -16,7 +16,7 @@
             <% if @group_assignment.deadline.passed? %>
               - Deadline Passed
             <% else %>
-              <%= "- Deadline in #{distance_of_time_in_words(Time.zone.now, @group_assignment.deadline.deadline_at)}" %>
+              <%= render partial: "shared/deadline_with_local_time", locals: { deadline: @group_assignment.deadline.deadline_at } %>
             <% end %>
           <% end %>
         </p>

--- a/app/views/group_assignments/show.html.erb
+++ b/app/views/group_assignments/show.html.erb
@@ -19,7 +19,7 @@
                 <% if @group_assignment.deadline.passed? %>
                   - Deadline Passed
                 <% else %>
-                  <%= "- Deadline in #{distance_of_time_in_words(Time.zone.now, @group_assignment.deadline.deadline_at)}" %>
+                  <%= render partial: "shared/deadline_with_local_time", locals: { deadline: @group_assignment.deadline.deadline_at } %>
                 <% end %>
               <% end %>
             </p>

--- a/app/views/shared/_deadline_with_local_time.html.erb
+++ b/app/views/shared/_deadline_with_local_time.html.erb
@@ -1,0 +1,1 @@
+- Deadline in <%= distance_of_time_in_words(Time.zone.now, deadline) %> (<%= local_time(deadline, '%m/%e/%y at %l %P') %>)

--- a/app/views/shared/_deadline_with_local_time.html.erb
+++ b/app/views/shared/_deadline_with_local_time.html.erb
@@ -1,1 +1,1 @@
-- Deadline in <%= distance_of_time_in_words(Time.zone.now, deadline) %> (<%= local_time(deadline, '%m/%e/%y at %l %P') %>)
+- Deadline in <%= distance_of_time_in_words(Time.zone.now, deadline) %> (<%= local_time(deadline, '%b %e, %Y, %H:%M (%Z)') %>)

--- a/app/views/shared/_deadline_with_local_time.html.erb
+++ b/app/views/shared/_deadline_with_local_time.html.erb
@@ -1,1 +1,1 @@
-- Deadline in <%= distance_of_time_in_words(Time.zone.now, deadline) %> (<%= local_time(deadline, '%b %e, %Y, %H:%M (%Z)') %>)
+- Deadline in <%= distance_of_time_in_words(Time.zone.now, deadline) %> (<%= local_time(deadline, '%b %e, %Y, %H:%M %Z') %>)


### PR DESCRIPTION
For https://github.com/education/classroom/issues/2363

Include the exact deadline on the assignment show page (in current user's local timezone)

It currently looks like this:
![Screen Shot 2019-09-30 at 11 54 14 AM](https://user-images.githubusercontent.com/7772827/65903148-84cfad80-e381-11e9-80a2-59372c8b4f7d.png)

We are discussing making further improvements to the time formatting, such as using 24 hour time and including the full month name and the user's timezone in the display.
