### PR TITLE
Fix search and filter form on Firefox

### DIFF
--- a/app/assets/javascripts/organization-filtering.js
+++ b/app/assets/javascripts/organization-filtering.js
@@ -1,26 +1,20 @@
 $(document).ready(function() {
-  const $searchAndSort = $("#js-search-and-sort-component");
-
-  if (!$searchAndSort) return;
-
-  const debounce = (function() {
-    let timer = 0;
-
-    return function(callback, ms) {
-      if (timer) {
-        clearTimeout(timer);
+  const debounce = (() => {
+    let timeoutId = null;
+    return (callback, ms) => {
+      if(timeoutId) {
+        clearTimeout(timeoutId);
       }
-      timer = setTimeout(callback, ms);
-    };
+      timeoutId = setTimeout(callback, ms);
+    }
   })();
 
   $("#js-filtering-form").on("change keyup input", function(e) {
-    const searchForm = document.getElementById("js-filtering-form");
-    const formData = $(searchForm).find('input[name!=utf8]').serialize();
+    const searchForm = e.currentTarget;
+    const formData = $(searchForm).serialize();
 
     history.replaceState(null, '', '?' + formData);
-    // Can't use .submit() here as it does not make request via XHR
-    debounce(function() { searchForm.dispatchEvent(new Event('submit', {bubbles: true})); }, 300);
+    debounce(() => submitSearchAndFilters(searchForm), 150)
   });
 
   $("#js-filtering-form .SelectMenu-item").on("change", function(e) {
@@ -34,3 +28,8 @@ $(document).ready(function() {
     currentMenu.removeAttribute('open');
   });
 });
+
+function submitSearchAndFilters(form) {
+    // Can't use .submit() here as it does not make request via XHR
+    form.dispatchEvent(new CustomEvent('submit', {bubbles: true, cancelable: true}));
+}


### PR DESCRIPTION
**************** NOTES ****************
This is adding back some of the work that was reverted in #2432 

This includes only the changes related to getting the form to work on Firefox. It does not include the details-menu js change which is what appears to have caused the break.

I've tested form functionality and assignment import functionality on Chrome, Safari, Firefox and Edge with these changes and it is working on all of them.
**************** NOTES ****************


Previously the search/filter form on the /classrooms page was not working in Firefox. It was submitting twice (the first time correctly as an async request and the second time as a full page load).

This updates the dispatchEvent for the form submission so it includes cancelable: true which prevents the double submission. It also gets the debounce working correctly so we aren't spamming the search end point.