### PR TITLE
Remove user from all classrooms tied to a GH organization that has revoked their access

### DIFF
--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -10,16 +10,25 @@ class OrganizationEventJob < ApplicationJob
 
     github_user_id = payload_body.dig("membership", "user", "id")
     github_organization_id = payload_body.dig("organization", "id")
-    @organization = Organization.find_by(github_id: github_organization_id)
+    organizations = Organization.where(github_id: github_organization_id)
 
-    return false if @organization.blank?
-    return false if @organization.users.count == 1
+    return false if organizations.empty?
 
-    @user = @organization.users.find_by(uid: github_user_id)
+    failed_removals = organizations.reject do |org|
+      # return false if org.users.count == 1
+      user = org.users.find_by(uid: github_user_id)
 
-    return true unless @user
-    TransferAssignmentsService.new(@organization, @user).transfer
-    @organization.users.delete(@user)
+      if user
+        TransferAssignmentsService.new(org, user).transfer
+        org.users.delete(user)
+      else
+        false
+      end
+    end
+
+    # This method should only report success (by returning true) if we were able to remove
+    # the user from all of the organizations tied to the given github_organization_id
+    failed_removals.empty?
   end
   # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
Addresses to https://github.com/github/education/issues/988

Our previous code assumed a 1-to-1 mapping of GitHub organizations to classrooms. However, many of our teachers are using a single organization on GitHub as a source for multiple classrooms.

This update ensures that when access is revoked for a GitHub organization for a user, the user is removed from all of the associated classrooms as well. 

Previously we would not remove classroom access if a user was the only user with admin access to the classroom. With this update, we will be removing access regardless. In a small number of cases, this may result in admin-less classrooms.