### PR TITLE
Fix script/setup by removing Homebrew cask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ spec/examples.txt
 
 # mac
 .DS_Store
+
+# Homebrew lock file
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-tap "caskroom/cask"
 tap "github/bootstrap"
 
 cask "docker" unless system "which docker"


### PR DESCRIPTION
## What
It fixes the app setup by removing `caskroom/cask` from `Brewfile`. 

Homebrew Cask is now integrated into Homebrew itself and tapping caskroom/cask is not necessary Homebrew/homebrew-cask#14384

Closes #2515 