### PR TITLE
Fix search/filter so it works on Firefox

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,6 +27,7 @@
 //= require remodal/dist/remodal
 //
 //= require dragula/dist/dragula
+//= require @github/details-menu-element/dist/index.umd
 //
 //= require peek
 //= require peek/views/dalli

--- a/app/assets/javascripts/organization-filtering.js
+++ b/app/assets/javascripts/organization-filtering.js
@@ -1,36 +1,24 @@
 $(document).ready(function() {
-  const $searchAndSort = $("#js-search-and-sort-component");
-
-  if (!$searchAndSort) return;
-
-  const debounce = (function() {
-    let timer = 0;
-
-    return function(callback, ms) {
-      if (timer) {
-        clearTimeout(timer);
+  const debounce = (() => { 
+    let timeoutId = null;
+    return (callback, ms) => {
+      if(timeoutId) {
+        clearTimeout(timeoutId);
       }
-      timer = setTimeout(callback, ms);
-    };
+      timeoutId = setTimeout(callback, ms);
+    }
   })();
 
   $("#js-filtering-form").on("change keyup input", function(e) {
-    const searchForm = document.getElementById("js-filtering-form");
-    const formData = $(searchForm).find('input[name!=utf8]').serialize();
+    const searchForm = e.currentTarget;
+    const formData = $(searchForm).serialize();
 
     history.replaceState(null, '', '?' + formData);
-    // Can't use .submit() here as it does not make request via XHR
-    debounce(function() { searchForm.dispatchEvent(new Event('submit', {bubbles: true})); }, 300);
-  });
-
-  $("#js-filtering-form .SelectMenu-item").on("change", function(e) {
-    const clickedItem = e.target.closest(".SelectMenu-item");
-    const currentMenu = clickedItem.closest("details");
-    const currentActiveItem = currentMenu.querySelector("[aria-checked=true]");
-
-    currentActiveItem.setAttribute("aria-checked", false);
-    clickedItem.setAttribute("aria-checked", true);
-    currentMenu.querySelector("[data-menu-button]").innerText = clickedItem.innerText;
-    currentMenu.removeAttribute('open');
+    debounce(() => submitSearchAndFilters(searchForm), 150)
   });
 });
+
+function submitSearchAndFilters(form) {
+  // Can't use .submit() here as it does not make request via XHR
+  form.dispatchEvent(new CustomEvent('submit', {bubbles: true, cancelable: true}))
+}

--- a/app/views/organizations/_organization_filters.html.erb
+++ b/app/views/organizations/_organization_filters.html.erb
@@ -38,7 +38,7 @@
           <div class="SelectMenu-list">
             <% view_options.each do |name| %>
               <label class="SelectMenu-item" role="menuitemradio" aria-checked="<%= active_view_option == name %>" tabindex="0">
-                <%= radio_button_tag "view", name, active_view_option == name, "hidden": "true", "data-autosubmit": "true" %>
+                <%= radio_button_tag "view", name, active_view_option == name, "hidden": "true" %>
                 <%= octicon("check", class: "SelectMenu-icon") %>
                 <span class="text-normal" data-menu-button-text><%= name %></span>
               </label>
@@ -66,7 +66,7 @@
             <div class="SelectMenu-list">
               <% sort_options.each do |name, value| %>
                 <label class="SelectMenu-item" role="menuitemradio" aria-checked="<%= active_sort_option == name %>" tabindex="0">
-                  <%= radio_button_tag "sort_by", name, active_sort_option == name, "hidden": "true", "data-autosubmit": "true" %>
+                  <%= radio_button_tag "sort_by", name, active_sort_option == name, "hidden": "true" %>
                   <%= octicon("check", class: "SelectMenu-icon") %>
                   <span class="text-normal" data-menu-button-text><%= name %></span>
                 </label>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "classroom",
   "private": true,
   "dependencies": {
+    "@github/details-menu-element": "^1.0.6",
     "clipboard": "^1.7.1",
     "dragula": "3.7.1",
     "github-markdown-css": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@github/details-menu-element@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@github/details-menu-element/-/details-menu-element-1.0.6.tgz#078b83f75d654dcc8359c8850fb73277e7740fcc"
+  integrity sha512-fDZvy6UWIzkIyn4ls8UmzEpr1H8WhixaQQsLc4ZsyRKe+JFD45T96rWhWJjpJiAVwmTUbx7nX2gA5WpJS+mSxA==
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Previously the search/filter form on the `/classrooms` page was not working in Firefox. It was submitting twice (the first time correctly as an async request and the second time as a full page load).

This updates the `dispatchEvent` for the form submission so it includes `cancelable: true` which prevents the double submission.

There was some additional cleanup work included here:
 - [x] Get debounce working correctly
 - [x] Add primer's JS for the detail-menu-element so we can remove the custom JS we'd written
 - [x] Remove `data-autosubmit: true` from the markup as it's not doing anything here

Eventually, we should replace our custom debounce functions with a standardized implementation. The JS folks recommended https://github.com/github/mini-throttle/. This will be done in a later PR as it will require some larger changes.