### PR TITLE
fixed small typo setup => set up

### DIFF
--- a/app/views/assignment_invitations/setup.html.erb
+++ b/app/views/assignment_invitations/setup.html.erb
@@ -8,7 +8,7 @@
 <div class="site-content">
   <div class="site-content-cap">
     <h2 class="site-content-heading">
-      Your assignment repository is being setup. This might take a while.
+      Your assignment repository is being set up. This might take a while.
     </h2>
   </div>
 </div>

--- a/app/views/group_assignment_invitations/setup.html.erb
+++ b/app/views/group_assignment_invitations/setup.html.erb
@@ -9,7 +9,7 @@
 <div class="site-content">
   <div class="site-content-cap">
     <h2 class="site-content-heading">
-      Your assignment repository is being setup. This might take a while.
+      Your assignment repository is being set up. This might take a while.
     </h2>
   </div>
 </div>


### PR DESCRIPTION
Fixing typo. `Setup` is a noun but in this context, `set up` the verb form applies.