### PR TITLE
Fix Webhook variable in app.json for Heroku deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   },
 
   "env": {
-    "CLASSROOM_WEBHOOK_PREFIX_URL": {
+    "CLASSROOM_WEBHOOK_URL_PREFIX": {
       "description": "The URL for your application to receive webhooks ex https://classroom.github.com",
       "required": true
     },


### PR DESCRIPTION
## What
The app.json names the wrong variable. This fixes that.

This wrong webhook variable made it impossible to create classrooms in your Heroku deployment. You would just get a 500 error after you select the organization. Here is the error you'd see in the logs, shortened for clarity.
```
INFO -- : method=POST path=/classrooms format=html controller=OrganizationsController action=create status=500 error='RuntimeError: WebHook failed to be created, please open an issue at https://github.com/education/classroom/issues/new' duration=828.51 view=0.00 db=14.74
FATAL -- : RuntimeError (WebHook failed to be created, please open an issue at https://github.com/education/classroom/issues/new): 
FATAL -- : app/models/organization_webhook.rb:174:in `webhook_url'
app/models/organization_webhook.rb:61:in `create_org_hook!'
app/models/organization_webhook.rb:95:in `ensure_webhook_is_active!'
app/models/organization/creator.rb:106:in `ensure_organization_webhook_exists!'
app/models/organization/creator.rb:70:in `perform'
app/models/organization/creator.rb:52:in `perform'
app/controllers/organizations_controller.rb:32:in `create'
```