### PR TITLE
small adjustment so longer usernames are readable on nav menu

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,7 +16,7 @@
 
               <div role="menu" class="dropdown-menu dropdown-menu-sw mt-2" style="width: 180px">
                 <%= link_to current_user.github_user.html_url, class: "dropdown-item", role: "menuitem" do %>
-                  <%= t("views.shared.signed_in_as") %> <strong><%= current_user.github_user.login %></strong>
+                  <%= t("views.shared.signed_in_as") %> <strong class="d-block"><%= current_user.github_user.login %></strong>
                 <% end %>
 
                 <div role="none" class="dropdown-divider"></div>

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -17,4 +17,4 @@ en:
       with_love_by_github: "Made with %{octicon_heart} by the %{education_href} team at %{href}."
       back_to_classroom: 'Back to GitHub Classroom'
       your_classrooms: "Your classrooms"
-      signed_in_as: "Signed in as"
+      signed_in_as: "Signed in as:"


### PR DESCRIPTION
Adjustment to accommodate longer (8 character +) usernames on the nav menu since it's likely that newer users will have longer usernames. Display follows the menu logged in username pattern on dotcom.

**Before**

<img width="276" alt="Screen Shot 2019-12-05 at 9 53 13 PM" src="https://user-images.githubusercontent.com/471514/70291751-1e647280-17aa-11ea-8734-bd6ab77aa026.png">


**After**

<img width="297" alt="Screen Shot 2019-12-05 at 9 52 48 PM" src="https://user-images.githubusercontent.com/471514/70291737-0f7dc000-17aa-11ea-8636-d234e125a5b2.png">


