### PR TITLE
Change Sidekiq queues to critical, default and low only. For efficiency

### DIFF
--- a/app/jobs/assignment_repository_visibility_job.rb
+++ b/app/jobs/assignment_repository_visibility_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AssignmentRepositoryVisibilityJob < ApplicationJob
-  queue_as :assignment
+  queue_as :low
 
   rescue_from ActiveJob::DeserializationError do |_exception|
     # Assignment no longer exists. No point in running this job anymore.

--- a/app/jobs/boom_job.rb
+++ b/app/jobs/boom_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BoomJob < ApplicationJob
-  queue_as :boom
+  queue_as :critical
 
   def perform(*)
     raise "BOOM"

--- a/app/jobs/create_github_repository_new_job.rb
+++ b/app/jobs/create_github_repository_new_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CreateGitHubRepositoryNewJob < ApplicationJob
-  queue_as :create_repository
+  queue_as :critical
 
   # Creates an AssignmentRepo or a GroupAssignmentRepo
   #

--- a/app/jobs/deadline_job.rb
+++ b/app/jobs/deadline_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeadlineJob < ApplicationJob
-  queue_as :deadline
+  queue_as :critical
 
   def perform(deadline_id)
     deadline = Deadline.find_by(id: deadline_id)

--- a/app/jobs/destroy_resource_job.rb
+++ b/app/jobs/destroy_resource_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DestroyResourceJob < ApplicationJob
-  queue_as :trash_can
+  queue_as :default
 
   def perform(resource)
     resource.destroy

--- a/app/jobs/last_active_job.rb
+++ b/app/jobs/last_active_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LastActiveJob < ApplicationJob
-  queue_as :last_active
+  queue_as :low
 
   # Public: Update the last time the User was active.
   #

--- a/app/jobs/membership_event_job.rb
+++ b/app/jobs/membership_event_job.rb
@@ -2,7 +2,7 @@
 
 # Documentation: https://developer.github.com/v3/activity/events/types/#membershipevent
 class MembershipEventJob < ApplicationJob
-  queue_as :github_event
+  queue_as :critical
 
   # rubocop:disable AbcSize
   def perform(payload_body)

--- a/app/jobs/organization_event_job.rb
+++ b/app/jobs/organization_event_job.rb
@@ -2,7 +2,7 @@
 
 # Documentation: https://developer.github.com/v3/activity/events/types/#organizationevent
 class OrganizationEventJob < ApplicationJob
-  queue_as :github_event
+  queue_as :critical
 
   # rubocop:disable Metrics/AbcSize
   def perform(payload_body)

--- a/app/jobs/repository_event_job.rb
+++ b/app/jobs/repository_event_job.rb
@@ -2,7 +2,7 @@
 
 # Documentation: https://developer.github.com/v3/activity/events/types/#repositoryevent
 class RepositoryEventJob < ApplicationJob
-  queue_as :github_event
+  queue_as :critical
 
   def perform(payload_body)
     return true unless payload_body.dig("action") == "deleted"

--- a/app/jobs/repository_import_event_job.rb
+++ b/app/jobs/repository_import_event_job.rb
@@ -2,7 +2,7 @@
 
 # Documentation: https://developer.github.com/v3/activity/events/types/#repositoryimportevent
 class RepositoryImportEventJob < ApplicationJob
-  queue_as :porter_status
+  queue_as :critical
 
   CREATE_COMPLETE = "Your GitHub repository was created."
   IMPORT_FAILED = "We were not able to import starter code to your assignment, please try again."

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,11 +5,6 @@
 :concurrency: <%= Integer(ENV['SIDEKIQ_CONCURRENCY'] || 5) %>
 :verbose: false
 :queues: # https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
-  - [assignment,        1]
-  - [last_active,       1]
-  - [github_event,      3]
-  - [trash_can,         2]
-  - [deadline,          3]
-  - [boom,              3]
-  - [create_repository, 3]
-  - [porter_status,     3]
+  - [critical, 3]
+  - [default,  2]
+  - [low,      1]

--- a/spec/jobs/boom_job_spec.rb
+++ b/spec/jobs/boom_job_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe BoomJob, type: :job do
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      BoomJob.perform_later
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   it "raises BOOM" do
     expect { BoomJob.perform_now }.to raise_error(StandardError, "BOOM")
   end

--- a/spec/jobs/create_github_repository_new_job_spec.rb
+++ b/spec/jobs/create_github_repository_new_job_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe CreateGitHubRepositoryNewJob, type: :job do
   let(:service) { CreateGitHubRepoService.new(assignment, student) }
   let(:invite_status) { assignment.invitation.status(student) }
 
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      CreateGitHubRepositoryNewJob.perform_later(assignment, student)
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   describe "#perform", :vcr do
     before(:each) do
       invite_status.waiting!

--- a/spec/jobs/deadline_job_spec.rb
+++ b/spec/jobs/deadline_job_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe DeadlineJob, type: :job do
     clear_performed_jobs
   end
 
-  it "uses the :deadline queue" do
+  it "uses the :critical queue" do
     ActiveJob::Base.queue_adapter = :test
     expect do
       DeadlineJob.perform_later(deadline.id)
-    end.to have_enqueued_job.on_queue("deadline")
+    end.to have_enqueued_job.on_queue("critical")
   end
 
   it "does not throw if the deadline no longer exists" do

--- a/spec/jobs/destroy_resource_job_spec.rb
+++ b/spec/jobs/destroy_resource_job_spec.rb
@@ -3,9 +3,16 @@
 require "rails_helper"
 
 RSpec.describe DestroyResourceJob, type: :job do
-  it "destroys the resource", :vcr do
-    organization = classroom_org
+  let(:organization) { classroom_org }
 
+  it "uses the :default queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      DestroyResourceJob.perform_later(organization)
+    end.to have_enqueued_job.on_queue("default")
+  end
+
+  it "destroys the resource", :vcr do
     DestroyResourceJob.perform_now(organization)
 
     expect(Organization.exists?(organization.id)).to eq(false)

--- a/spec/jobs/last_active_job_spec.rb
+++ b/spec/jobs/last_active_job_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe LastActiveJob, type: :job do
     Timecop.return
   end
 
-  it "uses the :last_active_at queue" do
-    assert_performed_with(job: LastActiveJob, args: [user.id, @time], queue: "last_active") do
+  it "uses the :low queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
       LastActiveJob.perform_later(user.id, @time)
-    end
+    end.to have_enqueued_job.on_queue("low")
   end
 
   it "updates the last_active_at attribute" do

--- a/spec/jobs/membership_event_job_spec.rb
+++ b/spec/jobs/membership_event_job_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe MembershipEventJob, type: :job do
   let(:organization) { classroom_org }
   let(:student)      { classroom_student }
 
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      MembershipEventJob.perform_later(payload)
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   context "ACTION member_removed", :vcr do
     it "removes user from team" do
       group_assignment = create(:group_assignment, title: "Intro to Rails #2", organization: organization)

--- a/spec/jobs/organization_event_job_spec.rb
+++ b/spec/jobs/organization_event_job_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 RSpec.describe OrganizationEventJob, type: :job do
   let(:payload) { json_payload("webhook_events/member_removed.json") }
 
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      OrganizationEventJob.perform_later(payload)
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   context "organization doesn't exist in classroom" do
     it "returns false" do
       expect(OrganizationEventJob.perform_now(payload)).to be_falsey

--- a/spec/jobs/repository_event_job_spec.rb
+++ b/spec/jobs/repository_event_job_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe RepositoryEventJob, type: :job do
   let(:organization) { classroom_org                                          }
   let(:payload)      { json_payload("webhook_events/repository_deleted.json") }
 
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      RepositoryEventJob.perform_later(payload)
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   context "ACTION deleted", :vcr do
     it "deletes the matching AssignmentRepo" do
       assignment_repo = create(

--- a/spec/jobs/repository_import_event_job_spec.rb
+++ b/spec/jobs/repository_import_event_job_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe RepositoryImportEventJob, type: :job do
   let(:invite_status)       { invitation.status(user) }
   let(:group_invite_status) { group_invitation.status(group) }
 
+  it "uses the :critical queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      subject.perform_later(success_payload)
+    end.to have_enqueued_job.on_queue("critical")
+  end
+
   context "with created assignment_repo", :vcr do
     let(:assignment_repo) do
       create(

--- a/spec/jobs/repository_visibility_job_spec.rb
+++ b/spec/jobs/repository_visibility_job_spec.rb
@@ -13,6 +13,15 @@ end
 RSpec.describe AssignmentRepositoryVisibilityJob, type: :job do
   subject { AssignmentRepositoryVisibilityJob }
 
+  let(:assignment) { create(:assignment) }
+
+  it "uses the :low queue" do
+    ActiveJob::Base.queue_adapter = :test
+    expect do
+      subject.perform_later(assignment, change: {})
+    end.to have_enqueued_job.on_queue("low")
+  end
+
   context "when a serialization error is thrown" do
     it "does not crash the test" do
       allow_any_instance_of(subject).to receive(:perform) { raise ActiveJob::DeserializationError }


### PR DESCRIPTION
## What
It creates three queues (`critical`, `default`, and `low`) and assign all the workers to it.

From Sidekiq documentation:
> I don't recommend having more than a handful of queues. Lots of queues makes for a more complex system and Sidekiq Pro cannot reliably handle multiple queues without polling. M Sidekiq Pro processes polling N queues means O(M*N) operations per second slamming Redis.
https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues

Closes #1381
