### PR TITLE
copy changes to help teachers come up with a useful classroom name

### DIFF
--- a/app/views/organizations/setup.html.erb
+++ b/app/views/organizations/setup.html.erb
@@ -1,5 +1,5 @@
 <div class="container-lg p-responsive">
-  <div class="Subhead Subhead--spacious">
+  <div class="Subhead Subhead--spacious mb-6">
     <div class="Subhead-heading"><%= t('views.organizations.name_your_classroom') %></div>
   </div>
 
@@ -10,9 +10,12 @@
       <dl class="form-group">
         <dt><label><%= t('views.organizations.give_descriptive_name') %></label></dt>
         <dd><%= f.text_field :title, class: 'textfield form-control input-contrast input-block', placeholder: t('views.organizations.give_descriptive_name') %></dd>
+        <p class="note">
+          <%= t('views.organizations.classroom_name_note') %>
+        </p>
       </dl>
 
-      <div class="my-4">
+      <div class="mt-6">
         <%= f.submit t('views.organizations.continue'), class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -72,8 +72,9 @@ en:
       group_assignment: 'Group assignment'
       group_assignment_desc: 'Participants form teams that work together on a shared repository.'
       create_group_assignment: 'Create a group assignment'
-      name_your_classroom: 'Name your classroom'
-      give_descriptive_name: 'Please give your classroom a more descriptive name'
+      name_your_classroom: 'Set up your classroom'
+      give_descriptive_name: 'Classroom name'
+      classroom_name_note: 'Try using your course name and section so students can identify your classroom.'
       set_of_teams: 'Set of teams'
       no_teams: "This classroom doesn't have any sets of teams yet."
       assignments: 'Assignments'

--- a/config/locales/views/organizations/en.yml
+++ b/config/locales/views/organizations/en.yml
@@ -74,7 +74,7 @@ en:
       create_group_assignment: 'Create a group assignment'
       name_your_classroom: 'Set up your classroom'
       give_descriptive_name: 'Classroom name'
-      classroom_name_note: 'Try using your course name and section so students can identify your classroom.'
+      classroom_name_note: 'Using your course name and section can help students identify your classroom.'
       set_of_teams: 'Set of teams'
       no_teams: "This classroom doesn't have any sets of teams yet."
       assignments: 'Assignments'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,9 +168,9 @@ ActiveRecord::Schema.define(version: 2019_09_16_192858) do
   create_table "lti_configurations", force: :cascade do |t|
     t.text "consumer_key", null: false
     t.text "shared_secret", null: false
+    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "organization_id"
     t.string "context_membership_url"
     t.text "lms_type", default: "other", null: false
     t.string "cached_launch_message_nonce"


### PR DESCRIPTION
## What
Small copy changes to help new GitHub Classroom users figure out a good name for their classroom

### Why
While observing teachers create new classrooms, I noticed that none of them actually used the classroom name that was auto-generated for them. But new users, in particular, weren't sure what _would_ make a good classroom name. They didn't know whether the name would be visible to students. They weren't sure if they needed to create separate classrooms for different sections of the same course. 

Hopefully, these small copy changes can help address those issues.

![screencapture-localhost-5000-classrooms-57011530-icm200-classroom-1-setup-2019-10-25-15_48_30](https://user-images.githubusercontent.com/471514/67599892-02979680-f73f-11e9-8380-c9a989ab8409.png)

